### PR TITLE
Bump charming-actions to the latest 2.1.1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check libs
-        uses: canonical/charming-actions/check-libraries@1.0.3
+        uses: canonical/charming-actions/check-libraries@2.1.1
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}" # FIXME: current token will expire in 2023-07-04
           github-token: "${{ secrets.GITHUB_TOKEN }}"
@@ -35,10 +35,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@2.0.0-rc
+        uses: canonical/charming-actions/channel@2.1.1
         id: channel
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.0.0-rc
+        uses: canonical/charming-actions/upload-charm@2.1.1
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
# Issue

GitHub Actions are not happy using the old version:

> Run canonical/charming-actions/upload-charm@2.0.0-rc
> /usr/bin/sudo snap install charmcraft --classic --channel latest/stable
> charmcraft 2.1.0 from Canonical** installed
> /usr/bin/sudo charmcraft pack --destructive-mode --quiet
> No suitable 'build-on' environment found in any 'bases' configuration.
> Full execution log: '/root/snap/charmcraft/common/cache/charmcraft/log/charmcraft-20221213-165944.902276.log'
> Error: The process '/usr/bin/sudo' failed with exit code 1
> Error: Error: The process '/usr/bin/sudo' failed with exit code 1

While we are here, bump 'check-libraries' to the latest version too.

# Solution

Bump charming-actions to the latest release 2.1.1

# Testing
Tested for other our repos already. It looks OK.

# Release Notes
Bump GH Action 'charming-actions' to the latest 2.1.1