### PR TITLE
Move clearing of extensions Blocked status to on_relation broken

### DIFF
--- a/src/relations/db.py
+++ b/src/relations/db.py
@@ -224,17 +224,6 @@ class DbProvides(Object):
             {unit for unit in current_allowed_units.split() if unit != departing_unit}
         )
 
-        # Clean up Blocked status if caused by the departed relation
-        if (
-            self.charm._has_blocked_status
-            and self.charm.unit.status.message == EXTENSIONS_BLOCKING_MESSAGE
-        ):
-            if "extensions" in event.relation.data.get(
-                event.app, {}
-            ) or "extensions" in event.relation.data.get(event.unit, {}):
-                if not self._check_for_blocking_relations(event.relation.id):
-                    self.charm.unit.status = ActiveStatus()
-
     def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Remove the user created for this relation."""
         # Check for some conditions before trying to access the PostgreSQL instance.
@@ -259,6 +248,17 @@ class DbProvides(Object):
             self.charm.unit.status = BlockedStatus(
                 f"Failed to delete user during {self.relation_name} relation broken event"
             )
+
+        # Clean up Blocked status if caused by the departed relation
+        if (
+            self.charm._has_blocked_status
+            and self.charm.unit.status.message == EXTENSIONS_BLOCKING_MESSAGE
+        ):
+            if "extensions" in event.relation.data.get(
+                event.app, {}
+            ) or "extensions" in event.relation.data.get(event.unit, {}):
+                if not self._check_for_blocking_relations(event.relation.id):
+                    self.charm.unit.status = ActiveStatus()
 
     def _get_allowed_subnets(self, relation: Relation) -> str:
         """Build the list of allowed subnets as in the legacy charm."""


### PR DESCRIPTION
# Issue
* [DPE-1085](https://warthogs.atlassian.net/browse/DPE-1085)
* `_on_relation_broken` appears to be a more appropriate place for unblocking the charm

# Solution
* Move the check to `on_relation_broken`

# Context
* `_on_relation_departed` would unblock the charm if we scale down the related application requesting extensions even if we have other units of it left

# Testing

# Release Notes

[DPE-1085]: https://warthogs.atlassian.net/browse/DPE-1085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