### PR TITLE
DPE 1034 Preventing extensions enabled through relations

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -499,6 +499,11 @@ class PostgresqlOperatorCharm(CharmBase):
                 self.unit.status = BlockedStatus(f"failed to create services {e}")
                 return
 
+    @property
+    def _has_blocked_status(self) -> bool:
+        """Returns whether the unit is in a blocked state."""
+        return isinstance(self.unit.status, BlockedStatus)
+
     def _on_get_password(self, event: ActionEvent) -> None:
         """Returns the password for a user as an action response.
 
@@ -617,11 +622,17 @@ class PostgresqlOperatorCharm(CharmBase):
         """Display an active status message if the current unit is the primary."""
         container = self.unit.get_container("postgresql")
         if not container.can_connect():
+            logger.debug("on_update_status early exit: Cannot connect to container")
+            return
+
+        if self._has_blocked_status:
+            logger.debug("on_update_status early exit: Unit is in Blocked status")
             return
 
         services = container.pebble.get_services(names=[self._postgresql_service])
         if len(services) == 0:
             # Service has not been added nor started yet, so don't try to check Patroni API.
+            logger.debug("on_update_status early exit: Service has not been added nor started yet")
             return
 
         try:

--- a/src/relations/db.py
+++ b/src/relations/db.py
@@ -91,7 +91,9 @@ class DbProvides(Object):
         application_relation_databag = event.relation.data[self.charm.app]
 
         # Do not allow apps requesting extensions to be installed.
-        if "extensions" in unit_relation_databag or "extensions" in application_relation_databag:
+        if "extensions" in event.relation.data[
+            event.app
+        ] or "extensions" in event.relation.data.get(event.unit, {}):
             logger.error(
                 "ERROR - `extensions` cannot be requested through relations"
                 " - they should be installed through a database charm config in the future"
@@ -101,7 +103,9 @@ class DbProvides(Object):
 
         # Sometimes a relation changed event is triggered,
         # and it doesn't have a database name in it.
-        database = event.relation.data[event.app].get("database")
+        database = event.relation.data[event.app].get(
+            "database", event.relation.data.get(event.unit, {}).get("database")
+        )
         if not database:
             logger.warning("Deferring on_relation_changed: No database name provided")
             event.defer()

--- a/tests/integration/test_db.py
+++ b/tests/integration/test_db.py
@@ -111,7 +111,7 @@ async def test_finos_waltz_db(ops_test: OpsTest) -> None:
 
 @pytest.mark.db_relation_tests
 async def test_indico_db_blocked(ops_test: OpsTest) -> None:
-    """Tests if deploying and relating to Indico charm will block due to requested relations."""
+    """Tests if deploying and relating to Indico charm will block due to requested extensions."""
     async with ops_test.fast_forward():
         # Build and deploy the PostgreSQL charm.
         await build_and_deploy(ops_test, 1)

--- a/tests/integration/test_db.py
+++ b/tests/integration/test_db.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
+from asyncio import gather
+
 import pytest as pytest
 from pytest_operator.plugin import OpsTest
 
@@ -17,6 +19,33 @@ ANOTHER_FINOS_WALTZ_APP_NAME = "another-finos-waltz"
 APPLICATION_UNITS = 1
 DATABASE_UNITS = 3
 
+charm = None
+
+
+async def build_and_deploy(ops_test: OpsTest, num_units: int) -> None:
+    """Builds the charm and deploys a specified number of units."""
+    global charm
+    if not charm:
+        charm = await ops_test.build_charm(".")
+    resources = {
+        "postgresql-image": METADATA["resources"]["postgresql-image"]["upstream-source"],
+    }
+    await ops_test.model.deploy(
+        charm,
+        resources=resources,
+        application_name=DATABASE_APP_NAME,
+        trust=True,
+        num_units=num_units,
+    ),
+    # Wait until the PostgreSQL charm is successfully deployed.
+    await ops_test.model.wait_for_idle(
+        apps=[DATABASE_APP_NAME],
+        status="active",
+        raise_on_blocked=True,
+        timeout=1000,
+        wait_for_exact_units=num_units,
+    )
+
 
 @pytest.mark.db_relation_tests
 async def test_finos_waltz_db(ops_test: OpsTest) -> None:
@@ -27,25 +56,8 @@ async def test_finos_waltz_db(ops_test: OpsTest) -> None:
     """
     async with ops_test.fast_forward():
         # Build and deploy the PostgreSQL charm.
