### PR TITLE
Add Jira 'component' to GH->Jira sync

### DIFF
--- a/.github/workflows/issues_to_jira.yaml
+++ b/.github/workflows/issues_to_jira.yaml
@@ -1,4 +1,4 @@
-# this workflow requires to provide JIRA webhook URL via JIRA_URL GitHub Secret
+# this workflow requires to provide JIRA webhook URL via JIRA_URL and JIRA_COMPONENT GitHub Secret
 # read more: https://support.atlassian.com/cloud-automation/docs/jira-automation-triggers/#Automationtriggers-Incomingwebhook
 # original code source: https://github.com/beliaev-maksim/github-to-jira-automation
 
@@ -41,6 +41,7 @@ jobs:
                   --arg body "" \
                   --arg type "$ISSUE_TYPE" \
                   --arg action '${{ github.event.action }}' \
-                  '{title: $title, url: $url, submitter: $submitter, body: $body, type: $type, action: $action}' )
+                  --arg component '${{ secrets.JIRA_COMPONENT }}' \
+                  '{title: $title, url: $url, submitter: $submitter, body: $body, type: $type, action: $action, component: $component}' )
 
           curl -X POST -H 'Content-type: application/json' --data "${data}" "${{ secrets.JIRA_URL }}"


### PR DESCRIPTION
# Issue
The newly created issue on GH should have Jira's "component" correctly and automatically set.
The component value is coming from GH Secrets.

# Testing
Can be tested on GH after merging only. Suppose to be the last part in the puzzle. 

# Release Notes
No need to mention in release notes.