### PR TITLE
Pin OS on release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
     needs:
       - lib-check
       - ci-tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
# Issue
As the `ubuntu-latest` GH runner image (it's still being updated on other places) was updated to jammy, the step that publishes the charm broke (due to using `--destructive-mode`).

We can see the issue on https://github.com/canonical/postgresql-k8s-operator/actions/runs/3685747468/jobs/6238552232.


# Solution
Pin focal runner image (`ubuntu-20.04`) on release workflow.


# Context
The bases on `charmcraft.yaml` weren't updated to jammy as there are some issues related to `psycopg2` (the library that is used by the charm to connect to the database) and jammy.


# Testing
Tested `sudo charmcraft pack --destructive-mode --quiet` manually on a focal VM.


# Release Notes
Pin focal runner image on release workflow.
