### PR TITLE
DPE-1024 DPE-995 Increase log verbosity and fix reestablishing relations

### DIFF
--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -32,7 +32,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 
 logger = logging.getLogger(__name__)

--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -119,6 +119,31 @@ class PostgreSQL:
                     sql.Identifier(database), sql.Identifier(user)
                 )
             )
+            with self._connect_to_database(database=database) as conn:
+                with conn.cursor() as curs:
+                    statements = []
+                    curs.execute(
+                        "SELECT schema_name FROM information_schema.schemata WHERE schema_name NOT LIKE 'pg_%' and schema_name <> 'information_schema';"
+                    )
+                    for row in curs:
+                        schema = sql.Identifier(row[0])
+                        statements.append(
+                            sql.SQL(
+                                "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA {} TO {};"
+                            ).format(schema, sql.Identifier(user))
+                        )
+                        statements.append(
+                            sql.SQL(
+                                "GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA {} TO {};"
+                            ).format(schema, sql.Identifier(user))
+                        )
+                        statements.append(
+                            sql.SQL(
+                                "GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA {} TO {};"
+                            ).format(schema, sql.Identifier(user))
+                        )
+                    for statement in statements:
+                        curs.execute(statement)
         except psycopg2.Error as e:
             logger.error(f"Failed to create database: {e}")
             raise PostgreSQLCreateDatabaseError()

--- a/src/charm.py
+++ b/src/charm.py
@@ -379,7 +379,7 @@ class PostgresqlOperatorCharm(CharmBase):
         # on fixing that.
         if not self.unit.is_leader() and "cluster_initialised" not in self._peers.data[self.app]:
             logger.debug(
-                "Deferring on_postgresql_pebble_ready: Not leader or cluster not initialized"
+                "Deferring on_postgresql_pebble_ready: Not leader and cluster not initialized"
             )
             event.defer()
             return

--- a/src/relations/db.py
+++ b/src/relations/db.py
@@ -76,6 +76,9 @@ class DbProvides(Object):
             "cluster_initialised" not in self.charm._peers.data[self.charm.app]
             or not self.charm._patroni.member_started
         ):
+            logger.debug(
+                "Deferring on_relation_changed: Cluster not initialized or patroni not running"
+            )
             event.defer()
             return
 
@@ -100,7 +103,7 @@ class DbProvides(Object):
         # and it doesn't have a database name in it.
         database = event.relation.data[event.app].get("database")
         if not database:
-            logger.warning("No database name provided")
+            logger.warning("Deferring on_relation_changed: No database name provided")
             event.defer()
             return
 
@@ -176,6 +179,9 @@ class DbProvides(Object):
             "cluster_initialised" not in self.charm._peers.data[self.charm.app]
             or not self.charm._patroni.member_started
         ):
+            logger.debug(
+                "Deferring on_relation_departed: Cluster not initialized or patroni not running"
+            )
             event.defer()
             return
 
@@ -204,6 +210,9 @@ class DbProvides(Object):
             "cluster_initialised" not in self.charm._peers.data[self.charm.app]
             or not self.charm._patroni.member_started
         ):
+            logger.debug(
+                "Deferring on_relation_broken: Cluster not initialized or patroni not running"
+            )
             event.defer()
             return
 

--- a/src/relations/postgresql_provider.py
+++ b/src/relations/postgresql_provider.py
@@ -66,6 +66,9 @@ class PostgreSQLProvider(Object):
             "cluster_initialised" not in self.charm._peers.data[self.charm.app]
             or not self.charm._patroni.member_started
         ):
+            logger.debug(
+                "Deferring on_database_requested: Cluster must be initialized before database can be requested"
+            )
             event.defer()
             return
 
@@ -116,6 +119,9 @@ class PostgreSQLProvider(Object):
             "cluster_initialised" not in self.charm._peers.data[self.charm.app]
             or not self.charm._patroni.member_started
         ):
+            logger.debug(
+                "Deferring on_relation_broken: Cluster must be initialized before user can be deleted"
+            )
             event.defer()
             return
 

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -50,7 +50,7 @@ async def test_mattermost_db(ops_test: OpsTest) -> None:
         )
         # Deploy TLS Certificates operator.
         config = {"generate-self-signed-certificates": "true", "ca-common-name": "Test CA"}
-        await ops_test.model.deploy(TLS_CERTIFICATES_APP_NAME, channel="edge", config=config)
+        await ops_test.model.deploy(TLS_CERTIFICATES_APP_NAME, channel="beta", config=config)
         # Relate it to the PostgreSQL to enable TLS.
         await ops_test.model.relate(DATABASE_APP_NAME, TLS_CERTIFICATES_APP_NAME)
         await ops_test.model.wait_for_idle(status="active", timeout=1000)


### PR DESCRIPTION
# Issue
* [DPE-1024](https://warthogs.atlassian.net/browse/DPE-1024)
* Low log verbosity when deferring events within the charm
* [DPE-995](https://warthogs.atlassian.net/browse/DPE-995)
* #64
* Re-relating an application with the charm breaks due to insufficient privileges on dangling DB objects

# Solution
* Add debug log messages on event deferrals
* Add more grants when reestablishing relations

# Context
* Added log messages within the charm, didn't touch or check library code deferrals
* Grants are happening in the postgresql_k8s library, it will need to be republished
* Grants should be given for tables, sequences and functions on all schemas for the new user


# Testing
*  Reestablish relation new database relations integration test

# Release Notes
*  Fixes insufficient privileges grant when reestablishing a relation
