### PR TITLE
Remove duplicate helper function

### DIFF
--- a/tests/integration/test_db.py
+++ b/tests/integration/test_db.py
@@ -19,33 +19,6 @@ ANOTHER_FINOS_WALTZ_APP_NAME = "another-finos-waltz"
 APPLICATION_UNITS = 1
 DATABASE_UNITS = 3
 
-charm = None
-
-
-async def build_and_deploy(ops_test: OpsTest, num_units: int) -> None:
-    """Builds the charm and deploys a specified number of units."""
-    global charm
-    if not charm:
-        charm = await ops_test.build_charm(".")
-    resources = {
-        "postgresql-image": METADATA["resources"]["postgresql-image"]["upstream-source"],
-    }
-    await ops_test.model.deploy(
-        charm,
-        resources=resources,
-        application_name=DATABASE_APP_NAME,
-        trust=True,
-        num_units=num_units,
-    ),
-    # Wait until the PostgreSQL charm is successfully deployed.
-    await ops_test.model.wait_for_idle(
-        apps=[DATABASE_APP_NAME],
-        status="active",
-        raise_on_blocked=True,
-        timeout=1000,
-        wait_for_exact_units=num_units,
-    )
-
 
 @pytest.mark.db_relation_tests
 async def test_finos_waltz_db(ops_test: OpsTest) -> None:


### PR DESCRIPTION
# Issue
Because I didn't merge main into [this PR](https://github.com/canonical/postgresql-k8s-operator/pull/74), some duplicated code was added when merging into main, [making the lint job fail](https://github.com/canonical/postgresql-k8s-operator/actions/runs/3904228221/jobs/6669720049#step:4:10).


# Solution
Remove the duplicate code.


# Release Notes
Remove duplicate code.
