### PR TITLE
Add initial backup and rewind settings

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -10,7 +10,7 @@ get-password:
     username:
       type: string
       description: The username, the default value 'operator'.
-        Possible values - operator, replication.
+        Possible values - operator, backup, replication.
 set-password:
   description: Change the system user's password, which is used by charm.
     It is for internal charm users and SHOULD NOT be used by applications.
@@ -18,7 +18,7 @@ set-password:
     username:
       type: string
       description: The username, the default value 'operator'.
-        Possible values - operator, replication.
+        Possible values - operator, backup, replication.
     password:
       type: string
       description: The password will be auto-generated if this option is not specified.

--- a/actions.yaml
+++ b/actions.yaml
@@ -10,7 +10,7 @@ get-password:
     username:
       type: string
       description: The username, the default value 'operator'.
-        Possible values - operator, backup, replication.
+        Possible values - operator, replication, rewind.
 set-password:
   description: Change the system user's password, which is used by charm.
     It is for internal charm users and SHOULD NOT be used by applications.
@@ -18,7 +18,7 @@ set-password:
     username:
       type: string
       description: The username, the default value 'operator'.
-        Possible values - operator, backup, replication.
+        Possible values - operator, replication rewind.
     password:
       type: string
       description: The password will be auto-generated if this option is not specified.

--- a/src/charm.py
+++ b/src/charm.py
@@ -37,6 +37,7 @@ from requests import ConnectionError
 from tenacity import RetryError
 
 from constants import (
+    BACKUP_PASSWORD_KEY,
     PEER,
     REPLICATION_PASSWORD_KEY,
     REPLICATION_USER,
@@ -332,6 +333,9 @@ class PostgresqlOperatorCharm(CharmBase):
         if self.get_secret("app", REPLICATION_PASSWORD_KEY) is None:
             self.set_secret("app", REPLICATION_PASSWORD_KEY, new_password())
 
+        if self.get_secret("app", BACKUP_PASSWORD_KEY) is None:
+            self.set_secret("app", BACKUP_PASSWORD_KEY, new_password())
+
         # Create resources and add labels needed for replication.
         self._create_resources()
 
@@ -599,6 +603,7 @@ class PostgresqlOperatorCharm(CharmBase):
             self._storage_path,
             self.get_secret("app", USER_PASSWORD_KEY),
             self.get_secret("app", REPLICATION_PASSWORD_KEY),
+            self.get_secret("app", BACKUP_PASSWORD_KEY),
             self.postgresql.is_tls_enabled(check_current_host=True),
         )
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -37,10 +37,10 @@ from requests import ConnectionError
 from tenacity import RetryError
 
 from constants import (
-    BACKUP_PASSWORD_KEY,
     PEER,
     REPLICATION_PASSWORD_KEY,
     REPLICATION_USER,
+    REWIND_PASSWORD_KEY,
     SYSTEM_USERS,
     TLS_CA_FILE,
     TLS_CERT_FILE,
@@ -333,8 +333,8 @@ class PostgresqlOperatorCharm(CharmBase):
         if self.get_secret("app", REPLICATION_PASSWORD_KEY) is None:
             self.set_secret("app", REPLICATION_PASSWORD_KEY, new_password())
 
-        if self.get_secret("app", BACKUP_PASSWORD_KEY) is None:
-            self.set_secret("app", BACKUP_PASSWORD_KEY, new_password())
+        if self.get_secret("app", REWIND_PASSWORD_KEY) is None:
+            self.set_secret("app", REWIND_PASSWORD_KEY, new_password())
 
         # Create resources and add labels needed for replication.
         self._create_resources()
@@ -603,7 +603,7 @@ class PostgresqlOperatorCharm(CharmBase):
             self._storage_path,
             self.get_secret("app", USER_PASSWORD_KEY),
             self.get_secret("app", REPLICATION_PASSWORD_KEY),
-            self.get_secret("app", BACKUP_PASSWORD_KEY),
+            self.get_secret("app", REWIND_PASSWORD_KEY),
             self.postgresql.is_tls_enabled(check_current_host=True),
         )
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -3,12 +3,12 @@
 
 """File containing constants to be used in the charm."""
 
