### PR TITLE
Avoid handling departing event in the departing unit

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -375,10 +375,13 @@ class PostgresqlOperatorCharm(CharmBase):
             with open("src/resources.yaml") as f:
                 for resource in codecs.load_all_yaml(f, context=self._context):
                     client.create(resource)
-                    logger.info(f"created {str(resource)}")
+                    logger.debug(f"created {str(resource)}")
         except ApiError as e:
+            # The 409 error code means that the resource was already created
+            # or has a higher version. This can happen if Patroni creates a
+            # resource that the charm is expected to create.
             if e.status.code == 409:
-                logger.info("replacing resource: %s.", str(resource.to_dict()))
+                logger.debug("replacing resource: %s.", str(resource.to_dict()))
                 client.replace(resource)
             else:
                 logger.error("failed to create resource: %s.", str(resource.to_dict()))

--- a/src/charm.py
+++ b/src/charm.py
@@ -108,7 +108,8 @@ class PostgresqlOperatorCharm(CharmBase):
 
     def _on_peer_relation_departed(self, event: RelationDepartedEvent) -> None:
         """The leader removes the departing units from the list of cluster members."""
-        if not self.unit.is_leader():
+        # Allow leader to update endpoints if it isn't leaving.
+        if not self.unit.is_leader() or event.departing_unit == self.unit:
             return
 
         if "cluster_initialised" not in self._peers.data[self.app]:


### PR DESCRIPTION
# Issue
An error happens in the peer relation departed event if the application is removed from the model.

In the relation departed event handler, it is not being checked if the departed unit is the one that is receiving the event, so if the workload is gone an error happens when the handler tries to connect to the Patroni API (it is part of the process to update the list of the members of the Patroni cluster).

# Solution
* Avoid handling the relation departed event in the departing unit.

# Context
* Some additional changes were made in `charm.py`, not related to the issue that was described. They are related to change the debug level of some logging calls that should be DEBUG instead of INFO, and also a missing comment about an error code. They were added as both changes and the solution for the issue are small.

# Testing
* Added an additional integration test for the application removal (which validates the logic to avoid handling the relation departed event in the departing).

# Release Notes
* Avoid handling departing event in the departing unit
* Change level of some logging calls to debug
* Add explanation about 409 error code when calling the k8s API