### PR TITLE
Fix delete user call when user was not created before

### DIFF
--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -32,7 +32,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 logger = logging.getLogger(__name__)
@@ -184,6 +184,11 @@ class PostgreSQL:
         Args:
             user: user to be deleted.
         """
+        # First of all, check whether the user exists. Otherwise, do nothing.
+        users = self.list_users()
+        if user not in users:
+            return
+
         # List all databases.
         try:
             with self._connect_to_database() as connection, connection.cursor() as cursor:

--- a/tests/integration/new_relations/application-charm/metadata.yaml
+++ b/tests/integration/new_relations/application-charm/metadata.yaml
@@ -17,3 +17,5 @@ requires:
   aliased-multiple-database-clusters:
     interface: postgresql_client
     limit: 2
+  no-database:
+    interface: postgresql_client

--- a/tests/integration/new_relations/application-charm/src/charm.py
+++ b/tests/integration/new_relations/application-charm/src/charm.py
@@ -103,6 +103,9 @@ class ApplicationCharm(CharmBase):
             self._on_cluster2_endpoints_changed,
         )
 
+        # Relation used to test the situation where no database name is provided.
+        self.no_database = DatabaseRequires(self, "no-database", database_name="")
+
     def _on_start(self, _) -> None:
         """Only sets an Active status."""
         self.unit.status = ActiveStatus()

--- a/tests/integration/new_relations/test_new_relations.py
+++ b/tests/integration/new_relations/test_new_relations.py
@@ -28,6 +28,7 @@ FIRST_DATABASE_RELATION_NAME = "first-database"
 SECOND_DATABASE_RELATION_NAME = "second-database"
 MULTIPLE_DATABASE_CLUSTERS_RELATION_NAME = "multiple-database-clusters"
 ALIASED_MULTIPLE_DATABASE_CLUSTERS_RELATION_NAME = "aliased-multiple-database-clusters"
+NO_DATABASE_RELATION_NAME = "no-database"
 
 
 @pytest.mark.abort_on_fail
@@ -358,3 +359,20 @@ async def test_restablish_relation(ops_test: OpsTest):
         cursor.execute("SELECT data FROM test;")
         data = cursor.fetchone()
         assert data[0] == "other data"
+
+
+@pytest.mark.database_relation_tests
+async def test_relation_with_no_database_name(ops_test: OpsTest):
+    """Test that a relation with no database name doesn't block the charm."""
+    async with ops_test.fast_forward():
+        # Relate the charms using a relation that doesn't provide a database name.
+        await ops_test.model.add_relation(
+            f"{APPLICATION_APP_NAME}:{NO_DATABASE_RELATION_NAME}", DATABASE_APP_NAME
+        )
+        await ops_test.model.wait_for_idle(apps=APP_NAMES, status="active", raise_on_blocked=True)
+
+        # Break the relation.
+        await ops_test.model.applications[DATABASE_APP_NAME].remove_relation(
+            f"{DATABASE_APP_NAME}", f"{APPLICATION_APP_NAME}:{NO_DATABASE_RELATION_NAME}"
+        )
+        await ops_test.model.wait_for_idle(apps=APP_NAMES, status="active", raise_on_blocked=True)


### PR DESCRIPTION
# Issue
Jira issue: [DPE-991](https://warthogs.atlassian.net/browse/DPE-991)

When a charm relates to the database interface without providing a database name and later the relation is removed the PostgreSQL charm tries to delete the database user that was not created (because the database user is only created if the relation is complete: the other application needs to provide a database name for that).


# Solution
Check whether the database user exists before the charm tries to delete it.


# Context
The solution was implemented in the charm library, so it can be imported on the VM charm (the charm that was tested and initially faced the issue) on https://github.com/canonical/postgresql-operator/pull/51.

As the issue also happens on this charm, it's worth to have the fix on the charm library.


# Testing
A test simulating a relation without providing a database name was implemented.

For that, the tester application got a new relation (because it was easy to implemented on that and the data integrator - the charm used in the test that lead to the bug report - is not available yet on Charmhub).


# Release Notes
Check if a database user exists before trying to delete it.


[DPE-991]: https://warthogs.atlassian.net/browse/DPE-991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