### PR TITLE
DPE-124 Additional Integration Testing 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,8 @@ docker save postgresql-patroni | microk8s ctr image import -
 juju add-model dev
 # Enable DEBUG logging
 juju model-config logging-config="<root>=INFO;unit=DEBUG"
+# enable Role-Based Access Control on microk8s
+microk8s enable rbac
 # Deploy the charm
 juju deploy ./postgresql-k8s_ubuntu-20.04-amd64.charm \
     --resource postgresql-image=ubuntu/postgres --trust

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,12 @@ tox -e integration   # integration tests
 tox                  # runs 'lint' and 'unit' environments
 ```
 
+Before running integration tests, run this command to ensure your config is accessible by lightkube:
+
+```shell
+microk8s config > ~/.kube/config
+```
+
 ## Build charm
 
 Build the charm in this git repository using:

--- a/src/charm.py
+++ b/src/charm.py
@@ -20,6 +20,7 @@ from ops.model import (
     WaitingStatus,
 )
 from ops.pebble import Layer
+from requests import ConnectionError
 from tenacity import RetryError
 
 from patroni import Patroni
@@ -175,7 +176,7 @@ class PostgresqlOperatorCharm(CharmBase):
         try:
             if self._patroni.get_primary(unit_name_pattern=True) == self.unit.name:
                 self.unit.status = ActiveStatus("Primary")
-        except RetryError as e:
+        except (RetryError, ConnectionError) as e:
             logger.error(f"failed to get primary with error {e}")
 
     def _restart_postgresql_service(self) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -171,6 +171,7 @@ class PostgresqlOperatorCharm(CharmBase):
         except RetryError as e:
             logger.error("failed to check PostgreSQL state")
             self.unit.status = BlockedStatus(f"failed to check PostgreSQL state with error {e}")
+            return
 
         # Display an active status message if the current unit is the primary.
         try:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -174,7 +174,12 @@ async def test_persist_data_through_failure(ops_test: OpsTest):
     # Wait for juju to notice one of the pods is gone and fix it
     logger.info("wait for juju to reset postgres container")
     await ops_test.model.wait_for_idle(
-        apps=[APP_NAME], status="active", timeout=1000, wait_for_exact_units=3, check_freq=2, idle_period=45
+        apps=[APP_NAME],
+        status="active",
+        timeout=1000,
+        wait_for_exact_units=3,
+        check_freq=2,
+        idle_period=45,
     )
     logger.info("juju has reset postgres container")
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -171,8 +171,9 @@ async def test_persist_data_through_failure(ops_test: OpsTest):
     await client.delete(Pod, name=primary.replace("/", "-"))
     logger.info("primary pod deleted")
 
+    # Wait 30 years for juju to notice one of the pods is gone and fix it
     await ops_test.model.wait_for_idle(
-        apps=[APP_NAME], status="active", timeout=1000, wait_for_exact_units=3, idle_period=30
+        apps=[APP_NAME], status="active", timeout=1000, wait_for_exact_units=3, idle_period=60
     )
 
     # Testing write occurred to every postgres instance by reading from them

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -221,11 +221,6 @@ async def primary_changed(ops_test: OpsTest, old_primary: str) -> bool:
     return primary != old_primary
 
 
-# @retry(
-#     retry=retry_if_result(lambda x: x == "None"),
-#     stop=stop_after_attempt(10),
-#     wait=wait_exponential(multiplier=1, min=2, max=30),
-# )
 async def get_primary(ops_test: OpsTest, unit_id=0) -> str:
     """Get the primary unit.
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -109,9 +109,12 @@ async def test_cluster_is_stable_after_leader_deletion(ops_test: OpsTest) -> Non
     model = await ops_test.model.get_info()
     client = AsyncClient(namespace=model.name)
     await client.delete(Pod, name=primary.replace("/", "-"))
+    logger.info(f"deleted pod {primary}")
 
     # Wait and get the primary again (which can be any unit, including the previous primary).
-    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME], status="active", timeout=1000, wait_for_exact_units=3
+    )
     primary = await get_primary(ops_test)
 
     # We also need to check that a replica can see the leader
@@ -169,7 +172,7 @@ async def test_persist_data_through_failure(ops_test: OpsTest):
     logger.info("primary pod deleted")
 
     await ops_test.model.wait_for_idle(
-        apps=[APP_NAME], status="active", timeout=1000, wait_for_exact_units=3
+        apps=[APP_NAME], status="active", timeout=1000, wait_for_exact_units=3, idle_period=30
     )
 
     # Testing write occurred to every postgres instance by reading from them

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -119,6 +119,7 @@ async def test_cluster_is_stable_after_leader_deletion(ops_test: OpsTest) -> Non
     other_unit_id = 1 if primary.split("/")[1] == 0 else 0
     assert await get_primary(ops_test, other_unit_id) != "None"
 
+
 async def test_persist_data_through_graceful_restart(ops_test: OpsTest):
     """Test data persists through a graceful restart."""
     primary = await get_primary(ops_test)
@@ -167,7 +168,9 @@ async def test_persist_data_through_failure(ops_test: OpsTest):
     await client.delete(Pod, name=primary.replace("/", "-"))
     logger.info("primary pod deleted")
 
-    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000, wait_for_exact_units=3, idle_period=30)
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME], status="active", timeout=1000, wait_for_exact_units=3
+    )
 
     # Testing write occurred to every postgres instance by reading from them
     status = await ops_test.model.get_status()  # noqa: F821
@@ -246,7 +249,8 @@ async def pull_content_from_unit_file(unit, path: str) -> str:
     action = await unit.run(f"cat {path}")
     return action.results.get("Stdout", None)
 
-def db_connect(host:str, password:str):
+
+def db_connect(host: str, password: str):
     """Returns psycopg2 connection object linked to postgres db in the given host.
 
     Args:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -221,11 +221,11 @@ async def primary_changed(ops_test: OpsTest, old_primary: str) -> bool:
     return primary != old_primary
 
 
-@retry(
-    retry=retry_if_result(lambda x: x == "None"),
-    stop=stop_after_attempt(10),
-    wait=wait_exponential(multiplier=1, min=2, max=30),
-)
+# @retry(
+#     retry=retry_if_result(lambda x: x == "None"),
+#     stop=stop_after_attempt(10),
+#     wait=wait_exponential(multiplier=1, min=2, max=30),
+# )
 async def get_primary(ops_test: OpsTest, unit_id=0) -> str:
     """Get the primary unit.
 
@@ -261,15 +261,6 @@ async def pull_content_from_unit_file(unit, path: str) -> str:
     """
     action = await unit.run(f"cat {path}")
     return action.results.get("Stdout", None)
-
-
-async def wait_for_status(ops_test, status: str, wait: float):
-    status = False
-    while True:
-        for unit in ops_test.model.applications[APP_NAME].units:
-            if unit.workload_status == status:
-                pass
-        await ops_test.jasyncio.sleep(wait)
 
 
 def db_connect(host: str, password: str):

--- a/tox.ini
+++ b/tox.ini
@@ -73,4 +73,4 @@ deps =
     psycopg2-binary
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} --durations=0


### PR DESCRIPTION
## Issue
This PR adds some integration tests that verify that data persists in the postgres charm after graceful restarts and catastrophic failures.

## Context
- Integration tests are failing on GitHub because the test runner doesn't have access to the patroni container.

## Release Notes
- Extra documentation for setup steps
- some minor cleanup for other tests, including `get_postgres_password` and `db_connect` methods
- Some extra `wait_for_idle`s in other tests to guarantee stability
- `test_persist_data_through_graceful_restart` test, which tests that data written to the primary persists across the other nodes after scaling juju down to 0 and back up to 3 nodes
- `test_persist_data_through_failure` test, which tests that data written to the primary persists across the other nodes after killing the primary using microk8s
- Early return in `_on_update_status` hook handler when postgres is inaccessible
- Added pytest logging to show how long each integration test runs for 
