### PR TITLE
DPE-994 Improve GH->Jira sync

### DIFF
--- a/.github/workflows/issues_to_jira.yaml
+++ b/.github/workflows/issues_to_jira.yaml
@@ -1,4 +1,4 @@
-# this workflow requires to provide JIRA webhook URL via JIRA_URL GitHub Secret
+# this workflow requires to provide JIRA webhook URL via JIRA_URL and JIRA_COMPONENT GitHub Secret
 # read more: https://support.atlassian.com/cloud-automation/docs/jira-automation-triggers/#Automationtriggers-Incomingwebhook
 # original code source: https://github.com/beliaev-maksim/github-to-jira-automation
 
@@ -25,12 +25,14 @@ jobs:
 
           # send JIRA request
           data=$( jq -n \
-                  --arg title "${{github.event.issue.title }}" \
-                  --arg url "${{ github.event.issue.html_url }}" \
-                  --arg submitter "${{ github.event.issue.user.login }}" \
-                  --arg body "${{ github.event.issue.body }}" \
-                  --arg type "$type" \
-                  --arg action ${{ github.event.action }} \
-                  '{title: $title, url: $url, submitter: $submitter, body: $body, type: $type, action: $action}' )
+                  --arg title '${{ github.event.issue.title }}' \
+                  --arg url '${{ github.event.issue.html_url }}' \
+                  --arg submitter '${{ github.event.issue.user.login }}' \
+                  --arg body '${{ github.event.issue.body }}' \
+                  --arg type "${type}" \
+                  --arg action '${{ github.event.action }}' \
+                  --arg component '${{ secrets.JIRA_COMPONENT }}' \
+                  '{title: $title, url: $url, submitter: $submitter, \
+                    body: $body, type: $type, action: $action, component: $component}' )
 
-          curl -X POST -H 'Content-type: application/json' --data "${data}" "${{ secrets.JIRA_URL }}"
+          curl -X POST -H 'Content-type: application/json' --data "${data}" '${{ secrets.JIRA_URL }}'


### PR DESCRIPTION
* Fixing support for code block ```cat /tmp/xxx```. It was not sent to Jira due to shell/bash execution on GH Action level. Using single quotes to avoid this. GH variables ${{var}} still work.
* Apply the above logic to all GH variables.
* Using common style for shell variable: ${var}.
* Add Jira component support (configured in GH Secrets). It allows to reuse the script for all DPE repositories.