### PR TITLE
Add check for primary endpoint ready

### DIFF
--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -19,6 +19,7 @@ The `postgresql` module provides methods for interacting with the PostgreSQL ins
 Any charm using this library should import the `psycopg2` or `psycopg2-binary` dependency.
 """
 import logging
+from typing import Set
 
 import psycopg2
 from psycopg2 import sql
@@ -31,7 +32,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 
 logger = logging.getLogger(__name__)
@@ -51,6 +52,10 @@ class PostgreSQLDeleteUserError(Exception):
 
 class PostgreSQLGetPostgreSQLVersionError(Exception):
     """Exception raised when retrieving PostgreSQL version fails."""
+
+
+class PostgreSQLListUsersError(Exception):
+    """Exception raised when retrieving PostgreSQL users list fails."""
 
 
 class PostgreSQLUpdateUserPasswordError(Exception):
@@ -132,13 +137,18 @@ class PostgreSQL:
         try:
             with self._connect_to_database() as connection, connection.cursor() as cursor:
                 cursor.execute(f"SELECT TRUE FROM pg_roles WHERE rolname='{user}';")
-                user_definition = f"{user} WITH LOGIN{' SUPERUSER' if admin else ''} ENCRYPTED PASSWORD '{password}'"
+                user_definition = (
+                    f"WITH LOGIN{' SUPERUSER' if admin else ''} ENCRYPTED PASSWORD '{password}'"
+                )
                 if extra_user_roles:
                     user_definition += f' {extra_user_roles.replace(",", " ")}'
                 if cursor.fetchone() is not None:
-                    cursor.execute(f"ALTER ROLE {user_definition};")
+                    statement = "ALTER ROLE {}"
                 else:
-                    cursor.execute(f"CREATE ROLE {user_definition};")
+                    statement = "CREATE ROLE {}"
+                cursor.execute(
+                    sql.SQL(f"{statement} {user_definition};").format(sql.Identifier(user))
+                )
         except psycopg2.Error as e:
             logger.error(f"Failed to create user: {e}")
             raise PostgreSQLCreateUserError()
@@ -161,12 +171,16 @@ class PostgreSQL:
                 with self._connect_to_database(
                     database
                 ) as connection, connection.cursor() as cursor:
-                    cursor.execute(f"REASSIGN OWNED BY {user} TO postgres;")
-                    cursor.execute(f"DROP OWNED BY {user};")
+                    cursor.execute(
+                        sql.SQL("REASSIGN OWNED BY {} TO {};").format(
+                            sql.Identifier(user), sql.Identifier(self.user)
+                        )
+                    )
+                    cursor.execute(sql.SQL("DROP OWNED BY {};").format(sql.Identifier(user)))
 
             # Delete the user.
             with self._connect_to_database() as connection, connection.cursor() as cursor:
-                cursor.execute(f"DROP ROLE {user};")
+                cursor.execute(sql.SQL("DROP ROLE {};").format(sql.Identifier(user)))
         except psycopg2.Error as e:
             logger.error(f"Failed to delete user: {e}")
             raise PostgreSQLDeleteUserError()
@@ -202,10 +216,24 @@ class PostgreSQL:
             ) as connection, connection.cursor() as cursor:
                 cursor.execute("SHOW ssl;")
                 return "on" in cursor.fetchone()[0]
-        except psycopg2.Error as e:
+        except psycopg2.Error:
             # Connection errors happen when PostgreSQL has not started yet.
-            logger.debug(e.pgerror)
             return False
+
+    def list_users(self) -> Set[str]:
+        """Returns the list of PostgreSQL database users.
+
+        Returns:
+            List of PostgreSQL database users.
+        """
+        try:
+            with self._connect_to_database() as connection, connection.cursor() as cursor:
+                cursor.execute("SELECT usename FROM pg_catalog.pg_user;")
+                usernames = cursor.fetchall()
+                return {username[0] for username in usernames}
+        except psycopg2.Error as e:
+            logger.error(f"Failed to list PostgreSQL database users: {e}")
+            raise PostgreSQLListUsersError()
 
     def update_user_password(self, username: str, password: str) -> None:
         """Update a user password.

