### PR TITLE
DPE-8 postgresql k8s replication with automatic failover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 venv/
 build/
 *.charm
-
+.tox/
 .coverage
 __pycache__/
 *.py[cod]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,11 +49,17 @@ charmcraft pack
 ### Deploy
 
 ```bash
+# Clone docker image repository
+git clone https://github.com/canonical/postgresql-patroni-container.git
+# Build docker image locally, since it's not been exported anywhere yet.
+docker build . -t postgresql-patroni
+# Import docker image into microk8s container registry
+docker save postgresql-patroni | microk8s ctr image import -
 # Create a model
 juju add-model dev
 # Enable DEBUG logging
 juju model-config logging-config="<root>=INFO;unit=DEBUG"
 # Deploy the charm
 juju deploy ./postgresql-k8s_ubuntu-20.04-amd64.charm \
-    --resource postgresql-image=ubuntu/postgres
+    --resource postgresql-image=ubuntu/postgres --trust
 ```

--- a/README.md
+++ b/README.md
@@ -17,3 +17,11 @@ You can access the database using any PostgreSQL client by connecting on the uni
 ```bash
 juju run-action postgresql-k8s/0 get-postgres-password --wait
 ```
+
+## Get the primary unit
+
+To get the primary unit you can call the `get-primary` action in any unit.
+
+```bash
+juju run-action postgresql-k8s/0 get-primary --wait
+```

--- a/actions.yaml
+++ b/actions.yaml
@@ -1,5 +1,7 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+get-primary:
+  description: Get the unit with is the primary/leader in the replication.
 get-postgres-password:
   description: Get the initial postgres user password for the database.

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -8,5 +8,4 @@ bases:
       channel: "20.04"
 parts:
   charm:
-    build-packages:
-      - git
+    charm-python-packages: [setuptools]

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -13,13 +13,13 @@ containers:
     resource: postgresql-image
     mounts:
       - storage: pgdata
-        location: /var/lib/postgresql/data/pgdata
+        location: /var/lib/postgresql/data
 
 resources:
   postgresql-image:
     type: oci-image
     description: OCI image for PostgreSQL (ubuntu/postgres)
-    upstream-source: ubuntu/postgres:12-20.04_beta
+    upstream-source: postgresql-patroni
 
 peers:
   postgresql-replicas:
@@ -28,4 +28,4 @@ peers:
 storage:
   pgdata:
     type: filesystem
-    location: /var/lib/postgresql/data/pgdata
+    location: /var/lib/postgresql/data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
-git+https://github.com/canonical/operator/#egg=ops
+jinja2==3.0.3
+lightkube==0.10.0
+ops==1.3.0
+requests==2.27.1
+tenacity==8.0.1

--- a/src/charm.py
+++ b/src/charm.py
@@ -161,10 +161,12 @@ class PostgresqlOperatorCharm(CharmBase):
                 # Restart the stuck replica.
                 self._restart_postgresql_service()
             elif state == "stopping":
-                # Restart the stuck previous leader (forcing the immediate  failover).
+                # Change needed to force an immediate failover.
                 self._patroni.change_master_start_timeout(0)
+                # Restart the stuck previous leader (will trigger an immediate failover).
                 self._restart_postgresql_service()
-                self._patroni.change_master_start_timeout(300)
+                # Revert configuration to default.
+                self._patroni.change_master_start_timeout(None)
         except RetryError as e:
             logger.error("failed to check PostgreSQL state")
             self.unit.status = BlockedStatus(f"failed to check PostgreSQL state with error {e}")

--- a/src/charm.py
+++ b/src/charm.py
@@ -169,6 +169,13 @@ class PostgresqlOperatorCharm(CharmBase):
             logger.error("failed to check PostgreSQL state")
             self.unit.status = BlockedStatus(f"failed to check PostgreSQL state with error {e}")
 
+        # Display an active status message if the current unit is the primary.
+        try:
+            if self._patroni.get_primary(unit_name_pattern=True) == self.unit.name:
+                self.unit.status = ActiveStatus("Primary")
+        except RetryError as e:
+            logger.error(f"failed to get primary with error {e}")
+
     def _restart_postgresql_service(self) -> None:
         """Restart PostgreSQL and Patroni."""
         self.unit.status = MaintenanceStatus(f"restarting {self._postgresql_service} service")

--- a/src/charm.py
+++ b/src/charm.py
@@ -208,7 +208,7 @@ class PostgresqlOperatorCharm(CharmBase):
                         "PATRONI_NAME": pod_name,
                         "PATRONI_SCOPE": self._namespace,
                         "PATRONI_REPLICATION_USERNAME": "replication",
-                        "PATRONI_REPLICATION_PASSWORD": self._get_replication_password(),
+                        "PATRONI_REPLICATION_PASSWORD": self._replication_password,
                         "PATRONI_SUPERUSER_USERNAME": "postgres",
                         "PATRONI_SUPERUSER_PASSWORD": self._get_postgres_password(),
                     },
@@ -242,7 +242,8 @@ class PostgresqlOperatorCharm(CharmBase):
         data = self._peers.data[self.app]
         return data.get("postgres-password", None)
 
-    def _get_replication_password(self) -> str:
+    @property
+    def _replication_password(self) -> str:
         """Get replication user password."""
         data = self._peers.data[self.app]
         return data.get("replication-password", None)

