### PR TITLE
DPE-1085: Clear up block status due to extensions and integration test

### DIFF
--- a/src/relations/db.py
+++ b/src/relations/db.py
@@ -105,7 +105,7 @@ class DbProvides(Object):
 
         # Sometimes a relation changed event is triggered,
         # and it doesn't have a database name in it.
-        database = event.relation.data[event.app].get(
+        database = event.relation.data.get(event.app, {}).get(
             "database", event.relation.data.get(event.unit, {}).get("database")
         )
         if not database:


### PR DESCRIPTION
# Issue
* [DPE-1085](https://warthogs.atlassian.net/browse/DPE-1085)
* When the charm blocks due to a legacy relation requesting an extension nothing clears up the blocked status

# Solution
* Add check at the end of  `_on_relation_departed()` to see if there are relations requesting extensions and setting the status to active if none

# Context

# Testing
* Extended the indico integration test to check if the blocked status is cleared up

# Release Notes
* Clear up blocked status when no relations requesting extensions are left

[DPE-1085]: https://warthogs.atlassian.net/browse/DPE-1085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