### PR TITLE
Change charm database user

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -3,5 +3,6 @@
 
 get-primary:
   description: Get the unit with is the primary/leader in the replication.
-get-postgres-password:
-  description: Get the initial postgres user password for the database.
+get-operator-password:
+  description: Get the operator user password used by charm.
+    It is internal charm user, SHOULD NOT be used by applications.

--- a/src/charm.py
+++ b/src/charm.py
@@ -30,7 +30,7 @@ from ops.pebble import Layer
 from requests import ConnectionError
 from tenacity import RetryError
 
-from constants import PEER
+from constants import PEER, USER
 from patroni import NotReadyError, Patroni
 from relations.db import DbProvides
 from relations.postgresql_provider import PostgreSQLProvider
@@ -59,7 +59,7 @@ class PostgresqlOperatorCharm(CharmBase):
         self.framework.observe(self.on.postgresql_pebble_ready, self._on_postgresql_pebble_ready)
         self.framework.observe(self.on.upgrade_charm, self._on_upgrade_charm)
         self.framework.observe(
-            self.on.get_postgres_password_action, self._on_get_postgres_password
+            self.on.get_operator_password_action, self._on_get_operator_password
         )
         self.framework.observe(self.on.get_primary_action, self._on_get_primary)
         self.framework.observe(self.on.update_status, self._on_update_status)
@@ -74,8 +74,8 @@ class PostgresqlOperatorCharm(CharmBase):
         """Returns an instance of the object used to interact with the database."""
         return PostgreSQL(
             host=self.primary_endpoint,
-            user="postgres",
-            password=self._get_postgres_password(),
+            user=USER,
+            password=self._get_operator_password(),
             database="postgres",
         )
 
@@ -250,11 +250,11 @@ class PostgresqlOperatorCharm(CharmBase):
     def _on_leader_elected(self, event: LeaderElectedEvent) -> None:
         """Handle the leader-elected event."""
         data = self._peers.data[self.app]
-        postgres_password = data.get("postgres-password", None)
+        operator_password = data.get("operator-password", None)
         replication_password = data.get("replication-password", None)
 
-        if postgres_password is None:
-            self._peers.data[self.app]["postgres-password"] = new_password()
+        if operator_password is None:
+            self._peers.data[self.app]["operator-password"] = new_password()
 
         if replication_password is None:
             self._peers.data[self.app]["replication-password"] = new_password()
@@ -387,9 +387,9 @@ class PostgresqlOperatorCharm(CharmBase):
                 self.unit.status = BlockedStatus(f"failed to create services {e}")
                 return
 
-    def _on_get_postgres_password(self, event: ActionEvent) -> None:
-        """Returns the password for the postgres user as an action response."""
-        event.set_results({"postgres-password": self._get_postgres_password()})
+    def _on_get_operator_password(self, event: ActionEvent) -> None:
+        """Returns the password for the operator user as an action response."""
+        event.set_results({"operator-password": self._get_operator_password()})
 
     def _on_get_primary(self, event: ActionEvent) -> None:
         """Get primary instance."""
@@ -501,8 +501,8 @@ class PostgresqlOperatorCharm(CharmBase):
                         "PATRONI_SCOPE": f"patroni-{self._name}",
                         "PATRONI_REPLICATION_USERNAME": "replication",
                         "PATRONI_REPLICATION_PASSWORD": self._replication_password,
-                        "PATRONI_SUPERUSER_USERNAME": "postgres",
-                        "PATRONI_SUPERUSER_PASSWORD": self._get_postgres_password(),
+                        "PATRONI_SUPERUSER_USERNAME": USER,
+                        "PATRONI_SUPERUSER_PASSWORD": self._get_operator_password(),
                     },
                 }
             },
