### PR TITLE
Add initial charm structure

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,9 @@
+[flake8]
+max-line-length = 99
+select: E,W,F,C,N
+exclude:
+  venv
+  .git
+  build
+  dist
+  *.egg_info

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+venv/
+build/
+*.charm
+
+.coverage
+__pycache__/
+*.py[cod]

--- a/.jujuignore
+++ b/.jujuignore
@@ -1,0 +1,3 @@
+/venv
+*.py[cod]
+*.charm

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# PostgreSQL Kubernetes Operator
+
+## Developing
+
+Create and activate a virtualenv with the development requirements:
+
+    virtualenv -p python3 venv
+    source venv/bin/activate
+    pip install -r requirements-dev.txt
+
+## Testing
+
+The Python operator framework includes a very nice harness for testing
+operator behaviour without full deployment. Just `run_tests`:
+
+    ./run_tests

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,47 @@
-Coming soon
+# PostgreSQL Kubernetes Operator
+
+## Overview
+
+This repository hosts the PostgreSQL Kubernetes Operator.
+
+## Description
+
+The PostgreSQL Kubernetes Operator deploys and operates the [PostgreSQL](https://www.postgresql.org/about/) database on Kubernetes clusters.
+
+This operator provides a Postgres database with replication enabled (one master instance and one or more hot standby replicas). The Operator in this repository is a Python script which wraps the LTS Postgres versions distributed by [Ubuntu](https://hub.docker.com/r/ubuntu/postgres), providing lifecycle management and handling events (install, configure, integrate, remove).
+
+## Usage
+
+In order to install this charm, execute the following commands (replace `SECRET_PASSWORD` with a strong password):
+
+```bash
+# Clone this charm respository
+$ git clone https://github.com/canonical/postgresql-k8s-operator
+$ cd postgresql-k8s-operator
+# Build the charm
+$ charmcraft pack
+# Create a model for our deployment
+$ juju add-model postgres
+# Deploy the charm (providing a password for the postgres user)
+$ juju deploy ./postgresql-k8s-operator*.charm \
+    --resource postgresql-image=ubuntu/postgres \
+    --config postgres-password=SECRET_PASSWORD
+# Wait for the deployment to complete
+$ watch -n1 --color "juju status --color"
+```
+
+The deployment process will take a few moments. You should end up with some output like the following:
+
+```
+❯ juju status
+Model     Controller  Cloud/Region        Version  SLA          Timestamp
+postgres  micro       microk8s/localhost  2.9.18   unsupported  14:46:27-03:00
+
+App                      Version  Status  Scale  Charm                    Store  Channel  Rev  OS          Address        Message
+postgresql-k8s-operator           active      1  postgresql-k8s-operator  local             1  kubernetes  10.152.183.42  
+
+Unit                        Workload  Agent  Address      Ports  Message
+postgresql-k8s-operator/0*  active    idle   10.1.65.207
+```
+
+You can now access the database (using the example above) by connecting as user `postgres` with the password `SECRET_PASSWORD` on host `10.1.65.207` and port `5432`.

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,0 +1,12 @@
+type: "charm"
+bases:
+  - build-on:
+    - name: "ubuntu"
+      channel: "20.04"
+    run-on:
+    - name: "ubuntu"
+      channel: "20.04"
+parts:
+  charm:
+    build-packages:
+      - git

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,9 @@
+# Copyright 2021 Canonical
+# See LICENSE file for licensing details.
+
+options:
+  postgres-password:
+    default: ""
+    description: >
+      The password to set for the postgres user.
+    type: string

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,9 +1,8 @@
 # Copyright 2021 Canonical
 # See LICENSE file for licensing details.
 
-name: postgresql-k8s-operator
-display-name: |
-  PostgreSQL K8s
+name: postgresql-k8s
+display-name: PostgreSQL K8s
 description: |
   Charm to operate the PostgreSQL database on Kubernetes clusters
 summary: |

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,0 +1,19 @@
+# Copyright 2021 Canonical
+# See LICENSE file for licensing details.
+
+name: postgresql-k8s-operator
+display-name: |
+  PostgreSQL K8s
+description: |
+  Charm to operate the PostgreSQL database on Kubernetes clusters
+summary: |
+  Charm to operate the PostgreSQL database on Kubernetes clusters
+
+containers:
+  postgresql:
+    resource: postgresql-image
+
+resources:
+  postgresql-image:
+    type: oci-image
+    description: OCI image for PostgreSQL (ubuntu/postgres)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+coverage
+flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/canonical/operator/#egg=ops

--- a/run_tests
+++ b/run_tests
@@ -1,0 +1,17 @@
+#!/bin/sh -e
+# Copyright 2021 Canonical
+# See LICENSE file for licensing details.
+
+if [ -z "$VIRTUAL_ENV" -a -d venv/ ]; then
+    . venv/bin/activate
+fi
+
+if [ -z "$PYTHONPATH" ]; then
+    export PYTHONPATH="lib:src"
+else
+    export PYTHONPATH="lib:src:$PYTHONPATH"
+fi
+
+flake8
+coverage run --branch --source=src -m unittest -v "$@"
+coverage report -m

--- a/src/charm.py
+++ b/src/charm.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# Copyright 2021 Canonical
+# See LICENSE file for licensing details.
+
+import logging
+
+from ops.charm import CharmBase
+from ops.main import main
+from ops.model import ActiveStatus, WaitingStatus
+
+logger = logging.getLogger(__name__)
+
+
+class PostgresqlOperatorCharm(CharmBase):
+    """Charmed Operator for the PostgreSQL database."""
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.framework.observe(self.on.config_changed, self._on_config_changed)
+
+    def _on_config_changed(self, _):
+        """Handle the config-changed event"""
+        # Get the postgresql container so we can configure/manipulate it
+        container = self.unit.get_container("postgresql")
+        # Create a new config layer
+        layer = self._postgresql_layer()
+
+        if container.can_connect():
+            # Get the current config
+            services = container.get_plan().to_dict().get("services", {})
+            # Check if there are any changes to services
+            if services != layer["services"]:
+                # Changes were made, add the new layer
+                container.add_layer("postgresql", layer, combine=True)
+                logging.info("Added updated layer 'postgresql' to Pebble plan")
+                # Restart it and report a new status to Juju
+                container.restart("postgresql")
+                logging.info("Restarted postgresql service")
+            # All is well, set an ActiveStatus
+            self.unit.status = ActiveStatus()
+        else:
+            self.unit.status = WaitingStatus("waiting for Pebble in workload container")
+
+    def _postgresql_layer(self):
+        """Returns a Pebble configuration layer for PostgreSQL"""
+        return {
+            "summary": "postgresql layer",
+            "description": "pebble config layer for postgresql",
+            "services": {
+                "postgresql": {
+                    "override": "replace",
+                    "summary": "entrypoint of the postgresql image",
+                    "command": "/usr/local/bin/docker-entrypoint.sh postgres",
+                    "startup": "enabled",
+                    "environment": {
+                        # We need to set either POSTGRES_HOST_AUTH_METHOD or POSTGRES_PASSWORD
+                        # in order to initialize the database.
+                        # Currently, this password can only be set on deploy.
+                        "POSTGRES_PASSWORD": self.config["postgres-password"]
+                    }
+                }
+            },
+        }
+
+
+if __name__ == "__main__":
+    main(PostgresqlOperatorCharm)

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,6 +7,7 @@ import logging
 from ops.charm import CharmBase
 from ops.main import main
 from ops.model import ActiveStatus, WaitingStatus
+from ops.pebble import Layer
 
 logger = logging.getLogger(__name__)
 
@@ -27,9 +28,9 @@ class PostgresqlOperatorCharm(CharmBase):
 
         if container.can_connect():
             # Get the current config
-            services = container.get_plan().to_dict().get("services", {})
+            services = container.get_plan().services
             # Check if there are any changes to services
-            if services != layer["services"]:
+            if services != layer.services:
                 # Changes were made, add the new layer
                 container.add_layer("postgresql", layer, combine=True)
                 logging.info("Added updated layer 'postgresql' to Pebble plan")
@@ -41,9 +42,9 @@ class PostgresqlOperatorCharm(CharmBase):
         else:
             self.unit.status = WaitingStatus("waiting for Pebble in workload container")
 
-    def _postgresql_layer(self):
+    def _postgresql_layer(self) -> Layer:
         """Returns a Pebble configuration layer for PostgreSQL"""
-        return {
+        layer_config = {
             "summary": "postgresql layer",
             "description": "pebble config layer for postgresql",
             "services": {
@@ -61,6 +62,7 @@ class PostgresqlOperatorCharm(CharmBase):
                 }
             },
         }
+        return Layer(layer_config)
 
 
 if __name__ == "__main__":

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -1,0 +1,70 @@
+# Copyright 2021 Canonical
+# See LICENSE file for licensing details.
+
+import unittest
+
+from charm import PostgresqlOperatorCharm
+from ops.model import ActiveStatus
+from ops.testing import Harness
+
+
+class TestCharm(unittest.TestCase):
+    def setUp(self):
+        self.harness = Harness(PostgresqlOperatorCharm)
+        self.addCleanup(self.harness.cleanup)
+        self.harness.begin()
+
+    def test_postgresql_layer(self):
+        # Test with empty config.
+        self.assertEqual(self.harness.charm.config["postgres-password"], "")
+        expected = {
+            "summary": "postgresql layer",
+            "description": "pebble config layer for postgresql",
+            "services": {
+                "postgresql": {
+                    "override": "replace",
+                    "summary": "entrypoint of the postgresql image",
+                    "command": "/usr/local/bin/docker-entrypoint.sh postgres",
+                    "startup": "enabled",
+                    "environment": {
+                        "POSTGRES_PASSWORD": ""
+                    }
+                }
+            },
+        }
+        self.assertEqual(self.harness.charm._postgresql_layer(), expected)
+        # And now test with a different value in the postgres-password config option.
+        # Disable hook firing first.
+        self.harness.disable_hooks()
+        self.harness.update_config({"postgres-password": "SECRET_PASSWORD"})
+        expected["services"]["postgresql"]["environment"]["POSTGRES_PASSWORD"] = "SECRET_PASSWORD"
+        self.assertEqual(self.harness.charm._postgresql_layer(), expected)
+
+    def test_on_config_changed(self):
+        plan = self.harness.get_container_pebble_plan("postgresql")
+        self.assertEqual(plan.to_dict(), {})
+        # Trigger a config-changed hook. Since there was no plan initially, the
+        # "postgresql" service in the container won't be running so we'll be
+        # testing the `is_running() == False` codepath.
+        self.harness.update_config({"postgres-password": ""})
+        plan = self.harness.get_container_pebble_plan("postgresql")
+        # Get the expected layer from the postgresql_layer method (tested above)
+        expected = self.harness.charm._postgresql_layer()
+        expected.pop("summary", "")
+        expected.pop("description", "")
+        # Check the plan is as expected
+        self.assertEqual(plan.to_dict(), expected)
+        self.assertEqual(self.harness.model.unit.status, ActiveStatus())
+        container = self.harness.model.unit.get_container("postgresql")
+        self.assertEqual(container.get_service("postgresql").is_running(), True)
+
+        # Now test again with different config, knowing that the "postgresql"
+        # service is running (because we've just tested it above), so we'll
+        # be testing the `is_running() == True` codepath.
+        self.harness.update_config({"postgres-password": "SECRET_PASSWORD"})
+        plan = self.harness.get_container_pebble_plan("postgresql")
+        # Adjust the expected plan
+        expected["services"]["postgresql"]["environment"]["POSTGRES_PASSWORD"] = "SECRET_PASSWORD"
+        self.assertEqual(plan.to_dict(), expected)
+        self.assertEqual(container.get_service("postgresql").is_running(), True)
+        self.assertEqual(self.harness.model.unit.status, ActiveStatus())

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -32,13 +32,13 @@ class TestCharm(unittest.TestCase):
                 }
             },
         }
