### PR TITLE
DPE-212 Add build of OCI image for integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,8 +26,37 @@ jobs:
         run: python -m pip install tox
       - name: Run tests
         run: tox -e unit
+  # This job is needed until the OCI image is published to ROCKS.
+  build-oci-image:
+    name: Build OCI image for integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          repository: 'canonical/postgresql-patroni-container'
+          ref: 'v0.1.0'
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build Image and Export
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          builder: ${{ steps.buildx.outputs.name }}
+          # Do not publish the image.
+          push: false
+          # Set the tag to retrieve the image in Deploy tests.
+          tags: postgresql-patroni
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Upload image to be used in integration tests
+        uses: actions/upload-artifact@v2
+        with:
+          name: image
+          path: /tmp/image.tar
   integration-test-microk8s:
     name: Integration tests (microk8s)
+    needs: build-oci-image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -36,5 +65,14 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
+      # These two steps (download and load image) are needed until the OCI image is published to ROCKS.
+      - name: Download image built in build oci image step
+        uses: actions/download-artifact@v2
+        with:
+          name: image
+          path: /tmp
+      - name: Load Image into microk8s
+        run: |
+          /usr/bin/sg microk8s -c "microk8s ctr image import /tmp/image.tar"
       - name: Run integration tests
         run: tox -e integration

--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,7 @@ description = Run integration tests
 deps =
     git+https://github.com/juju/python-libjuju.git
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git
+    pytest-operator
     psycopg2-binary
     -r{toxinidir}/requirements.txt
 commands =


### PR DESCRIPTION
# Issue
In short this PR address JIRA ticket [DPE-212](https://warthogs.atlassian.net/browse/DPE-212).

In long:
* Currently, we don't have ROCKS available to publish our OCI images.
* This charm needs a custom OCI image from https://github.com/canonical/postgresql-patroni-container.
* In order to make the integration tests work we need to be able to pull the OCI image even if we still don't have it published to ROCKS.


# Solution
* Pull, build and import the OCI image to microk8s registry during integration tests.


# Context
* There is an additional workaround for https://github.com/charmed-kubernetes/pytest-operator/issues/72.
* I'm not using something on python code as this implementation is a temporary workaround until ROCKS is available.



# Testing
* It's possible to check the tests passing just on GitHub CI.


# Release Notes
* Add OCI image pull, build and import on integration tests
* Add workaround for https://github.com/charmed-kubernetes/pytest-operator/issues/72