### PR TITLE
Fix SANs list

### DIFF
--- a/lib/charms/postgresql_k8s/v0/postgresql_tls.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql_tls.py
@@ -174,7 +174,7 @@ class PostgreSQLTLS(Object):
             try:
                 ipaddress.ip_address(address)
                 return True
-            except ValueError:
+            except (ipaddress.AddressValueError, ValueError):
                 return False
 
         unit_id = self.charm.unit.name.split("/")[1]

--- a/lib/charms/postgresql_k8s/v0/postgresql_tls.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql_tls.py
@@ -62,7 +62,7 @@ class PostgreSQLTLS(Object):
         super().__init__(charm, "client-relations")
         self.charm = charm
         self.peer_relation = peer_relation
-        self.additional_dns_names = [] if additional_dns_names is None else additional_dns_names
+        self.additional_dns_names = additional_dns_names or []
         self.certs = TLSCertificatesRequiresV1(self.charm, TLS_RELATION)
         self.framework.observe(
             self.charm.on.set_tls_private_key_action, self._on_set_tls_private_key

--- a/lib/charms/tls_certificates_interface/v1/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v1/tls_certificates.py
@@ -222,6 +222,7 @@ import json
 import logging
 import uuid
 from datetime import datetime, timedelta
+from ipaddress import IPv4Address
 from typing import Dict, List, Optional
 
 from cryptography import x509
@@ -657,7 +658,9 @@ def generate_csr(
     email_address: str = None,
     country_name: str = None,
     private_key_password: Optional[bytes] = None,
-    sans: Optional[List[str]] = None,
+    sans_oid: Optional[str] = None,
+    sans_ip: Optional[List[str]] = None,
+    sans_dns: Optional[List[str]] = None,
     additional_critical_extensions: Optional[List] = None,
 ) -> bytes:
     """Generates a CSR using private key and subject.
@@ -672,7 +675,9 @@ def generate_csr(
         email_address (str): Email address.
         country_name (str): Country Name.
         private_key_password (bytes): Private key password
-        sans (list): List of subject alternative names
+        sans_dns (list): List of DNS subject alternative names
+        sans_ip (list): List of IP subject alternative names
+        sans_oid (str): Additional OID
         additional_critical_extensions (list): List if critical additional extension objects.
             Object must be a x509 ExtensionType.
 
@@ -693,10 +698,17 @@ def generate_csr(
     if country_name:
         subject_name.append(x509.NameAttribute(x509.NameOID.COUNTRY_NAME, country_name))
     csr = x509.CertificateSigningRequestBuilder(subject_name=x509.Name(subject_name))
-    if sans:
-        csr = csr.add_extension(
-            x509.SubjectAlternativeName([x509.DNSName(san) for san in sans]), critical=False
-        )
+
+    _sans = []
+    if sans_oid:
+        _sans.append(x509.RegisteredID(x509.ObjectIdentifier(sans_oid)))
+    if sans_ip:
+        _sans.extend([x509.IPAddress(IPv4Address(san)) for san in sans_ip])
+    if sans_dns:
+        _sans.extend([x509.DNSName(san) for san in sans_dns])
+    if _sans:
+        csr = csr.add_extension(x509.SubjectAlternativeName(_sans), critical=False)
+
     if additional_critical_extensions:
         for extension in additional_critical_extensions:
             csr = csr.add_extension(extension, critical=True)

--- a/src/charm.py
+++ b/src/charm.py
@@ -87,7 +87,7 @@ class PostgresqlOperatorCharm(CharmBase):
         self.postgresql_client_relation = PostgreSQLProvider(self)
         self.legacy_db_relation = DbProvides(self, admin=False)
         self.legacy_db_admin_relation = DbProvides(self, admin=True)
-        self.tls = PostgreSQLTLS(self, PEER)
+        self.tls = PostgreSQLTLS(self, PEER, [self.primary_endpoint, self.replicas_endpoint])
         self.restart_manager = RollingOpsManager(
             charm=self, relation="restart", callback=self._restart
         )

--- a/tests/unit/test_postgresql_tls.py
+++ b/tests/unit/test_postgresql_tls.py
@@ -187,12 +187,16 @@ class TestPostgreSQLTLS(unittest.TestCase):
         sans = self.charm.tls._get_sans()
         self.assertEqual(
             sans,
-            [
-                "postgresql-k8s-0",
-                "postgresql-k8s-0.postgresql-k8s-endpoints",
-                socket.getfqdn(),
-                "1.1.1.1",
-            ],
+            {
+                "sans_ip": ["1.1.1.1"],
+                "sans_dns": [
+                    "postgresql-k8s-0",
+                    "postgresql-k8s-0.postgresql-k8s-endpoints",
+                    socket.getfqdn(),
+                    "postgresql-k8s-primary.None.svc.cluster.local",
+                    "postgresql-k8s-replicas.None.svc.cluster.local",
+                ],
+            },
         )
 
     def test_get_tls_extensions(self):

--- a/tox.ini
+++ b/tox.ini
@@ -68,7 +68,7 @@ commands =
 [testenv:charm-integration]
 description = Run charm integration tests
 deps =
-    juju
+    juju==2.9.11 # juju 3.0 has issues with retrieving action results and deploying charms
     pytest
     pytest-operator
     psycopg2-binary
@@ -79,7 +79,7 @@ commands =
 [testenv:database-relation-integration]
 description = Run database relation integration tests
 deps =
-    juju
+    juju==2.9.11 # juju 3.0 has issues with retrieving action results and deploying charms
     pytest
     pytest-operator
     psycopg2-binary
@@ -90,7 +90,7 @@ commands =
 [testenv:db-relation-integration]
 description = Run db relation integration tests
 deps =
-    juju
+    juju==2.9.11 # juju 3.0 has issues with retrieving action results and deploying charms
     pytest
     pytest-operator
     psycopg2-binary
@@ -101,7 +101,7 @@ commands =
 [testenv:db-admin-relation-integration]
 description = Run db-admin relation integration tests
 deps =
-    juju
+    juju==2.9.11 # juju 3.0 has issues with retrieving action results and deploying charms
     pytest
     pytest-operator
     psycopg2-binary
@@ -112,7 +112,7 @@ commands =
 [testenv:password-rotation-integration]
 description = Run password rotation integration tests
 deps =
-    juju
+    juju==2.9.11 # juju 3.0 has issues with retrieving action results and deploying charms
     pytest
     pytest-operator
     psycopg2-binary
@@ -123,7 +123,7 @@ commands =
 [testenv:tls-integration]
 description = Run TLS integration tests
 deps =
-    juju
+    juju==2.9.11 # juju 3.0 has issues with retrieving action results and deploying charms
     pytest
     pytest-operator
     psycopg2-binary
@@ -134,7 +134,7 @@ commands =
 [testenv:integration]
 description = Run all integration tests
 deps =
-    juju
+    juju==2.9.11 # juju 3.0 has issues with retrieving action results and deploying charms
     pytest
     pytest-operator
     psycopg2-binary


### PR DESCRIPTION
# Issue
* Jira issue: [DPE-844](https://warthogs.atlassian.net/browse/DPE-844)
* The k8s services that are created by the charm to redirect traffic to the primary and the replicas were not part of the certificate signing request sent to the TLS certificates operator.
* With that, in the first test run on a fresh microk8s installation the charm got stuck trying to call the Patroni REST API without success, as the hostname doesn’t match with the ones from the certificate. This was not happening in other test runs, but could happen in other situations. to the charm sending a certificate signing request (CSR) with it's IP address as a DNS name instead of an IP address.

# Solution
* Update the code to add those services in the certificate signing request.

# Context
* You can `FOCUS` on the following files when reviewing:

  * `lib/charms/postgresql_k8s/v0/postgresql_tls.py`: it contains the fix for the IP address issue in the VM charm and also a way to provide additional DNS names for the certificate signing request. 

  * `src/charm.py`: it sends the k8s service names to the PostgreSQL TLS library.

* Other files and what has changed on them:
  * `lib/charms/tls_certificates_interface/v1/tls_certificates.py`: this is a patched version of the library that is used to solve the IP address issue. It was copied from https://github.com/canonical/opensearch-operator/blob/main/lib/charms/tls_certificates_interface/v1/tls_certificates.py (that patch will be pushed to the right repo in some weeks). Thanks @Mehdi-Bendriss!

  * `tox.ini`: the version of the Juju Python library was pinned due to `ImportError: No supported version for facade: ModelConfigFacade` errors when deploying the charm.

* In a future PR those k8s services probably should be replaced by the pods endpoints.

# Testing
* It's very complicated to add a test to prevent this issue again in this repo because it happens (at least is what we could check) only with charm coming from Charmhub (we imagine that it's because they take some time to be downloaded to the model, so the events from it and the TLS certificates operator take a different order in the first deployment, but in the second and in the later deployment the charm is already there, so the order is different).
* The test that will check the issue is fixed is the one from https://github.com/canonical/postgresql-k8s-bundle/blob/6444a12423eacf45447debe82e2ab9c1f443c98a/tests/integration/bundle/test_tls_bundle.py (it fails every time on Giithub because every CI run uses a fresh microk8s installation).
* This fix was manually tested by publishing it in a different channel of Charmhub and using it to run the above test.

# Release Notes
* Add the k8s services as DNS names on the certificate signing request.
* Update the PostgreSQL k8s library to handle this situation and also IP address issues in the VM charm.