--- a/src/patroni.py
+++ b/src/patroni.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Helper class used to manage interactions with Patroni API and configuration files."""
+
+import logging
+import os
+import pwd
+
+import requests
+from jinja2 import Template
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+logger = logging.getLogger(__name__)
+
+
+STORAGE_PATH = "/var/lib/postgresql/data"
+
+
+class Patroni:
+    """This class handles the communication with Patroni API and configuration files."""
+
+    def __init__(self, pod_ip: str):
+        self._pod_ip = pod_ip
+
+    def get_primary(self, unit_name_pattern=False) -> str:
+        """Get primary instance.
+
+        Args:
+            unit_name_pattern: whether or not to convert pod name to unit name
+
+        Returns:
+            primary pod or unit name.
+        """
+        primary = None
+        # Request info from cluster endpoint (which returns all members of the cluster).
+        r = requests.get(f"http://{self._pod_ip}:8008/cluster")
+        for member in r.json()["members"]:
+            if member["role"] == "leader":
+                primary = member["name"]
+                if unit_name_pattern:
+                    # Change the last dash to / in order to match unit name pattern.
+                    primary = "/".join(primary.rsplit("-", 1))
+                break
+        return primary
+
+    @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=2, max=10))
+    def get_postgresql_state(self) -> str:
+        """Get PostgreSQL state.
+
+        Returns:
+            running, restarting or stopping.
+        """
+        r = requests.get(f"http://{self._pod_ip}:8008/health")
+        return r.json()["state"]
+
+    def _render_file(self, path: str, content: str, mode: int) -> None:
+        """Write a content rendered from a template to a file.
+
+        Args:
+            path: the path to the file.
+            content: the data to be written to the file.
+            mode: access permission mask applied to the
+              file using chmod (e.g. 0o640).
+        """
+        with open(path, "w+") as file:
+            file.write(content)
+        # Ensure correct permissions are set on the file.
+        os.chmod(path, mode)
+        try:
+            # Get the uid/gid for the postgres user.
+            u = pwd.getpwnam("postgres")
+            # Set the correct ownership for the file.
+            os.chown(path, uid=u.pw_uid, gid=u.pw_gid)
+        except KeyError:
+            # Ignore non existing user error when it wasn't created yet.
+            pass
+
+    def render_patroni_yml_file(self) -> None:
+        """Render the Patroni configuration file."""
+        # Open the template postgresql.conf file.
+        with open("templates/patroni.yml.j2", "r") as file:
+            template = Template(file.read())
+        # Render the template file with the correct values.
+        rendered = template.render(pod_ip=self._pod_ip)
+        self._render_file(f"{STORAGE_PATH}/patroni.yml", rendered, 0o644)
+
+    def render_postgresql_conf_file(self) -> None:
+        """Render the PostgreSQL configuration file."""
+        # Open the template postgresql.conf file.
+        with open("templates/postgresql.conf.j2", "r") as file:
+            template = Template(file.read())
+        # Render the template file with the correct values.
+        # TODO: add extra configurations here later.
+        rendered = template.render(
+            logging_collector="on", synchronous_commit="on", synchronous_standby_names="*"
+        )
+        self._render_file(f"{STORAGE_PATH}/postgresql-k8s-operator.conf", rendered, 0o644)

--- a/src/patroni.py
+++ b/src/patroni.py
@@ -24,6 +24,17 @@ class Patroni:
     def __init__(self, pod_ip: str):
         self._pod_ip = pod_ip
 
+    def change_master_start_timeout(self, seconds: int) -> None:
+        """Change master start timeout configuration.
+
+        Args:
+            seconds: number of seconds to set in master_start_timeout configuration.
+        """
+        requests.patch(
+            f"http://{self._pod_ip}:8008/config",
+            json={"master_start_timeout": seconds},
+        )
+
     def get_primary(self, unit_name_pattern=False) -> str:
         """Get primary instance.
 

--- a/src/resources.yaml
+++ b/src/resources.yaml
@@ -1,0 +1,85 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ app_name }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+  - patch
+  - update
+  - create
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ app_name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ app_name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ app_name }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: patroni-k8s-ep-access
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  resourceNames:
+  - kubernetes
+  verbs:
+  - get
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: patroni-k8s-ep-access
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: patroni-k8s-ep-access
+subjects:
+- kind: ServiceAccount
+  name: {{ app_name }}
+  namespace: {{ namespace }}

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -1,0 +1,27 @@
+bootstrap:
+  dcs:
+    postgresql:
+      use_pg_rewind: true
+  initdb:
+  - auth-host: md5
+  - auth-local: trust
+  - encoding: UTF8
+  - locale: en_US.UTF-8
+  - data-checksums
+  pg_hba:
+  - host all all 0.0.0.0/0 md5
+  - host replication replication {{ pod_ip }}/16 md5
+bypass_api_service: true
+log:
+  dir: /var/log/postgresql
+restapi:
+  connect_address: '{{ pod_ip }}:8008'
+  listen: 0.0.0.0:8008
+pod_ip: '{{ pod_ip }}'
+postgresql:
+  connect_address: '{{ pod_ip }}:5432'
+  custom_conf: /var/lib/postgresql/data/postgresql-k8s-operator.conf
+  data_dir: /var/lib/postgresql/data/pgdata
+  listen: 0.0.0.0:5432
+  pgpass: /tmp/pgpass
+use_endpoints: true

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -20,8 +20,8 @@ restapi:
 pod_ip: '{{ pod_ip }}'
 postgresql:
   connect_address: '{{ pod_ip }}:5432'
