### PR TITLE
Reverted password encryption to md5

### DIFF
--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -7,6 +7,7 @@ bootstrap:
       parameters:
         archive_command: /bin/true
         archive_mode: on
+        password_encryption: md5
         wal_level: logical
   initdb:
   - auth-host: md5


### PR DESCRIPTION
## Proposal
Revert postgres password encryption from SCRAM (the new default in version 14) to the old version 12 default (md5). 

## Context
- Updating postgres to version 14 has caused the default password encryption to change to SCRAM. While this is a good thing, it breaks the md5 password hashing that pgbouncer uses. We can't yet move to SCRAM in pgbouncer, at least until TLS exists, so for now we can downgrade postgres to md5, and we'll reinstate SCRAM when we're ready.

## Testing
- This PR is currently running tests, but we're technically _reverting_ functionality so everything should run correctly. 