### PR TITLE
Rename relation interface names

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,5 @@
 name: Tests
 on:
-  push:
-    branches:
-      - main
   pull_request:
 
 jobs:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -22,12 +22,12 @@ resources:
     upstream-source: dataplatformoci/postgres-patroni
 
 peers:
-  postgresql-replicas:
-    interface: postgresql-replicas
+  database-peers:
+    interface: postgresql_peers
 
 provides:
   database:
-    interface: postgresql-client
+    interface: postgresql_client
   db:
     interface: pgsql
   db-admin:

--- a/src/charm.py
+++ b/src/charm.py
@@ -30,14 +30,13 @@ from ops.pebble import Layer
 from requests import ConnectionError
 from tenacity import RetryError
 
+from constants import PEER
 from patroni import NotReadyError, Patroni
 from relations.db import DbProvides
 from relations.postgresql_provider import PostgreSQLProvider
 from utils import new_password
 
 logger = logging.getLogger(__name__)
-
-PEER = "postgresql-replicas"
 
 
 class PostgresqlOperatorCharm(CharmBase):

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,3 +4,4 @@
 """File containing constants to be used in the charm."""
 
 DATABASE_PORT = "5432"
+PEER = "database-peers"

--- a/tests/integration/new_relations/application-charm/metadata.yaml
+++ b/tests/integration/new_relations/application-charm/metadata.yaml
@@ -9,11 +9,11 @@ summary: |
 
 requires:
   first-database:
-    interface: postgresql-client
+    interface: postgresql_client
   second-database:
-    interface: postgresql-client
+    interface: postgresql_client
   multiple-database-clusters:
-    interface: postgresql-client
+    interface: postgresql_client
   aliased-multiple-database-clusters:
-    interface: postgresql-client
+    interface: postgresql_client
     limit: 2

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -55,7 +55,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
 
 @pytest.mark.parametrize("unit_id", UNIT_IDS)
 async def test_labels_consistency_across_pods(ops_test: OpsTest, unit_id: int) -> None:
-    model = await ops_test.model.get_info()
+    model = ops_test.model.info
     client = AsyncClient(namespace=model.name)
     pod = await client.get(Pod, name=f"postgresql-k8s-{unit_id}")
     # Ensures that the correct kubernetes labels are set
@@ -118,7 +118,7 @@ async def test_cluster_is_stable_after_leader_deletion(ops_test: OpsTest) -> Non
     primary = await get_primary(ops_test)
 
     # Delete the primary pod.
-    model = await ops_test.model.get_info()
+    model = ops_test.model.info
     client = AsyncClient(namespace=model.name)
     await client.delete(Pod, name=primary.replace("/", "-"))
     logger.info(f"deleted pod {primary}")
@@ -201,7 +201,7 @@ async def test_persist_data_through_failure(ops_test: OpsTest):
         connection.cursor().execute("CREATE TABLE failtest (testcol INT );")
 
     # Cause a machine failure by killing a unit in k8s
-    model = await ops_test.model.get_info()
+    model = ops_test.model.info
     client = AsyncClient(namespace=model.name)
     await client.delete(Pod, name=primary.replace("/", "-"))
     logger.info("primary pod deleted")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -11,13 +11,14 @@ from ops.testing import Harness
 from tenacity import RetryError
 
 from charm import PostgresqlOperatorCharm
+from constants import PEER
 from tests.helpers import patch_network_get
 
 
 class TestCharm(unittest.TestCase):
     @patch_network_get(private_address="1.1.1.1")
     def setUp(self):
-        self._peer_relation = "postgresql-replicas"
+        self._peer_relation = PEER
         self._postgresql_container = "postgresql"
         self._postgresql_service = "postgresql"
 

--- a/tox.ini
+++ b/tox.ini
@@ -68,7 +68,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     pytest-operator
     psycopg2-binary


### PR DESCRIPTION
# Issue
Relation interface name must not include hyphens.

# Solution
Change `-` to `_` in the relation interface names.

# Context
* Fixed `postgresql-replicas` relation, which has the incorrect name and also the interface name in the wrong format.
* Also removed the duplicate CI run on `ci.yaml` when the code is merged to main. This was done because there is already a workflow running through `release.yaml`.
* Also fixed the juju python library in `tox.ini`. The dependecy was pointing to git instead of the published version, which caused some issues in the integration tests because of some breaking changes (one of them, related to https://github.com/juju/python-libjuju/commit/d42f7e6d6095c0ff7ed807764779b395092e2f7e, was fixed now on `tests/integration/test_charm.py` to avoid errors again when a new version of the library is published on PyPi).

# Release Notes
* Rename relation interface names.
* Remove duplicate CI run when changed are merged to main.
* Change juju dependency in tox.ini to the one that is published.