-BACKUP_USER = "backup"
-BACKUP_PASSWORD_KEY = "backup-password"
 DATABASE_PORT = "5432"
 PEER = "database-peers"
 REPLICATION_USER = "replication"
 REPLICATION_PASSWORD_KEY = "replication-password"
+REWIND_USER = "rewind"
+REWIND_PASSWORD_KEY = "rewind-password"
 TLS_KEY_FILE = "key.pem"
 TLS_CA_FILE = "ca.pem"
 TLS_CERT_FILE = "cert.pem"
@@ -17,4 +17,4 @@ USER_PASSWORD_KEY = "operator-password"
 WORKLOAD_OS_GROUP = "postgres"
 WORKLOAD_OS_USER = "postgres"
 # List of system usernames needed for correct work of the charm/workload.
-SYSTEM_USERS = [BACKUP_USER, REPLICATION_USER, USER]
+SYSTEM_USERS = [REPLICATION_USER, REWIND_USER, USER]

--- a/src/constants.py
+++ b/src/constants.py
@@ -3,6 +3,8 @@
 
 """File containing constants to be used in the charm."""
 
+BACKUP_USER = "backup"
+BACKUP_PASSWORD_KEY = "backup-password"
 DATABASE_PORT = "5432"
 PEER = "database-peers"
 REPLICATION_USER = "replication"
@@ -15,4 +17,4 @@ USER_PASSWORD_KEY = "operator-password"
 WORKLOAD_OS_GROUP = "postgres"
 WORKLOAD_OS_USER = "postgres"
 # List of system usernames needed for correct work of the charm/workload.
-SYSTEM_USERS = [REPLICATION_USER, USER]
+SYSTEM_USERS = [BACKUP_USER, REPLICATION_USER, USER]

--- a/src/patroni.py
+++ b/src/patroni.py
@@ -21,7 +21,7 @@ from tenacity import (
     wait_fixed,
 )
 
-from constants import BACKUP_USER, TLS_CA_FILE
+from constants import REWIND_USER, TLS_CA_FILE
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +42,7 @@ class Patroni:
         storage_path: str,
         superuser_password: str,
         replication_password: str,
-        backup_password: str,
+        rewind_password: str,
         tls_enabled: bool,
     ):
         self._endpoint = endpoint
@@ -52,7 +52,7 @@ class Patroni:
         self._planned_units = planned_units
         self._superuser_password = superuser_password
         self._replication_password = replication_password
-        self._backup_password = backup_password
+        self._rewind_password = rewind_password
         self._tls_enabled = tls_enabled
         # Variable mapping to requests library verify parameter.
         # The CA bundle file is used to validate the server certificate when
@@ -168,8 +168,8 @@ class Patroni:
             storage_path=self._storage_path,
             superuser_password=self._superuser_password,
             replication_password=self._replication_password,
-            backup_user=BACKUP_USER,
-            backup_password=self._backup_password,
+            rewind_user=REWIND_USER,
+            rewind_password=self._rewind_password,
         )
         self._render_file(f"{self._storage_path}/patroni.yml", rendered, 0o644)
 

--- a/src/patroni.py
+++ b/src/patroni.py
@@ -160,13 +160,10 @@ class Patroni:
         with open("templates/patroni.yml.j2", "r") as file:
             template = Template(file.read())
         # Render the template file with the correct values.