-  custom_conf: /var/lib/postgresql/data/postgresql-k8s-operator.conf
-  data_dir: /var/lib/postgresql/data/pgdata
+  custom_conf: {{ storage_path }}/postgresql-k8s-operator.conf
+  data_dir: {{ storage_path }}/pgdata
   listen: 0.0.0.0:5432
   pgpass: /tmp/pgpass
 use_endpoints: true

--- a/templates/postgresql.conf.j2
+++ b/templates/postgresql.conf.j2
@@ -1,0 +1,7 @@
+#########################################################################################
+# [ WARNING ]
+# postgresql configuration file maintained by the postgresql-k8s-operator
+# local changes may be overwritten.
+#########################################################################################
+synchronous_commit = '{{ synchronous_commit }}'
+synchronous_standby_names = '{{ synchronous_standby_names }}'

--- a/tests/data/patroni.yml
+++ b/tests/data/patroni.yml
@@ -1,0 +1,27 @@
+bootstrap:
+  dcs:
+    postgresql:
+      use_pg_rewind: true
+  initdb:
+  - auth-host: md5
+  - auth-local: trust
+  - encoding: UTF8
+  - locale: en_US.UTF-8
+  - data-checksums
+  pg_hba:
+  - host all all 0.0.0.0/0 md5
+  - host replication replication 1.1.1.1/16 md5
+bypass_api_service: true
+log:
+  dir: /var/log/postgresql
+restapi:
+  connect_address: '1.1.1.1:8008'
+  listen: 0.0.0.0:8008
+pod_ip: '1.1.1.1'
+postgresql:
+  connect_address: '1.1.1.1:5432'
+  custom_conf: /var/lib/postgresql/data/postgresql-k8s-operator.conf
+  data_dir: /var/lib/postgresql/data/pgdata
+  listen: 0.0.0.0:5432
+  pgpass: /tmp/pgpass
+use_endpoints: true

--- a/tests/data/postgresql.conf
+++ b/tests/data/postgresql.conf
@@ -1,0 +1,7 @@
+#########################################################################################
+# [ WARNING ]
+# postgresql configuration file maintained by the postgresql-k8s-operator
+# local changes may be overwritten.
+#########################################################################################
+synchronous_commit = 'on'
+synchronous_standby_names = '*'

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,8 +2,14 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+from pathlib import Path
 from typing import Callable
 from unittest.mock import patch
+
+import yaml
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+STORAGE_PATH = METADATA["storage"]["pgdata"]["location"]
 
 
 def patch_network_get(private_address="10.1.157.116") -> Callable:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -5,22 +5,20 @@
 
 import logging
 import os
-from pathlib import Path
 
 import psycopg2
 import pytest
-import yaml
 from jinja2 import Template
 from lightkube import AsyncClient
 from lightkube.resources.core_v1 import Pod
 from pytest_operator.plugin import OpsTest
 from tenacity import retry, retry_if_result, stop_after_attempt, wait_exponential
 
+from tests.helpers import METADATA, STORAGE_PATH
+
 logger = logging.getLogger(__name__)
 
-METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
-STORAGE_PATH = "/var/lib/postgresql/data"
 UNIT_IDS = [0, 1, 2]
 
 
@@ -88,7 +86,7 @@ async def test_config_files_are_correct(ops_test: OpsTest, unit_id: int):
     # Get the expected contents from files.
     with open("templates/patroni.yml.j2") as file:
         template = Template(file.read())
-    expected_patroni_yml = template.render(pod_ip=pod_ip)
+    expected_patroni_yml = template.render(pod_ip=pod_ip, storage_path=STORAGE_PATH)
     with open("tests/data/postgresql.conf") as file:
         expected_postgresql_conf = file.read()
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -4,19 +4,30 @@
 
 
 import logging
+import os
 from pathlib import Path
 
 import psycopg2
 import pytest
 import yaml
+from jinja2 import Template
+from lightkube import AsyncClient
+from lightkube.resources.core_v1 import Pod
 from pytest_operator.plugin import OpsTest
+from tenacity import retry, retry_if_result, stop_after_attempt, wait_exponential
 
 logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
