### PR TITLE
Updated tls _on_certificate_available event handler to defer on pebble ConnectionError

### DIFF
--- a/lib/charms/postgresql_k8s/v0/postgresql_tls.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql_tls.py
@@ -34,7 +34,7 @@ from cryptography import x509
 from cryptography.x509.extensions import ExtensionType
 from ops.charm import ActionEvent
 from ops.framework import Object
-from ops.pebble import PathError, ProtocolError
+from ops.pebble import ConnectionError, PathError, ProtocolError
 
 # The unique Charmhub library identifier, never change it
 LIBID = "c27af44a92df4ef38d7ae06418b2800f"
@@ -133,7 +133,7 @@ class PostgreSQLTLS(Object):
 
         try:
             self.charm.push_tls_files_to_workload()
-        except (PathError, ProtocolError) as e:
+        except (ConnectionError, PathError, ProtocolError) as e:
             logger.error("Cannot push TLS certificates: %r", e)
             event.defer()
             return

--- a/lib/charms/postgresql_k8s/v0/postgresql_tls.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql_tls.py
@@ -135,7 +135,6 @@ class PostgreSQLTLS(Object):
             self.charm.push_tls_files_to_workload()
         except (ConnectionError, PathError, ProtocolError) as e:
             logger.error("Cannot push TLS certificates: %r", e)
-            logger.error(event.defer)
             event.defer()
             return
 

--- a/lib/charms/postgresql_k8s/v0/postgresql_tls.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql_tls.py
@@ -135,6 +135,7 @@ class PostgreSQLTLS(Object):
             self.charm.push_tls_files_to_workload()
         except (ConnectionError, PathError, ProtocolError) as e:
             logger.error("Cannot push TLS certificates: %r", e)
+            logger.error(event.defer)
             event.defer()
             return
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -706,7 +706,10 @@ class PostgresqlOperatorCharm(CharmBase):
         return self.model.get_relation(PEER)
 
     def push_tls_files_to_workload(self, container: Container = None) -> None:
-        """Uploads TLS files to the workload container."""
+        """Uploads TLS files to the workload container.
+
+        TODO if the container doesn't exist, adding this relation will break.
+        """
         if container is None:
             container = self.unit.get_container("postgresql")
 

--- a/tests/unit/test_postgresql_tls.py
+++ b/tests/unit/test_postgresql_tls.py
@@ -5,8 +5,8 @@ import socket
 import unittest
 from unittest.mock import MagicMock, patch
 
-from ops.testing import Harness
 from ops.pebble import ConnectionError
+from ops.testing import Harness
 
 from charm import PostgresqlOperatorCharm
 from constants import PEER


### PR DESCRIPTION
## Proposal
When the postgres bundle is deployed, the TLS relation is created before pebble is ready, so the deployment fails. Therefore, this container handles the ConnectionError thrown when we try to connect to the workload container. 