@@ -519,10 +519,10 @@ class PostgresqlOperatorCharm(CharmBase):
         """
         return self.model.get_relation(PEER)
 
-    def _get_postgres_password(self) -> str:
-        """Get postgres user password."""
+    def _get_operator_password(self) -> str:
+        """Get operator user password."""
         data = self._peers.data[self.app]
-        return data.get("postgres-password", None)
+        return data.get("operator-password", None)
 
     @property
     def _replication_password(self) -> str:

--- a/src/constants.py
+++ b/src/constants.py
@@ -5,3 +5,4 @@
 
 DATABASE_PORT = "5432"
 PEER = "database-peers"
+USER = "operator"

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -161,7 +161,7 @@ async def execute_query_on_unit(
         A list of rows that were potentially returned from the query.
     """
     with psycopg2.connect(
-        f"dbname='{database}' user='postgres' host='{unit_address}' password='{password}' connect_timeout=10"
+        f"dbname='{database}' user='operator' host='{unit_address}' password='{password}' connect_timeout=10"
     ) as connection, connection.cursor() as cursor:
         cursor.execute(query)
         output = list(itertools.chain(*cursor.fetchall()))

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -30,7 +30,7 @@ async def check_database_users_existence(
     """
     unit = ops_test.model.applications[DATABASE_APP_NAME].units[0]
     unit_address = await get_unit_address(ops_test, unit.name)
-    password = await get_postgres_password(ops_test)
+    password = await get_operator_password(ops_test)
 
     # Retrieve all users in the database.
     output = await execute_query_on_unit(
@@ -61,7 +61,7 @@ async def check_database_creation(ops_test: OpsTest, database: str) -> None:
         ops_test: The ops test framework
         database: Name of the database that should have been created
     """
-    password = await get_postgres_password(ops_test)
+    password = await get_operator_password(ops_test)
 
     for unit in ops_test.model.applications[DATABASE_APP_NAME].units:
         unit_address = await get_unit_address(ops_test, unit.name)
@@ -196,12 +196,12 @@ def get_application_units(ops_test: OpsTest, application_name: str) -> List[str]
     ]
 
 
-async def get_postgres_password(ops_test: OpsTest):
-    """Retrieve the postgres user password using the action."""
+async def get_operator_password(ops_test: OpsTest):
+    """Retrieve the operator user password using the action."""
     unit = ops_test.model.units.get(f"{DATABASE_APP_NAME}/0")
-    action = await unit.run_action("get-postgres-password")
+    action = await unit.run_action("get-operator-password")
     result = await action.wait()
-    return result.results["postgres-password"]
+    return result.results["operator-password"]
 
 
 async def get_primary(ops_test: OpsTest, unit_id=0) -> str:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -18,6 +18,7 @@ from tests.integration.helpers import (
     convert_records_to_dict,
     get_application_units,
     get_cluster_members,
+    get_operator_password,
     get_unit_address,
     scale_application,
 )
@@ -75,7 +76,7 @@ async def test_database_is_up(ops_test: OpsTest, unit_id: int):
 
 @pytest.mark.parametrize("unit_id", UNIT_IDS)
 async def test_settings_are_correct(ops_test: OpsTest, unit_id: int):
-    password = await get_postgres_password(ops_test)
+    password = await get_operator_password(ops_test)
 
     # Connect to PostgreSQL.
     host = await get_unit_address(ops_test, f"{APP_NAME}/{unit_id}")
@@ -163,7 +164,7 @@ async def test_scale_down_and_up(ops_test: OpsTest):
 async def test_persist_data_through_graceful_restart(ops_test: OpsTest):
     """Test data persists through a graceful restart."""
     primary = await get_primary(ops_test)
-    password = await get_postgres_password(ops_test)
+    password = await get_operator_password(ops_test)
     address = await get_unit_address(ops_test, primary)
 
     # Write data to primary IP.
@@ -191,7 +192,7 @@ async def test_persist_data_through_graceful_restart(ops_test: OpsTest):
 async def test_persist_data_through_failure(ops_test: OpsTest):
     """Test data persists through a failure."""
     primary = await get_primary(ops_test)
-    password = await get_postgres_password(ops_test)
+    password = await get_operator_password(ops_test)
     address = await get_unit_address(ops_test, primary)
 
     # Write data to primary IP.
@@ -291,14 +292,6 @@ async def get_primary(ops_test: OpsTest, unit_id=0) -> str:
     return action.results["primary"]
 
 