+STORAGE_PATH = "/var/lib/postgresql/data"
+UNIT_IDS = [0, 1, 2]
 
 
+@pytest.mark.skipif(
+    os.environ.get("PYTEST_SKIP_DEPLOY", False),
+    reason="skipping deploy, model expected to be provided.",
+)
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest):
     """Build the charm-under-test and deploy it.
@@ -26,20 +37,25 @@ async def test_build_and_deploy(ops_test: OpsTest):
     # Build and deploy charm from local source folder.
     charm = await ops_test.build_charm(".")
     resources = {"postgresql-image": METADATA["resources"]["postgresql-image"]["upstream-source"]}
-    # Deploy two units in order to test later the sharing of password through peer relation data.
-    await ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME, num_units=2)
-
-    # Issuing dummy update_status just to trigger an event.
-    await ops_test.model.set_config({"update-status-hook-interval": "10s"})
+    await ops_test.model.deploy(
+        charm, resources=resources, application_name=APP_NAME, num_units=len(UNIT_IDS), trust=True
+    )
 
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
     assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
 
-    # Effectively disable the update status from firing.
-    await ops_test.model.set_config({"update-status-hook-interval": "60m"})
+
+@pytest.mark.parametrize("unit_id", UNIT_IDS)
+async def test_labels_consistency_across_pods(ops_test: OpsTest, unit_id: int) -> None:
+    model = await ops_test.model.get_info()
+    client = AsyncClient(namespace=model.name)
+    pod = await client.get(Pod, name=f"postgresql-k8s-{unit_id}")
+    # Ensures that the correct kubernetes labels are set
+    # (these ones guarantee the correct working of replication).
+    assert pod.metadata.labels["application"] == "patroni"
+    assert pod.metadata.labels["cluster-name"] == model.name
 
 
-@pytest.mark.abort_on_fail
 async def test_database_is_up(ops_test: OpsTest):
     # Retrieving the postgres user password using the action.
     action = await ops_test.model.units.get(f"{APP_NAME}/0").run_action("get-postgres-password")
@@ -56,3 +72,110 @@ async def test_database_is_up(ops_test: OpsTest):
         )
         assert connection.status == psycopg2.extensions.STATUS_READY
         connection.close()
+
+
+@pytest.mark.parametrize("unit_id", UNIT_IDS)
+async def test_config_files_are_correct(ops_test: OpsTest, unit_id: int):
+    unit_name = f"postgresql-k8s/{unit_id}"
+
+    # Retrieve the pod IP.
+    status = await ops_test.model.get_status()  # noqa: F821
+    for _, unit in status["applications"][APP_NAME]["units"].items():
+        if unit["provider-id"] == unit_name.replace("/", "-"):
+            pod_ip = unit["address"]
+            break
+
+    # Get the expected contents from files.
+    with open("templates/patroni.yml.j2") as file:
+        template = Template(file.read())
+    expected_patroni_yml = template.render(pod_ip=pod_ip)
+    with open("tests/data/postgresql.conf") as file:
+        expected_postgresql_conf = file.read()
+
+    unit = ops_test.model.units[unit_name]
+
+    # Check whether Patroni configuration is correctly set up.
+    patroni_yml_data = await pull_content_from_unit_file(unit, f"{STORAGE_PATH}/patroni.yml")
+    assert patroni_yml_data == expected_patroni_yml
+
+    # Check that the PostgreSQL settings are as expected.
+    postgresql_conf_data = await pull_content_from_unit_file(
+        unit, f"{STORAGE_PATH}/postgresql-k8s-operator.conf"
+    )
+    assert postgresql_conf_data == expected_postgresql_conf
+
+
+async def test_cluster_is_stable_after_leader_deletion(ops_test: OpsTest) -> None:
+    """Tests that the cluster maintains a primary after the primary is deleted."""
+    # Find the current primary unit.
+    primary = await get_primary(ops_test)
+
+    # Delete the primary pod.
+    model = await ops_test.model.get_info()
+    client = AsyncClient(namespace=model.name)
+    await client.delete(Pod, name=primary.replace("/", "-"))
+
+    # Wait and get the primary again (which can be any unit, including the previous primary).
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
+    primary = await get_primary(ops_test)
+
+    # We also need to check that a replica can see the leader
+    # to make sure that the cluster is stable again.
+    other_unit_id = 1 if primary.split("/")[1] == 0 else 0
+    assert await get_primary(ops_test, other_unit_id) is not None
+
+
+async def test_automatic_failover_after_leader_issue(ops_test: OpsTest) -> None:
+    """Tests that an automatic failover is triggered after an issue happens in the leader."""
+    # Change update status hook interval to be triggered more often
+    # (it's required to handle https://github.com/canonical/postgresql-k8s-operator/issues/3).
+    await ops_test.model.set_config({"update-status-hook-interval": "5s"})
+
+    # Find the current primary unit.
+    primary = await get_primary(ops_test)
+
+    # Crash PostgreSQL by removing the data directory.
+    await ops_test.model.units.get(primary).run(f"rm -rf {STORAGE_PATH}/pgdata")
+
+    # Check the leader again (it should be another unit).
+    await primary_changed(ops_test, primary)
+
+
+@retry(
+    retry=retry_if_result(lambda x: not x),
+    stop=stop_after_attempt(10),
+    wait=wait_exponential(multiplier=1, min=2, max=30),
+)
+async def primary_changed(ops_test: OpsTest, old_primary: str) -> bool:
+    """Checks whether or not the primary unit has changed."""
+    primary = await get_primary(ops_test)
+    return primary != old_primary
+
+
+async def get_primary(ops_test: OpsTest, unit_id=0) -> str:
+    """Get the primary unit.
+
+    Args:
+        ops_test: ops_test instance.
+        unit_id: the number of the unit.
+
+    Returns:
+        the current primary unit.
+    """
+    action = await ops_test.model.units.get(f"{APP_NAME}/{unit_id}").run_action("get-primary")
+    action = await action.wait()
+    return action.results["primary"]
+
+
+async def pull_content_from_unit_file(unit, path: str) -> str:
+    """Pull the content of a file from one unit.
+
+    Args:
+        unit: the Juju unit instance.
+        path: the path of the file to get the contents from.
+
+    Returns:
+        the entire content of the file.
+    """
+    action = await unit.run(f"cat {path}")
+    return action.results.get("Stdout", None)

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from typing import Callable
+from unittest.mock import patch
+
+
+def patch_network_get(private_address="10.1.157.116") -> Callable:
+    def network_get(*args, **kwargs) -> dict:
+        """Patch for the not-yet-implemented testing backend needed for `bind_address`.
+
+        This patch decorator can be used for cases such as:
+        self.model.get_binding(event.relation).network.bind_address
+        """
+        return {
+            "bind-addresses": [
+                {
+                    "addresses": [{"value": private_address}],
+                }
+            ]
+        }
+
+    return patch("ops.testing._TestingModelBackend.network_get", network_get)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -5,13 +5,18 @@ import re
 import unittest
 from unittest.mock import Mock, patch
 
-from ops.model import ActiveStatus, WaitingStatus
+from helpers import patch_network_get
+from lightkube import codecs
+from lightkube.resources.core_v1 import Pod
+from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.testing import Harness
+from tenacity import RetryError
 
 from charm import PostgresqlOperatorCharm
 
 
 class TestCharm(unittest.TestCase):
+    @patch_network_get(private_address="1.1.1.1")
     def setUp(self):
         self._peer_relation = "postgresql-replicas"
         self._postgresql_container = "postgresql"
@@ -21,25 +26,55 @@ class TestCharm(unittest.TestCase):
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
         self.charm = self.harness.charm
+        self._context = {
+            "namespace": self.harness.model.name,
+            "app_name": self.harness.model.app.name,
+        }
+
+    @patch("charm.Patroni.render_postgresql_conf_file")
+    @patch("charm.PostgresqlOperatorCharm._patch_pod_labels")
+    @patch("charm.PostgresqlOperatorCharm._create_resources")
+    def test_on_install(
+        self,
+        _create_resources,
+        _patch_pod_labels,
+        _render_postgresql_conf_file,
+    ):
+        self.charm.on.install.emit()
+        _create_resources.assert_called_once()
+        _patch_pod_labels.assert_called_once()
+        _render_postgresql_conf_file.assert_called_once()
 
     def test_on_leader_elected(self):
         # Assert that there is no password in the peer relation.
         self.harness.add_relation(self._peer_relation, self.charm.app.name)
         self.assertIsNone(self.charm._peers.data[self.charm.app].get("postgres-password", None))
+        self.assertIsNone(self.charm._peers.data[self.charm.app].get("replication-password", None))
 
         # Check that a new password was generated on leader election.
         self.harness.set_leader()
-        password = self.charm._peers.data[self.charm.app].get("postgres-password", None)
-        self.assertIsNotNone(password)
+        superuser_password = self.charm._peers.data[self.charm.app].get("postgres-password", None)
+        self.assertIsNotNone(superuser_password)
+
+        replication_password = self.charm._peers.data[self.charm.app].get(
+            "replication-password", None
+        )
+        self.assertIsNotNone(replication_password)
 
         # Trigger a new leader election and check that the password is still the same.
         self.harness.set_leader(False)
         self.harness.set_leader()
         self.assertEqual(
-            self.charm._peers.data[self.charm.app].get("postgres-password", None), password
+            self.charm._peers.data[self.charm.app].get("postgres-password", None),
+            superuser_password,
+        )
+        self.assertEqual(
+            self.charm._peers.data[self.charm.app].get("replication-password", None),
+            replication_password,
         )
 
-    def test_on_postgresql_pebble_ready(self):
+    @patch("charm.Patroni.render_patroni_yml_file")
+    def test_on_postgresql_pebble_ready(self, _render_patroni_yml_file):
         # Check that the initial plan is empty.
         plan = self.harness.get_container_pebble_plan(self._postgresql_container)
         self.assertEqual(plan.to_dict(), {})
@@ -53,6 +88,7 @@ class TestCharm(unittest.TestCase):
                 self.harness.model.unit.status,
                 WaitingStatus("waiting for Pebble in workload container"),
             )
+            _render_patroni_yml_file.assert_not_called()
 
         # Get the current and the expected layer from the pebble plan and the _postgresql_layer
         # method, respectively.
@@ -66,6 +102,7 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(self.harness.model.unit.status, ActiveStatus())
         container = self.harness.model.unit.get_container(self._postgresql_container)
         self.assertEqual(container.get_service(self._postgresql_service).is_running(), True)
+        _render_patroni_yml_file.assert_called_once()
 
     @patch("charm.PostgresqlOperatorCharm._get_postgres_password")
     def test_on_get_postgres_password(self, _get_postgres_password):
@@ -75,28 +112,136 @@ class TestCharm(unittest.TestCase):
         _get_postgres_password.assert_called_once()
         mock_event.set_results.assert_called_once_with({"postgres-password": "test-password"})
 
+    @patch("charm.Patroni.get_primary")
+    def test_on_get_primary(self, _get_primary):
+        mock_event = Mock()
+        _get_primary.return_value = "postgresql-k8s-1"
+        self.charm._on_get_primary(mock_event)
+        _get_primary.assert_called_once()
+        mock_event.set_results.assert_called_once_with({"primary": "postgresql-k8s-1"})
+
+    @patch("charm.Patroni.get_primary")
+    def test_fail_to_get_primary(self, _get_primary):
+        mock_event = Mock()
+        _get_primary.side_effect = [RetryError("fake error")]
+        self.charm._on_get_primary(mock_event)
+        _get_primary.assert_called_once()
+        mock_event.set_results.assert_not_called()
+
+    @patch("ops.model.Container.start")
+    @patch("charm.sleep")
+    @patch("ops.model.Container.stop")
+    def test_restart_postgresql_service(self, _stop, _sleep, _start):
+        self.charm._restart_postgresql_service()
+        _stop.assert_called_once_with(self._postgresql_service)
+        _sleep.assert_called_once_with(30)
+        _start.assert_called_once_with(self._postgresql_service)
+        self.assertEqual(
+            self.harness.model.unit.status,
+            ActiveStatus(),
+        )
+
+    @patch("ops.model.Container.start")
+    @patch("charm.sleep")
+    @patch("ops.model.Container.stop")
+    def test_restart_postgresql_service_without_waiting(self, _stop, _sleep, _start):
+        self.charm._restart_postgresql_service(wait=False)
+        _stop.assert_called_once_with(self._postgresql_service)
+        _sleep.assert_not_called()
+        _start.assert_called_once_with(self._postgresql_service)
+        self.assertEqual(
+            self.harness.model.unit.status,
+            ActiveStatus(),
+        )
+
+    @patch("charm.PostgresqlOperatorCharm._restart_postgresql_service")
+    @patch("charm.Patroni.get_postgresql_state")
+    def test_on_update_status(self, _get_postgresql_state, _restart_postgresql_service):
+        _get_postgresql_state.side_effect = ["running", "restarting", "stopping"]
+
+        # Test running status.
+        self.charm.on.update_status.emit()
+        _restart_postgresql_service.assert_not_called()
+
+        # Test restarting status.
+        self.charm.on.update_status.emit()
+        _restart_postgresql_service.assert_called_once_with(wait=False)
+
+        # Test stopping status.
+        _restart_postgresql_service.reset_mock()
+        self.charm.on.update_status.emit()
+        _restart_postgresql_service.assert_called_once_with()
+
+    @patch("charm.PostgresqlOperatorCharm._restart_postgresql_service")
+    @patch("charm.Patroni.get_postgresql_state")
+    def test_on_update_status_with_error_on_postgresql_status_check(
+        self, _get_postgresql_state, _restart_postgresql_service
+    ):
+        _get_postgresql_state.side_effect = [RetryError("fake error")]
+        self.charm.on.update_status.emit()
+        _restart_postgresql_service.assert_not_called()
+        self.assertEqual(
+            self.harness.model.unit.status,
+            BlockedStatus("failed to check PostgreSQL state with error RetryError[fake error]"),
+        )
+
+    @patch("charm.PostgresqlOperatorCharm._patch_pod_labels")
+    def test_on_upgrade_charm(self, _patch_pod_labels):
+        self.charm.on.upgrade_charm.emit()
+        _patch_pod_labels.assert_called_once()
+
+    @patch("charm.Client")
+    def test_create_resources(self, _client):
+        self.charm._create_resources()
+        with open("src/resources.yaml") as f:
+            for obj in codecs.load_all_yaml(f, context=self._context):
+                _client.return_value.create.assert_any_call(obj)
+
+    @patch("charm.Client")
+    def test_patch_pod_labels(self, _client):
+        self.charm._patch_pod_labels()
+        expected_patch = {
+            "metadata": {
+                "labels": {"application": "patroni", "cluster-name": self.charm._namespace}
+            }
+        }
+        _client.return_value.patch.assert_called_once_with(
+            Pod,
+            name=self.charm._unit.replace("/", "-"),
+            namespace=self.charm._namespace,
+            obj=expected_patch,
+        )
+
     def test_postgresql_layer(self):
         # Test with the already generated password.
         self.harness.add_relation(self._peer_relation, self.charm.app.name)
         self.harness.set_leader()
         plan = self.charm._postgresql_layer().to_dict()
         expected = {
-            "summary": "postgresql layer",
-            "description": "pebble config layer for postgresql",
+            "summary": "postgresql + patroni layer",
+            "description": "pebble config layer for postgresql + patroni",
             "services": {
                 self._postgresql_service: {
                     "override": "replace",
-                    "summary": "entrypoint of the postgresql image",
-                    "command": "/usr/local/bin/docker-entrypoint.sh postgres",
+                    "summary": "entrypoint of the postgresql + patroni image",
+                    "command": "/usr/bin/python3 /usr/local/bin/patroni /var/lib/postgresql/data/patroni.yml",
                     "startup": "enabled",
+                    "user": "postgres",
+                    "group": "postgres",
                     "environment": {
-                        "PGDATA": "/var/lib/postgresql/data/pgdata",
-                        "POSTGRES_PASSWORD": self.charm._get_postgres_password(),
+                        "PATRONI_KUBERNETES_LABELS": "{application: patroni, cluster-name: postgresql-k8s}",
+                        "PATRONI_KUBERNETES_NAMESPACE": self.charm._namespace,
+                        "PATRONI_NAME": "postgresql-k8s-0",
+                        "PATRONI_SCOPE": self.charm._namespace,
+                        "PATRONI_REPLICATION_USERNAME": "replication",
+                        "PATRONI_REPLICATION_PASSWORD": self.charm._get_replication_password(),
+                        "PATRONI_SUPERUSER_USERNAME": "postgres",
+                        "PATRONI_SUPERUSER_PASSWORD": self.charm._get_postgres_password(),
                     },
                 }
             },
         }
-        self.assertEqual(plan, expected)
+        self.assertDictEqual(plan, expected)
 
     def test_new_password(self):
         # Test the password generation twice in order to check if we get different passwords and
@@ -113,6 +258,17 @@ class TestCharm(unittest.TestCase):
         # Test for a None password.
         self.harness.add_relation(self._peer_relation, self.charm.app.name)
         self.assertIsNone(self.charm._get_postgres_password())
+
+        # Then test for a non empty password after leader election and peer data set.
+        self.harness.set_leader()
+        password = self.charm._get_postgres_password()
+        self.assertIsNotNone(password)
+        self.assertNotEqual(password, "")
+
+    def test_get_replication_password(self):
+        # Test for a None password.
+        self.harness.add_relation(self._peer_relation, self.charm.app.name)
+        self.assertIsNone(self.charm._get_replication_password())
 
         # Then test for a non empty password after leader election and peer data set.
         self.harness.set_leader()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -188,7 +188,7 @@ class TestCharm(unittest.TestCase):
         # Test stopping status.
         _restart_postgresql_service.reset_mock()
         self.charm.on.update_status.emit()
-        expected_calls = [call.c(0), call.r(), call.c(300)]
+        expected_calls = [call.c(0), call.r(), call.c(None)]
         self.assertEqual(manager.mock_calls, expected_calls)
 
     @patch("charm.Patroni.get_primary")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -5,7 +5,6 @@ import re
 import unittest
 from unittest.mock import Mock, call, patch
 
-from helpers import patch_network_get
 from lightkube import codecs
 from lightkube.resources.core_v1 import Pod
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
@@ -13,6 +12,7 @@ from ops.testing import Harness
 from tenacity import RetryError
 
 from charm import PostgresqlOperatorCharm
+from tests.helpers import patch_network_get
 
 
 class TestCharm(unittest.TestCase):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -265,7 +265,7 @@ class TestCharm(unittest.TestCase):
                         "PATRONI_NAME": "postgresql-k8s-0",
                         "PATRONI_SCOPE": self.charm._namespace,
                         "PATRONI_REPLICATION_USERNAME": "replication",
-                        "PATRONI_REPLICATION_PASSWORD": self.charm._get_replication_password(),
+                        "PATRONI_REPLICATION_PASSWORD": self.charm._replication_password,
                         "PATRONI_SUPERUSER_USERNAME": "postgres",
                         "PATRONI_SUPERUSER_PASSWORD": self.charm._get_postgres_password(),
                     },
@@ -289,17 +289,6 @@ class TestCharm(unittest.TestCase):
         # Test for a None password.
         self.harness.add_relation(self._peer_relation, self.charm.app.name)
         self.assertIsNone(self.charm._get_postgres_password())
-
-        # Then test for a non empty password after leader election and peer data set.
-        self.harness.set_leader()
-        password = self.charm._get_postgres_password()
-        self.assertIsNotNone(password)
-        self.assertNotEqual(password, "")
-
-    def test_get_replication_password(self):
-        # Test for a None password.
-        self.harness.add_relation(self._peer_relation, self.charm.app.name)
-        self.assertIsNone(self.charm._get_replication_password())
 
         # Then test for a non empty password after leader election and peer data set.
         self.harness.set_leader()

--- a/tests/unit/test_patroni.py
+++ b/tests/unit/test_patroni.py
@@ -13,6 +13,21 @@ class TestPatroni(unittest.TestCase):
         # Setup Patroni wrapper.
         self.patroni = Patroni("1.1.1.1")
 
+    @patch("requests.patch")
+    def test_change_master_start_timeout(self, _patch):
+        # Test with an initial timeout value.
+        self.patroni.change_master_start_timeout(0)
+        _patch.assert_called_once_with(
+            "http://1.1.1.1:8008/config", json={"master_start_timeout": 0}
+        )
+
+        # Test with another timeout value.
+        _patch.reset_mock()
+        self.patroni.change_master_start_timeout(300)
+        _patch.assert_called_once_with(
+            "http://1.1.1.1:8008/config", json={"master_start_timeout": 300}
+        )
+
     @patch("requests.get")
     def test_get_postgresql_state(self, _get):
         _get.return_value.json.return_value = {"state": "running"}

--- a/tests/unit/test_patroni.py
+++ b/tests/unit/test_patroni.py
@@ -5,13 +5,14 @@
 import unittest
 from unittest.mock import mock_open, patch
 
-from patroni import STORAGE_PATH, Patroni
+from patroni import Patroni
+from tests.helpers import STORAGE_PATH
 
 
 class TestPatroni(unittest.TestCase):
     def setUp(self):
         # Setup Patroni wrapper.
-        self.patroni = Patroni("1.1.1.1")
+        self.patroni = Patroni("1.1.1.1", STORAGE_PATH)
 
     @patch("requests.patch")
     def test_change_master_start_timeout(self, _patch):

--- a/tests/unit/test_patroni.py
+++ b/tests/unit/test_patroni.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import unittest
+from unittest.mock import mock_open, patch
+
+from patroni import STORAGE_PATH, Patroni
+
+
+class TestPatroni(unittest.TestCase):
+    def setUp(self):
+        # Setup Patroni wrapper.
+        self.patroni = Patroni("1.1.1.1")
+
+    @patch("requests.get")
+    def test_get_postgresql_state(self, _get):
+        _get.return_value.json.return_value = {"state": "running"}
+        state = self.patroni.get_postgresql_state()
+        self.assertEqual(state, "running")
+        _get.assert_called_once_with("http://1.1.1.1:8008/health")
+
+    @patch("requests.get")
+    def test_get_primary(self, _get):
+        # Mock Patroni cluster API.
+        _get.return_value.json.return_value = {
+            "members": [
+                {"name": "postgresql-k8s-0", "role": "replica"},
+                {"name": "postgresql-k8s-1", "role": "leader"},
+                {"name": "postgresql-k8s-2", "role": "replica"},
+            ]
+        }
+
+        # Test returning pod name.
+        primary = self.patroni.get_primary()
+        self.assertEqual(primary, "postgresql-k8s-1")
+        _get.assert_called_once_with("http://1.1.1.1:8008/cluster")
+
+        # Test returning unit name.
+        _get.reset_mock()
+        primary = self.patroni.get_primary(unit_name_pattern=True)
+        self.assertEqual(primary, "postgresql-k8s/1")
+        _get.assert_called_once_with("http://1.1.1.1:8008/cluster")
+
+    @patch("os.chmod")
+    @patch("os.chown")
+    @patch("pwd.getpwnam")
+    @patch("tempfile.NamedTemporaryFile")
+    def test_render_file(self, _temp_file, _pwnam, _chown, _chmod):
+        # Set a mocked temporary filename.
+        filename = "/tmp/temporaryfilename"
+        _temp_file.return_value.name = filename
+        # Setup a mock for the `open` method.
+        mock = mock_open()
+        # Patch the `open` method with our mock.
+        with patch("builtins.open", mock, create=True):
+            # Set the uid/gid return values for lookup of 'postgres' user.
+            _pwnam.return_value.pw_uid = 35
+            _pwnam.return_value.pw_gid = 35
+            # Call the method using a temporary configuration file.
+            self.patroni._render_file(filename, "rendered-content", 0o640)
+
+        # Check the rendered file is opened with "w+" mode.
+        self.assertEqual(mock.call_args_list[0][0], (filename, "w+"))
+        # Ensure that the correct user is lookup up.
+        _pwnam.assert_called_with("postgres")
+        # Ensure the file is chmod'd correctly.
+        _chmod.assert_called_with(filename, 0o640)
+        # Ensure the file is chown'd correctly.
+        _chown.assert_called_with(filename, uid=35, gid=35)
+
+    @patch("charm.Patroni._render_file")
+    def test_render_patroni_yml_file(self, _render_file):
+        # Get the expected content from a file.
+        with open("tests/data/patroni.yml") as file:
+            expected_content = file.read()
+
+        # Setup a mock for the `open` method, set returned data to postgresql.conf template.
+        with open("templates/patroni.yml.j2", "r") as f:
+            mock = mock_open(read_data=f.read())
+
+        # Patch the `open` method with our mock.
+        with patch("builtins.open", mock, create=True):
+            # Call the method
+            self.patroni.render_patroni_yml_file()
+
+        # Check the template is opened read-only in the call to open.
+        self.assertEqual(mock.call_args_list[0][0], ("templates/patroni.yml.j2", "r"))
+        # Ensure the correct rendered template is sent to _render_file method.
+        _render_file.assert_called_once_with(
+            f"{STORAGE_PATH}/patroni.yml",
+            expected_content,
+            0o644,
+        )
+
+    @patch("charm.Patroni._render_file")
+    def test_render_postgresql_conf_file(self, _render_file):
+        # Get the expected content from a file.
+        with open("tests/data/postgresql.conf") as file:
+            expected_content = file.read()
+
+        # Setup a mock for the `open` method, set returned data to postgresql.conf template.
+        with open("templates/postgresql.conf.j2", "r") as f:
+            mock = mock_open(read_data=f.read())
+
+        # Patch the `open` method with our mock.
+        with patch("builtins.open", mock, create=True):
+            # Call the method
+            self.patroni.render_postgresql_conf_file()
+
+        # Check the template is opened read-only in the call to open.
+        self.assertEqual(mock.call_args_list[0][0], ("templates/postgresql.conf.j2", "r"))
+        # Ensure the correct rendered template is sent to _render_file method.
+        _render_file.assert_called_once_with(
+            f"{STORAGE_PATH}/postgresql-k8s-operator.conf",
+            expected_content,
+            0o644,
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ passenv =
   HOME
   CHARM_BUILD_DIR
   MODEL_SETTINGS
+  PYTEST_SKIP_DEPLOY
 
 [testenv:fmt]
 description = Apply coding style standards to code


### PR DESCRIPTION
This PR enables the replication of the data among PostgreSQL units and also automatic failover, both features using [Patroni](https://github.com/zalando/patroni).

The integration tests focus on checking what is needed (configuration files and labels) to make Patroni manage correctly the replication and the automatic failover.

There is also a workaround in the update status hook to restart Patroni + PostgreSQL during an automatic failover. It’s needed because there is an issue about [zombie processes](https://github.com/canonical/pebble/issues/6).

Even separating some manual actions (manual failover and switchover) from this PR it got a little bigger. I’ll work to have smaller PRs in the future.

One last detail: the integration tests should fail as the docker image is not published yet, but it can be executed locally using the instructions from CONTRIBUTING.md. 