-        peers_count = self._planned_units - 1
         rendered = template.render(
             enable_tls=enable_tls,
             endpoint=self._endpoint,
             endpoints=self._endpoints,
-            max_wal_senders=peers_count
-            + 3,  # One WAL sender for each replica plus 3 backup WAL senders.
             namespace=self._namespace,
             storage_path=self._storage_path,
             superuser_password=self._superuser_password,

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -2,6 +2,9 @@ bootstrap:
   dcs:
     postgresql:
       use_pg_rewind: true
+      parameters:
+        max_wal_senders: 3
+        wal_level: logical
   initdb:
   - auth-host: md5
   - auth-local: trust

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -58,8 +58,8 @@ postgresql:
     replication:
       password: {{ replication_password }}
     rewind:
-      username: {{ backup_user }}
-      password: {{ backup_password }}
+      username: {{ rewind_user }}
+      password: {{ rewind_password }}
     superuser:
       password: {{ superuser_password }}
 use_endpoints: true

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -7,8 +7,6 @@ bootstrap:
       parameters:
         archive_command: /bin/true
         archive_mode: on
-        max_replication_slots: {{ max_wal_senders }}
-        max_wal_senders: {{ max_wal_senders }}
         wal_level: logical
   initdb:
   - auth-host: md5

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -2,8 +2,12 @@ bootstrap:
   dcs:
     postgresql:
       use_pg_rewind: true
+      remove_data_directory_on_rewind_failure: true
+      remove_data_directory_on_diverged_timelines: true
       parameters:
-        max_wal_senders: 3
+        archive_command: /bin/true
+        archive_mode: on
+        max_wal_senders: {{ max_wal_senders }}
         wal_level: logical
   initdb:
   - auth-host: md5
@@ -54,6 +58,9 @@ postgresql:
   authentication:
     replication:
       password: {{ replication_password }}
+    rewind:
+      username: {{ backup_user }}
+      password: {{ backup_password }}
     superuser:
       password: {{ superuser_password }}
 use_endpoints: true

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -7,6 +7,7 @@ bootstrap:
       parameters:
         archive_command: /bin/true
         archive_mode: on
+        max_replication_slots: {{ max_wal_senders }}
         max_wal_senders: {{ max_wal_senders }}
         wal_level: logical
   initdb:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -533,7 +533,7 @@ async def run_command_on_unit(ops_test: OpsTest, unit_name: str, command: str) -
         the command output if it succeeds, otherwise raises an exception.
     """
     complete_command = f"ssh --container postgresql {unit_name} {command}"
-    return_code, stdout, stderr = await ops_test.juju(*complete_command.split())
+    return_code, stdout, _ = await ops_test.juju(*complete_command.split())
     if return_code != 0:
         raise Exception(
             "Expected command %s to succeed instead it failed: %s", command, return_code

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -188,6 +188,12 @@ async def deploy_and_relate_application_with_postgresql(
 
 
 async def enable_connections_logging(ops_test: OpsTest, unit_name: str) -> None:
+    """Turn on the log of all connections made to a PostgreSQL instance.
+
+    Args:
+        ops_test: The ops test framework instance
+        unit_name: The name of the unit to turn on the connection logs
+    """
     unit_address = await get_unit_address(ops_test, unit_name)
     requests.patch(
         f"https://{unit_address}:8008/config",
@@ -471,7 +477,12 @@ async def check_tls_patroni_api(ops_test: OpsTest, unit_name: str, enabled: bool
     wait=wait_exponential(multiplier=1, min=2, max=30),
 )
 async def primary_changed(ops_test: OpsTest, old_primary: str) -> bool:
-    """Checks whether the primary unit has changed."""
+    """Checks whether the primary unit has changed.
+
+    Args:
+        ops_test: The ops test framework instance
+        old_primary: The name of the unit that was the primary before.
+    """
     other_unit = [
         unit.name
         for unit in ops_test.model.applications[DATABASE_APP_NAME].units
@@ -511,6 +522,16 @@ def resource_exists(client: Client, resource: GenericNamespacedResource) -> bool
 
 
 async def run_command_on_unit(ops_test: OpsTest, unit_name: str, command: str) -> str:
+    """Run a command on a specific unit.
+
+    Args:
+        ops_test: The ops test framework instance
+        unit_name: The name of the unit to run the command on
+        command: The command to run
+
+    Returns:
+        the command output if it succeeds, otherwise raises an exception.
+    """
     complete_command = f"ssh --container postgresql {unit_name} {command}"
     return_code, stdout, stderr = await ops_test.juju(*complete_command.split())
     if return_code != 0:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -108,8 +108,6 @@ async def test_settings_are_correct(ops_test: OpsTest, unit_id: int):
             "cluster_name",
             "data_checksums",
             "listen_addresses",
-            "max_replication_slots",
-            "max_wal_senders",
             "wal_level",
         ]
         cursor.execute(
@@ -128,12 +126,6 @@ async def test_settings_are_correct(ops_test: OpsTest, unit_id: int):
     assert settings["data_directory"] == f"{STORAGE_PATH}/pgdata"
     assert settings["data_checksums"] == "on"
     assert settings["listen_addresses"] == "0.0.0.0"
-    assert settings["max_replication_slots"] == str(
-        len(UNIT_IDS) + 2
-    )  # Number of units - 1 (primary) + 3 (backup WAL senders).
-    assert settings["max_wal_senders"] == str(
-        len(UNIT_IDS) + 2
-    )  # Number of units - 1 (primary) + 3 (backup WAL senders).
     assert settings["wal_level"] == "logical"
 
     # Retrieve settings from Patroni REST API.

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -108,6 +108,7 @@ async def test_settings_are_correct(ops_test: OpsTest, unit_id: int):
             "cluster_name",
             "data_checksums",
             "listen_addresses",
+            "max_replication_slots",
             "max_wal_senders",
             "wal_level",
         ]
@@ -127,6 +128,9 @@ async def test_settings_are_correct(ops_test: OpsTest, unit_id: int):
     assert settings["data_directory"] == f"{STORAGE_PATH}/pgdata"
     assert settings["data_checksums"] == "on"
     assert settings["listen_addresses"] == "0.0.0.0"
+    assert settings["max_replication_slots"] == str(
+        len(UNIT_IDS) + 2
+    )  # Number of units - 1 (primary) + 3 (backup WAL senders).
     assert settings["max_wal_senders"] == str(
         len(UNIT_IDS) + 2
     )  # Number of units - 1 (primary) + 3 (backup WAL senders).

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -11,7 +11,6 @@ from lightkube import AsyncClient
 from lightkube.resources.core_v1 import Pod
 from psycopg2 import sql
 from pytest_operator.plugin import OpsTest
-from tenacity import retry, retry_if_result, stop_after_attempt, wait_exponential
 
 from tests.helpers import METADATA, STORAGE_PATH
 from tests.integration.helpers import (
@@ -321,17 +320,6 @@ async def test_redeploy_charm_same_model(ops_test: OpsTest):
         await ops_test.model.wait_for_idle(
             apps=[APP_NAME], status="active", timeout=1000, wait_for_exact_units=3
         )
-
-
-@retry(
-    retry=retry_if_result(lambda x: not x),
-    stop=stop_after_attempt(10),
-    wait=wait_exponential(multiplier=1, min=2, max=30),
-)
-async def primary_changed(ops_test: OpsTest, old_primary: str) -> bool:
-    """Checks whether or not the primary unit has changed."""
-    primary = await get_primary(ops_test)
-    return primary != old_primary
 
 
 async def get_primary(ops_test: OpsTest, unit_id=0) -> str:

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -21,7 +21,7 @@ from tests.integration.helpers import (
 MATTERMOST_APP_NAME = "mattermost"
 TLS_CERTIFICATES_APP_NAME = "tls-certificates-operator"
 APPLICATION_UNITS = 2
-DATABASE_UNITS = 2
+DATABASE_UNITS = 3
 
 
 @pytest.mark.abort_on_fail
@@ -102,7 +102,7 @@ async def test_mattermost_db(ops_test: OpsTest) -> None:
         assert (
             "connection authorized: user=rewind database=postgres"
             " SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384, bits=256)" in logs
-        ), "TLS was not being used on pg_rewind connections"
+        ), "TLS is not being used on pg_rewind connections"
 
         # Deploy and check Mattermost user and database existence.
         relation_id = await deploy_and_relate_application_with_postgresql(

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -78,6 +78,9 @@ async def test_mattermost_db(ops_test: OpsTest) -> None:
             for unit in ops_test.model.applications[DATABASE_APP_NAME].units
             if unit.name != primary
         ][0]
+
+        # Enable additional logs on the PostgreSQL instance to check TLS
+        # being used in a later step.
         await enable_connections_logging(ops_test, primary)
 
         # Promote the replica to primary.

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -12,12 +12,16 @@ from tests.integration.helpers import (
     check_tls,
     check_tls_patroni_api,
     deploy_and_relate_application_with_postgresql,
+    enable_connections_logging,
+    get_primary,
+    primary_changed,
+    run_command_on_unit,
 )
 
 MATTERMOST_APP_NAME = "mattermost"
 TLS_CERTIFICATES_APP_NAME = "tls-certificates-operator"
 APPLICATION_UNITS = 2
-DATABASE_UNITS = 3
+DATABASE_UNITS = 2
 
 
 @pytest.mark.abort_on_fail
@@ -64,6 +68,38 @@ async def test_mattermost_db(ops_test: OpsTest) -> None:
         for unit in ops_test.model.applications[DATABASE_APP_NAME].units:
             assert await check_tls(ops_test, unit.name, enabled=True)
             assert await check_tls_patroni_api(ops_test, unit.name, enabled=True)
+
+        # Test TLS being used by pg_rewind. To accomplish that, get the primary unit
+        # and a replica that will be promoted to primary (this should trigger a rewind
+        # operation when the old primary is started again).
+        primary = await get_primary(ops_test)
+        replica = [
+            unit.name
+            for unit in ops_test.model.applications[DATABASE_APP_NAME].units
+            if unit.name != primary
+        ][0]
+        await enable_connections_logging(ops_test, primary)
+
+        # Promote the replica to primary.
+        await run_command_on_unit(
+            ops_test,
+            replica,
+            'su postgres -c "/usr/lib/postgresql/14/bin/pg_ctl -D /var/lib/postgresql/data/pgdata promote"',
+        )
+
+        # Stop the initial primary.
+        await run_command_on_unit(ops_test, primary, "/charm/bin/pebble stop postgresql")
+
+        # Check that the primary changed.
+        assert await primary_changed(ops_test, primary), "primary not changed"
+
+        # Restart the initial primary and check the logs to ensure TLS is being used by pg_rewind.
+        await run_command_on_unit(ops_test, primary, "/charm/bin/pebble start postgresql")
+        logs = await run_command_on_unit(ops_test, replica, "/charm/bin/pebble logs")
+        assert (
+            "connection authorized: user=rewind database=postgres"
+            " SSL enabled (protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384, bits=256)" in logs
+        ), "TLS was not being used on pg_rewind connections"
 
         # Deploy and check Mattermost user and database existence.
         relation_id = await deploy_and_relate_application_with_postgresql(

--- a/tests/unit/test_patroni.py
+++ b/tests/unit/test_patroni.py
@@ -84,7 +84,6 @@ class TestPatroni(unittest.TestCase):
         expected_content = template.render(
             endpoint=self.patroni._endpoint,
             endpoints=self.patroni._endpoints,
-            max_wal_senders=3,
             namespace=self.patroni._namespace,
             storage_path=self.patroni._storage_path,
             superuser_password=self.patroni._superuser_password,
@@ -117,7 +116,6 @@ class TestPatroni(unittest.TestCase):
             enable_tls=True,
             endpoint=self.patroni._endpoint,
             endpoints=self.patroni._endpoints,
-            max_wal_senders=3,
             namespace=self.patroni._namespace,
             storage_path=self.patroni._storage_path,
             superuser_password=self.patroni._superuser_password,

--- a/tests/unit/test_patroni.py
+++ b/tests/unit/test_patroni.py
@@ -7,7 +7,7 @@ from unittest.mock import mock_open, patch
 
 from jinja2 import Template
 
-from constants import BACKUP_USER
+from constants import REWIND_USER
 from patroni import Patroni
 from tests.helpers import STORAGE_PATH
 
@@ -23,7 +23,7 @@ class TestPatroni(unittest.TestCase):
             STORAGE_PATH,
             "superuser-password",
             "replication-password",
-            "backup-password",
+            "rewind-password",
             False,
         )
 
@@ -88,8 +88,8 @@ class TestPatroni(unittest.TestCase):
             storage_path=self.patroni._storage_path,
             superuser_password=self.patroni._superuser_password,
             replication_password=self.patroni._replication_password,
-            backup_user=BACKUP_USER,
-            backup_password=self.patroni._backup_password,
+            rewind_user=REWIND_USER,
+            rewind_password=self.patroni._rewind_password,
         )
 
         # Setup a mock for the `open` method, set returned data to postgresql.conf template.
@@ -120,8 +120,8 @@ class TestPatroni(unittest.TestCase):
             storage_path=self.patroni._storage_path,
             superuser_password=self.patroni._superuser_password,
             replication_password=self.patroni._replication_password,
-            backup_user=BACKUP_USER,
-            backup_password=self.patroni._backup_password,
+            rewind_user=REWIND_USER,
+            rewind_password=self.patroni._rewind_password,
         )
         self.assertNotEqual(expected_content_with_tls, expected_content)
 
@@ -184,7 +184,7 @@ class TestPatroni(unittest.TestCase):
             STORAGE_PATH,
             "superuser-password",
             "replication-password",
-            "backup-password",
+            "rewind-password",
             False,
         )
         expected_content = template.render(

--- a/tests/unit/test_patroni.py
+++ b/tests/unit/test_patroni.py
@@ -7,6 +7,7 @@ from unittest.mock import mock_open, patch
 
 from jinja2 import Template
 
+from constants import BACKUP_USER
 from patroni import Patroni
 from tests.helpers import STORAGE_PATH
 
@@ -16,12 +17,13 @@ class TestPatroni(unittest.TestCase):
         # Setup Patroni wrapper.
         self.patroni = Patroni(
             "postgresql-k8s-0",
-            "postgresql-k8s-0",
+            ["postgresql-k8s-0"],
             "test-model",
             1,
             STORAGE_PATH,
             "superuser-password",
             "replication-password",
+            "backup-password",
             False,
         )
 
@@ -82,10 +84,13 @@ class TestPatroni(unittest.TestCase):
         expected_content = template.render(
             endpoint=self.patroni._endpoint,
             endpoints=self.patroni._endpoints,
+            max_wal_senders=3,
             namespace=self.patroni._namespace,
             storage_path=self.patroni._storage_path,
             superuser_password=self.patroni._superuser_password,
             replication_password=self.patroni._replication_password,
+            backup_user=BACKUP_USER,
+            backup_password=self.patroni._backup_password,
         )
 
         # Setup a mock for the `open` method, set returned data to postgresql.conf template.
@@ -112,10 +117,13 @@ class TestPatroni(unittest.TestCase):
             enable_tls=True,
             endpoint=self.patroni._endpoint,
             endpoints=self.patroni._endpoints,
+            max_wal_senders=3,
             namespace=self.patroni._namespace,
             storage_path=self.patroni._storage_path,
             superuser_password=self.patroni._superuser_password,
             replication_password=self.patroni._replication_password,
+            backup_user=BACKUP_USER,
+            backup_password=self.patroni._backup_password,
         )
         self.assertNotEqual(expected_content_with_tls, expected_content)
 
@@ -172,12 +180,13 @@ class TestPatroni(unittest.TestCase):
         # Also test with multiple planned units (synchronous_commit is turned on).
         self.patroni = Patroni(
             "postgresql-k8s-0",
-            "postgresql-k8s-0",
+            ["postgresql-k8s-0"],
             "test-model",
             3,
             STORAGE_PATH,
             "superuser-password",
             "replication-password",
+            "backup-password",
             False,
         )
         expected_content = template.render(


### PR DESCRIPTION
# Issue
* Jira issue: [DPE-700](https://warthogs.atlassian.net/browse/DPE-700)
* PostgreSQL needs some initial settings for backups and rewind operations (synchronisation of the data between a primary and the replicas after a replica is promoted to primary).
* We also need to ensure that a rewind operations (the ones using the [pg_rewind](https://www.postgresql.org/docs/current/app-pgrewind.html) tool) are done using connections encrypted by TLS.

# Solution
* Add the following settings for backup operations:

  * achieve_mode=on

  * archive_command=/bin/true

  * wal_level = logical

* Add the following settings for rewind operations:

  * remove_data_directory_on_rewind_failure = true

  * remove_data_directory_on_diverged_timelines = true

Add a user for pg_rewind and test that it uses TLS when connecting to other PostgreSQL instance.

# Context
* pg_rewind had a new user created only for it, and that user was added in the list of users that can have the password rotated.

* You can `FOCUS` more on the following files when reviewing the code:

  * `templates/patroni.yml.j2`: contains the new backup and rewind settings.

  * `tests/integration/helpers.py`: container new helper methods used to ensure that pg_rewind is using TLS in its connections.

  * `tests/integration/test_charm.py`: the integration test was updated to ensure that the new settings are the current settings in the database.

  * `tests/integration/test_tls.py`: adds an additional check that ensures pg_rewind is using TLS in its connections.

* Other files are related to the new pg_rewind user.

# Testing
* Existing unit tests on `tests/unit/test_patroni.py` were updated to match the new settings.
* The extra backup and rewind settings are now added to the integration test that checks the current instance configuration.
* An additional check was added to ensure that `pg_rewind` is using TLS.

# Release Notes
* Add initial settings for backup and rewind operations.
* Add user for pg_rewind.
* Add test to ensure pg_rewind is using TLS.