-async def get_postgres_password(ops_test: OpsTest):
-    """Retrieve the postgres user password using the action."""
-    unit = ops_test.model.units.get(f"{APP_NAME}/0")
-    action = await unit.run_action("get-postgres-password")
-    result = await action.wait()
-    return result.results["postgres-password"]
-
-
 def db_connect(host: str, password: str):
     """Returns psycopg2 connection object linked to postgres db in the given host.
 
@@ -307,7 +300,7 @@ def db_connect(host: str, password: str):
         password: postgres password
 
     Returns:
-        psycopg2 connection object linked to postgres db, under "postgres" user.
+        psycopg2 connection object linked to postgres db, under "operator" user.
     """
     return psycopg2.connect(
         f"dbname='postgres' user='postgres' host='{host}' password='{password}' connect_timeout=10"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -82,7 +82,7 @@ async def test_settings_are_correct(ops_test: OpsTest, unit_id: int):
     host = await get_unit_address(ops_test, f"{APP_NAME}/{unit_id}")
     logger.info("connecting to the database host: %s", host)
     with psycopg2.connect(
-        f"dbname='postgres' user='postgres' host='{host}' password='{password}' connect_timeout=1"
+        f"dbname='postgres' user='operator' host='{host}' password='{password}' connect_timeout=1"
     ) as connection, connection.cursor() as cursor:
         assert connection.status == psycopg2.extensions.STATUS_READY
 
@@ -303,5 +303,5 @@ def db_connect(host: str, password: str):
         psycopg2 connection object linked to postgres db, under "operator" user.
     """
     return psycopg2.connect(
-        f"dbname='postgres' user='postgres' host='{host}' password='{password}' connect_timeout=10"
+        f"dbname='postgres' user='operator' host='{host}' password='{password}' connect_timeout=10"
     )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -52,7 +52,7 @@ class TestCharm(unittest.TestCase):
 
         # Check that a new password was generated on leader election.
         self.harness.set_leader()
-        superuser_password = self.charm._peers.data[self.charm.app].get("postgres-password", None)
+        superuser_password = self.charm._peers.data[self.charm.app].get("operator-password", None)
         self.assertIsNotNone(superuser_password)
 
         replication_password = self.charm._peers.data[self.charm.app].get(
@@ -65,7 +65,7 @@ class TestCharm(unittest.TestCase):
         self.harness.set_leader(False)
         self.harness.set_leader()
         self.assertEqual(
-            self.charm._peers.data[self.charm.app].get("postgres-password", None),
+            self.charm._peers.data[self.charm.app].get("operator-password", None),
             superuser_password,
         )
         self.assertEqual(
@@ -104,13 +104,13 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(container.get_service(self._postgresql_service).is_running(), True)
         _render_patroni_yml_file.assert_called_once()
 
-    @patch("charm.PostgresqlOperatorCharm._get_postgres_password")
-    def test_on_get_postgres_password(self, _get_postgres_password):
+    @patch("charm.PostgresqlOperatorCharm._get_operator_password")
+    def test_on_get_operator_password(self, _get_operator_password):
         mock_event = Mock()
-        _get_postgres_password.return_value = "test-password"
-        self.charm._on_get_postgres_password(mock_event)
-        _get_postgres_password.assert_called_once()
-        mock_event.set_results.assert_called_once_with({"postgres-password": "test-password"})
+        _get_operator_password.return_value = "test-password"
+        self.charm._on_get_operator_password(mock_event)
+        _get_operator_password.assert_called_once()
+        mock_event.set_results.assert_called_once_with({"operator-password": "test-password"})
 
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.Patroni.get_primary")
@@ -278,8 +278,8 @@ class TestCharm(unittest.TestCase):
                         "PATRONI_SCOPE": f"patroni-{self.charm._name}",
                         "PATRONI_REPLICATION_USERNAME": "replication",
                         "PATRONI_REPLICATION_PASSWORD": self.charm._replication_password,
-                        "PATRONI_SUPERUSER_USERNAME": "postgres",
-                        "PATRONI_SUPERUSER_PASSWORD": self.charm._get_postgres_password(),
+                        "PATRONI_SUPERUSER_USERNAME": "operator",
+                        "PATRONI_SUPERUSER_PASSWORD": self.charm._get_operator_password(),
                     },
                 }
             },
@@ -290,13 +290,13 @@ class TestCharm(unittest.TestCase):
     @patch("charm.Patroni.render_postgresql_conf_file")
     @patch("charm.PostgresqlOperatorCharm._patch_pod_labels")
     @patch("charm.PostgresqlOperatorCharm._create_resources")
-    def test_get_postgres_password(self, _, __, ___, ____):
+    def test_get_operator_password(self, _, __, ___, ____):
         # Test for a None password.
         self.harness.add_relation(self._peer_relation, self.charm.app.name)
-        self.assertIsNone(self.charm._get_postgres_password())
+        self.assertIsNone(self.charm._get_operator_password())
 
         # Then test for a non empty password after leader election and peer data set.
         self.harness.set_leader()
-        password = self.charm._get_postgres_password()
+        password = self.charm._get_operator_password()
         self.assertIsNotNone(password)
         self.assertNotEqual(password, "")


### PR DESCRIPTION
# Issue
* Database charms need a database user with a name that is easy to identify. This user shouldnt be used by charms related to the database charm.

# Solution
* Change the default `postgres` superuser to a user called `operator`.

# Context
* Changed the `postgres` superuser to `operator`. Patroni uses that for some operations too.
* Patroni uses another user for replication, so no issues because of changing the superuser. 

# Testing
* Unit and integration tests were updated.
* Manually tested the charm to check that the right user is created inside PostgreSQL.

# Release Notes
* Change charm user to a user called `operator`.