--- a/src/charm.py
+++ b/src/charm.py
@@ -137,7 +137,7 @@ class PostgresqlOperatorCharm(CharmBase):
     def postgresql(self) -> PostgreSQL:
         """Returns an instance of the object used to interact with the database."""
         return PostgreSQL(
-            primary_host=self.primary_endpoint,
+            primary_host=self._primary_endpoint,
             current_host=self.endpoint,
             user=USER,
             password=self.get_secret("app", f"{USER}-password"),
@@ -150,7 +150,7 @@ class PostgresqlOperatorCharm(CharmBase):
         return f'{self._unit.replace("/", "-")}.{self._build_service_name("endpoints")}'
 
     @property
-    def primary_endpoint(self) -> str:
+    def _primary_endpoint(self) -> str:
         """Returns the endpoint of the primary instance's service."""
         return self._build_service_name("primary")
 
@@ -616,7 +616,7 @@ class PostgresqlOperatorCharm(CharmBase):
         return Patroni(
             self._endpoint,
             self._endpoints,
-            self.primary_endpoint,
+            self._primary_endpoint,
             self._namespace,
             self._storage_path,
             self.get_secret("app", USER_PASSWORD_KEY),

--- a/src/charm.py
+++ b/src/charm.py
@@ -137,7 +137,7 @@ class PostgresqlOperatorCharm(CharmBase):
     def postgresql(self) -> PostgreSQL:
         """Returns an instance of the object used to interact with the database."""
         return PostgreSQL(
-            primary_host=self._primary_endpoint,
+            primary_host=self.primary_endpoint,
             current_host=self.endpoint,
             user=USER,
             password=self.get_secret("app", f"{USER}-password"),
@@ -150,7 +150,7 @@ class PostgresqlOperatorCharm(CharmBase):
         return f'{self._unit.replace("/", "-")}.{self._build_service_name("endpoints")}'
 
     @property
-    def _primary_endpoint(self) -> str:
+    def primary_endpoint(self) -> str:
         """Returns the endpoint of the primary instance's service."""
         return self._build_service_name("primary")
 
@@ -616,7 +616,7 @@ class PostgresqlOperatorCharm(CharmBase):
         return Patroni(
             self._endpoint,
             self._endpoints,
-            self._primary_endpoint,
+            self.primary_endpoint,
             self._namespace,
             self._storage_path,
             self.get_secret("app", USER_PASSWORD_KEY),

--- a/src/patroni.py
+++ b/src/patroni.py
@@ -30,6 +30,10 @@ class NotReadyError(Exception):
     """Raised when not all cluster members healthy or finished initial sync."""
 
 
+class EndpointNotReadyError(Exception):
+    """Raised when an endpoint is not ready."""
+
+
 class Patroni:
     """This class handles the communication with Patroni API and configuration files."""
 
@@ -124,10 +128,12 @@ class Patroni:
                         f"{'https' if self._tls_enabled else 'http'}://{self._primary_endpoint}:8008/health",
                         verify=self._verify,
                     )
+                    if r.json()["state"] != "running":
+                        raise EndpointNotReadyError
         except RetryError:
             return False
 
-        return r.json()["state"] == "running"
+        return True
 
     @property
     def member_started(self) -> bool:

--- a/src/patroni.py
+++ b/src/patroni.py
@@ -37,8 +37,8 @@ class Patroni:
         self,
         endpoint: str,
         endpoints: List[str],
+        primary_endpoint: str,
         namespace: str,
-        planned_units,
         storage_path: str,
         superuser_password: str,
         replication_password: str,
@@ -46,9 +46,10 @@ class Patroni:
     ):
         self._endpoint = endpoint
         self._endpoints = endpoints
+        self._primary_endpoint = primary_endpoint
         self._namespace = namespace
         self._storage_path = storage_path
-        self._planned_units = planned_units
+        self._members_count = len(self._endpoints)
         self._superuser_password = superuser_password
         self._replication_password = replication_password
         self._tls_enabled = tls_enabled
@@ -108,6 +109,25 @@ class Patroni:
             return False
 
         return all(member["state"] == "running" for member in r.json()["members"])
+
+    @property
+    def primary_endpoint_ready(self) -> bool:
+        """Is the primary endpoint redirecting connections to the primary pod.
+
+        Returns:
+            Return whether the primary endpoint is redirecting connections to the primary pod.
+        """
+        try:
+            for attempt in Retrying(stop=stop_after_delay(10), wait=wait_fixed(3)):
+                with attempt:
+                    r = requests.get(
+                        f"{'https' if self._tls_enabled else 'http'}://{self._primary_endpoint}:8008/health",
+                        verify=self._verify,
+                    )
+        except RetryError:
+            return False
+
+        return r.json()["state"] == "running"
 
     @property
     def member_started(self) -> bool:
@@ -178,7 +198,7 @@ class Patroni:
         # TODO: add extra configurations here later.
         rendered = template.render(
             logging_collector="on",
-            synchronous_commit="on" if self._planned_units > 1 else "off",
+            synchronous_commit="on" if self._members_count > 1 else "off",
             synchronous_standby_names="*",
         )
         self._render_file(f"{self._storage_path}/postgresql-k8s-operator.conf", rendered, 0o644)

--- a/src/resources.yaml
+++ b/src/resources.yaml
@@ -6,8 +6,12 @@ metadata:
   name: {{ app_name }}-primary
 spec:
   ports:
-    - port: 5432
+    - name: database
+      port: 5432
       targetPort: 5432
+    - name: api
+      port: 8008
+      targetPort: 8008
   selector:
     cluster-name: patroni-{{ app_name }}
     role: master

--- a/tests/integration/new_relations/test_new_relations.py
+++ b/tests/integration/new_relations/test_new_relations.py
@@ -32,8 +32,10 @@ ALIASED_MULTIPLE_DATABASE_CLUSTERS_RELATION_NAME = "aliased-multiple-database-cl
 
 @pytest.mark.abort_on_fail
 @pytest.mark.database_relation_tests
-async def test_deploy_charms(ops_test: OpsTest, application_charm, database_charm):
-    """Deploy both charms (application and database) to use in the tests."""
+async def test_database_relation_with_charm_libraries(
+    ops_test: OpsTest, application_charm, database_charm
+):
+    """Test basic functionality of database relation interface."""
     # Deploy both charms (multiple units for each application to test that later they correctly
     # set data in the relation application databag using only the leader unit).
     async with ops_test.fast_forward():
@@ -66,17 +68,11 @@ async def test_deploy_charms(ops_test: OpsTest, application_charm, database_char
                 trust=True,
             ),
         )
-        await ops_test.model.wait_for_idle(apps=APP_NAMES, status="active", wait_for_units=1)
-
-
-@pytest.mark.database_relation_tests
-async def test_database_relation_with_charm_libraries(ops_test: OpsTest):
-    """Test basic functionality of database relation interface."""
-    # Relate the charms and wait for them exchanging some connection data.
-    await ops_test.model.add_relation(
-        f"{APPLICATION_APP_NAME}:{FIRST_DATABASE_RELATION_NAME}", DATABASE_APP_NAME
-    )
-    await ops_test.model.wait_for_idle(apps=APP_NAMES, status="active")
+        # Relate the charms and wait for them exchanging some connection data.
+        await ops_test.model.add_relation(
+            f"{APPLICATION_APP_NAME}:{FIRST_DATABASE_RELATION_NAME}", DATABASE_APP_NAME
+        )
+        await ops_test.model.wait_for_idle(apps=APP_NAMES, status="active", raise_on_blocked=True)
 
     # Get the connection string to connect to the database using the read/write endpoint.
     connection_string = await build_connection_string(

--- a/tests/unit/test_patroni.py
+++ b/tests/unit/test_patroni.py
@@ -16,9 +16,9 @@ class TestPatroni(unittest.TestCase):
         # Setup Patroni wrapper.
         self.patroni = Patroni(
             "postgresql-k8s-0",
-            "postgresql-k8s-0",
+            ["postgresql-k8s-0"],
+            "postgresql-k8s-primary.dev.svc.cluster.local",
             "test-model",
-            1,
             STORAGE_PATH,
             "superuser-password",
             "replication-password",
@@ -173,8 +173,8 @@ class TestPatroni(unittest.TestCase):
         self.patroni = Patroni(
             "postgresql-k8s-0",
             "postgresql-k8s-0",
+            "postgresql-k8s-primary.dev.svc.cluster.local",
             "test-model",
-            3,
             STORAGE_PATH,
             "superuser-password",
             "replication-password",

--- a/tests/unit/test_patroni.py
+++ b/tests/unit/test_patroni.py
@@ -207,10 +207,11 @@ class TestPatroni(unittest.TestCase):
 
         # Mock the request return values.
         _get.side_effect = None
-        _get.return_value.json.side_effect = [{"state": "stopped"}, {"state": "running"}]
+        _get.return_value.json.return_value = {"state": "stopped"}
 
         # Test with the primary endpoint not ready yet.
         self.assertFalse(self.patroni.primary_endpoint_ready)
 
         # Test with the primary endpoint ready.
+        _get.return_value.json.return_value = {"state": "running"}
         self.assertTrue(self.patroni.primary_endpoint_ready)


### PR DESCRIPTION
# Issue
* When relating the PostgreSQL k8s charm with other charm before the PostgreSQL charm is fully initialised (in an Active state), we can face some errors related to database connection problems. This can be checked by testing the relation between this charm and the PgBouncer k8s charm.
* Those problems happen due the PostgreSQL charm primary k8s endpoint/service is not yet correctly pointing to the primary pod (it takes some time to work).
* Jira issue: [DPE-701](https://warthogs.atlassian.net/browse/DPE-701)

# Solution
* Avoid setting the `cluster_initialised` flag (that is checked in multiple charm events) before the primary endpoint/service is fully ready by checking its accessibility.

# Context

* Files to `FOCUS` when reviewing this PR:

  * `src/charm.py`: has the call to the check, an update to the upgrade charm event handler to avoid problems withe the primary endpoint being deleted when the pod is killed and also an update to the update status event holder to avoid logging error messages when the PostgreSQL/Patroni pebble service is not ready yet.

  * `src/patroni.py`: has the implementation of the primary endpoint/service readiness check. 

  * `src/resources.yaml` has an additional port that is used to contact the primary endpoint during the initial check on charm.py pebble ready event.

  * `tests/integration/new_relations/test_new_relations.py` has an update to merge two tests in one (in a way that makes the PostgreSQL charm to be related faster to the application charm; this avoids any kind of regression on this new implementation).

* Extra details about the other files:

  * `tests/unit/test_charm.py` and `tests/unit/test_patroni.py` were updated just to match the new implementations.

# Testing
* Unit tests were updated.
* Integration tests for the relation were changed to (the same will work for legacy relations, but the charms that are used on those tests work differently, so they don't trigger the specific issue that is being solved through this PR).
* The changes from this PR were manually tested by deploying this charm, the PgBouncer k8s charm and immediately relating them (which triggers the problem before these changes).

# Release Notes
* Add check for started/ready primary endpoint/service.