### PR TITLE
Change default asyncio mode to fix error on fixtures

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -74,4 +74,4 @@ deps =
     psycopg2-binary
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} --durations=0
+    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} --durations=0 --asyncio-mode=auto


### PR DESCRIPTION
# Issue
Today `pytest-asyncio` was updated and changed the default asyncio mode to `strict`. This breaks some fixtures that we have in our charms, specially the ones used in the new relations tests.

[Release notes about the update](https://github.com/pytest-dev/pytest-asyncio/releases/tag/v0.19.0).

# Solution
* Change the default asyncio mode to `auto` (the recommended if we do not use multiple async frameworks).

# Release Notes
* Change default asyncio mode to auto.