### PR TITLE
Updating ops framework and postgresql_tls charm lib

### DIFF
--- a/lib/charms/postgresql_k8s/v0/postgresql_tls.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql_tls.py
@@ -125,7 +125,10 @@ class PostgreSQLTLS(Object):
 
     def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:
         """Enable TLS when TLS certificate available."""
-        if event.certificate_signing_request.strip() != self.charm.get_secret(SCOPE, "csr").strip():
+        if (
+            event.certificate_signing_request.strip()
+            != str(self.charm.get_secret(SCOPE, "csr")).strip()
+        ):
             logger.error("An unknown certificate available.")
             return
 
@@ -144,7 +147,7 @@ class PostgreSQLTLS(Object):
 
     def _on_certificate_expiring(self, event: CertificateExpiringEvent) -> None:
         """Request the new certificate when old certificate is expiring."""
-        if event.certificate.strip() != self.charm.get_secret(SCOPE, "cert").strip():
+        if event.certificate.strip() != str(self.charm.get_secret(SCOPE, "cert")).strip():
             logger.error("An unknown certificate expiring.")
             return
 

--- a/lib/charms/postgresql_k8s/v0/postgresql_tls.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql_tls.py
@@ -45,7 +45,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version.
-LIBPATCH = 4
+LIBPATCH = 5
 
 logger = logging.getLogger(__name__)
 SCOPE = "unit"
@@ -125,8 +125,8 @@ class PostgreSQLTLS(Object):
 
     def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:
         """Enable TLS when TLS certificate available."""
-        if event.certificate_signing_request != self.charm.get_secret(SCOPE, "csr"):
-            logger.error("An unknown certificate expiring.")
+        if event.certificate_signing_request.strip() != self.charm.get_secret(SCOPE, "csr").strip():
+            logger.error("An unknown certificate available.")
             return
 
         self.charm.set_secret(
@@ -144,7 +144,7 @@ class PostgreSQLTLS(Object):
 
     def _on_certificate_expiring(self, event: CertificateExpiringEvent) -> None:
         """Request the new certificate when old certificate is expiring."""
-        if event.certificate != self.charm.get_secret(SCOPE, "cert"):
+        if event.certificate.strip() != self.charm.get_secret(SCOPE, "cert").strip():
             logger.error("An unknown certificate expiring.")
             return
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ jinja2==3.0.3
 jsonschema==4.14.0
 lightkube==0.10.0
 lightkube-models==1.26.0.4
-ops==1.5.0
+ops==1.5.4
 requests==2.27.1
 tenacity==8.0.1

--- a/tests/unit/test_postgresql_tls.py
+++ b/tests/unit/test_postgresql_tls.py
@@ -152,7 +152,7 @@ class TestPostgreSQLTLS(unittest.TestCase):
         _push_tls_files_to_workload.assert_not_called()
 
         # Test providing CSR.
-        self.charm.set_secret(SCOPE, "csr", "test-csr")
+        self.charm.set_secret(SCOPE, "csr", "test-csr\n")
         self.emit_certificate_available_event()
         self.assertEqual(self.charm.get_secret(SCOPE, "ca"), "test-ca")
         self.assertEqual(self.charm.get_secret(SCOPE, "cert"), "test-cert")
@@ -180,7 +180,7 @@ class TestPostgreSQLTLS(unittest.TestCase):
         self.charm.set_secret(
             SCOPE, "key", self.get_content_from_file(filename="tests/unit/key.pem")
         )
-        self.charm.set_secret(SCOPE, "cert", "test-cert")
+        self.charm.set_secret(SCOPE, "cert", "test-cert\n")
         self.charm.set_secret(SCOPE, "csr", "test-csr")
         self.emit_certificate_expiring_event()
         self.assertTrue(self.no_secrets(include_certificate=False))


### PR DESCRIPTION
# Issue
* [DPE-1081](https://warthogs.atlassian.net/browse/DPE-1081)
* VM charm [PR#53](https://github.com/canonical/postgresql-operator/pull/53)
* Moving fixes from the VM charm to K8S charm to publish the updated charm library


# Solution


# Context
* TLS tests broke with the update of ops to 1.5.4, fixes to the library should remedy this


# Testing

# Release Notes
* Updating ops framework to 1.5.4
* Updating postgresql_tls charm lib to 0.5


[DPE-1081]: https://warthogs.atlassian.net/browse/DPE-1081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