### PR TITLE
DPE-781 Run integration tests for passed lint/unit tests only

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,9 @@ jobs:
 
   integration-test-microk8s-charm:
     name: Integration tests for charm deployment (microk8s)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -42,6 +45,9 @@ jobs:
 
   integration-test-microk8s-database-relation:
     name: Integration tests for database relation (microk8s)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -57,6 +63,9 @@ jobs:
 
   integration-test-microk8s-db-relation:
     name: Integration tests for db relation (microk8s)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -72,6 +81,9 @@ jobs:
 
   integration-test-microk8s-db-admin-relation:
     name: Integration tests for db-admin relation (microk8s)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -87,6 +99,9 @@ jobs:
 
   integration-test-microk8s-password-rotation:
     name: Integration tests for password rotation (microk8s)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -102,6 +117,9 @@ jobs:
 
   integration-test-microk8s-tls:
     name: Integration tests for TLS (microk8s)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,6 +44,10 @@ jobs:
 
   integration-test-charm:
     name: Integration tests for charm deployment
+    needs:
+      - lib-check
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -59,6 +63,10 @@ jobs:
 
   integration-test-database-relation:
     name: Integration tests for database relation
+    needs:
+      - lib-check
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -74,6 +82,10 @@ jobs:
 
   integration-test-db-relation:
     name: Integration tests for db relation
+    needs:
+      - lib-check
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -89,6 +101,10 @@ jobs:
 
   integration-test-db-admin-relation:
     name: Integration tests for db-admin relation
+    needs:
+      - lib-check
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -104,6 +120,10 @@ jobs:
 
   integration-test-password-rotation:
     name: Integration tests for password rotation
+    needs:
+      - lib-check
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -119,6 +139,10 @@ jobs:
 
   integration-test-tls:
     name: Integration tests for TLS
+    needs:
+      - lib-check
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Avoid a long-running integration test in case of failing gatekeeping tests. It will slightly increase the complete tests scope runtime but will save (a lot?) of electricity/money for Canonical as often new pull requests have some initial typos/issues to be polished.