### PR TITLE
DPE-994 Improve GH->Jira sync and introduce templates and labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,62 @@
+name: Bug Report
+description: File a bug report
+labels: ["Type: Bug", "Status: Triage"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for taking the time to fill out this bug report! Before submitting your issue, please make
+        sure you are using the latest version of the charm. If not, please switch to this image prior to
+        posting your report to make sure it's not already solved.
+
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Bug Description
+      description: >
+        If applicable, add screenshots to help explain the problem you are facing.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: To Reproduce
+      description: >
+        Please provide a step-by-step instruction of how to reproduce the behavior.
+      placeholder: |
+        1. `juju deploy ...`
+        2. `juju relate ...`
+        3. `juju status --relations`
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: >
+        We need to know a bit more about the context in which you run the charm.
+        - Are you running Juju locally, on lxd, in multipass or on some other platform?
+        - What track and channel you deployed the charm from (ie. `latest/edge` or similar).
+        - Version of any applicable components, like the juju snap, the model controller, lxd, microk8s, and/or multipass.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: >
+        Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+        Fetch the logs using `juju debug-log --replay` and `kubectl logs ...`. Additional details available in the juju docs
+        at https://juju.is/docs/olm/juju-logs
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+

--- a/.github/ISSUE_TEMPLATE/enhancement_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement_proposal.yml
@@ -1,0 +1,29 @@
+name: Enhancement Proposal
+description: File an enhancement proposal
+labels: ["Type: Enhancement", "Status: Triage"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for taking the time to fill out this enhancement proposal! Before submitting your issue, please make
+        sure there isn't already a prior issue concerning this. If there is, please join that discussion instead.
+
+  - type: textarea
+    id: enhancement-proposal
+    attributes:
+      label: Enhancement Proposal
+      description: >
+        Describe the enhancement you would like to see in as much detail as needed.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: interested-in-implementing
+    attributes:
+      label: Is this a feature you are interested in implementing yourself?
+      options:
+        - 'Yes'
+        - 'Maybe'
+        - 'No'
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+# Issue
+<!-- What issue is this PR trying to solve? -->
+
+
+# Solution
+<!-- A summary of the solution addressing the above issue -->
+
+
+# Context
+<!-- What is some specialized knowledge relevant to this project/technology -->
+
+
+# Testing
+<!-- What steps need to be taken to test this PR? -->
+
+
+# Release Notes
+<!-- A digestable summary of the change in this PR -->

--- a/.github/workflows/issues_to_jira.yaml
+++ b/.github/workflows/issues_to_jira.yaml
@@ -15,22 +15,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create JIRA ticket
+        env:
+           # put into env vars to properly escape special bash chars
+           ISSUE_TITLE: ${{ github.event.issue.title }}
+           ISSUE_DESCRIPTION: ${{ github.event.issue.body }}
         run: |
           # Determine Bug/Enhancement
           if ${{ contains(github.event.*.labels.*.name, 'Bug') }}; then
-            type=bug
+            ISSUE_TYPE=bug
           else
-            type=story
+            ISSUE_TYPE=story
           fi
 
           # send JIRA request
+
+          # Canonical doesn't encourage discussions in JIRA on public project issues.
+          # Thus, it is NOT recommended to put description in JIRA in order to push conversation to GitHub
+          # if strongly required, then replace '--arg body ""' with the next line
+          # --arg body "$ISSUE_DESCRIPTION"
+
           data=$( jq -n \
-                  --arg title "${{github.event.issue.title }}" \
-                  --arg url "${{ github.event.issue.html_url }}" \
-                  --arg submitter "${{ github.event.issue.user.login }}" \
-                  --arg body "${{ github.event.issue.body }}" \
-                  --arg type "$type" \
-                  --arg action ${{ github.event.action }} \
+                  --arg title "$ISSUE_TITLE" \
+                  --arg url '${{ github.event.issue.html_url }}' \
+                  --arg submitter '${{ github.event.issue.user.login }}' \
+                  --arg body "" \
+                  --arg type "$ISSUE_TYPE" \
+                  --arg action '${{ github.event.action }}' \
                   '{title: $title, url: $url, submitter: $submitter, body: $body, type: $type, action: $action}' )
 
           curl -X POST -H 'Content-type: application/json' --data "${data}" "${{ secrets.JIRA_URL }}"


### PR DESCRIPTION
GH labels are necessary to create Jira bugreports and stories properly. The templates helps to create common style bugreports and pull requests.