-        charm = await ops_test.build_charm(".")
-        resources = {
-            "postgresql-image": METADATA["resources"]["postgresql-image"]["upstream-source"],
-        }
-        await ops_test.model.deploy(
-            charm,
-            resources=resources,
-            application_name=DATABASE_APP_NAME,
-            trust=True,
-            num_units=DATABASE_UNITS,
-        ),
-        # Wait until the PostgreSQL charm is successfully deployed.
-        await ops_test.model.wait_for_idle(
-            apps=[DATABASE_APP_NAME],
-            status="active",
-            raise_on_blocked=True,
-            timeout=1000,
-            wait_for_exact_units=DATABASE_UNITS,
-        )
+        await build_and_deploy(ops_test, DATABASE_UNITS)
+
         assert len(ops_test.model.applications[DATABASE_APP_NAME].units) == DATABASE_UNITS
 
         for unit in ops_test.model.applications[DATABASE_APP_NAME].units:
@@ -95,3 +107,46 @@ async def test_finos_waltz_db(ops_test: OpsTest) -> None:
 
         # Remove the PostgreSQL application.
         await ops_test.model.remove_application(DATABASE_APP_NAME, block_until_done=True)
+
+
+@pytest.mark.db_relation_tests
+async def test_indico_db_blocked(ops_test: OpsTest) -> None:
+    """Tests if deploying and relating to Indico charm will block due to requested relations."""
+    async with ops_test.fast_forward():
+        # Build and deploy the PostgreSQL charm.
+        await build_and_deploy(ops_test, 1)
+
+        await ops_test.model.deploy(
+            "indico",
+            channel="stable",
+            application_name="indico",
+            num_units=APPLICATION_UNITS,
+        )
+
+        # Wait for model to stabilise
+        await ops_test.model.wait_for_idle(
+            apps=["indico"],
+            status="waiting",
+            raise_on_blocked=False,
+            timeout=1000,
+        )
+
+        await ops_test.model.relate(f"{DATABASE_APP_NAME}:db", "indico:db")
+
+        await ops_test.model.wait_for_idle(
+            apps=[DATABASE_APP_NAME],
+            status="blocked",
+            raise_on_blocked=False,
+            timeout=1000,
+        )
+
+        assert (
+            ops_test.model.applications[DATABASE_APP_NAME].units[0].workload_status_message
+            == "extensions requested through relation"
+        )
+
+        # Cleanup
+        await gather(
+            ops_test.model.remove_application(DATABASE_APP_NAME, block_until_done=True),
+            ops_test.model.remove_application("indico", block_until_done=True),
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -58,6 +58,7 @@ description = Run unit tests
 deps =
     psycopg2-binary
     pytest
+    pytest-asyncio
     coverage[toml]
     -r{toxinidir}/requirements.txt
 commands =


### PR DESCRIPTION
# Issue
* [DPE-1034](https://warthogs.atlassian.net/browse/DPE-1034)
* Relating with Indico using the legacy db interface hangs

# Solution
* Changed where the charm was looking for if extensions were enabled


# Context
* The Postgresql charm should block in case relation extensions are enabled, but it was looking for them in the relation databags, not in the event data
* The Indico charm was likely waiting for requested extensions to be enabled, so it kept on waiting for the database relation even after the Postgresql charm believed to be done
* Added pytest-asyncio to suppress unit test asyncio_mode warning


# Testing

# Release Notes
Fixes bug in preventing relation extensions


[DPE-1034]: https://warthogs.atlassian.net/browse/DPE-1034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