-        self.assertEqual(self.harness.charm._postgresql_layer(), expected)
+        self.assertEqual(self.harness.charm._postgresql_layer().to_dict(), expected)
         # And now test with a different value in the postgres-password config option.
         # Disable hook firing first.
         self.harness.disable_hooks()
         self.harness.update_config({"postgres-password": "SECRET_PASSWORD"})
         expected["services"]["postgresql"]["environment"]["POSTGRES_PASSWORD"] = "SECRET_PASSWORD"
-        self.assertEqual(self.harness.charm._postgresql_layer(), expected)
+        self.assertEqual(self.harness.charm._postgresql_layer().to_dict(), expected)
 
     def test_on_config_changed(self):
         plan = self.harness.get_container_pebble_plan("postgresql")
@@ -49,7 +49,7 @@ class TestCharm(unittest.TestCase):
         self.harness.update_config({"postgres-password": ""})
         plan = self.harness.get_container_pebble_plan("postgresql")
         # Get the expected layer from the postgresql_layer method (tested above)
-        expected = self.harness.charm._postgresql_layer()
+        expected = self.harness.charm._postgresql_layer().to_dict()
         expected.pop("summary", "")
         expected.pop("description", "")
         # Check the plan is as expected


### PR DESCRIPTION
This PR introduces the following changes:

- README.md: Added repository description and usage instructions.
- Added the initial charm structure created by the `charmcraft init` call (with an initial PostgreSQL instance running - without replication - just to initialize the charm structure).