### PR TITLE
Run check-lib as a part of ci.yaml CI/CD

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,9 +31,24 @@ jobs:
       - name: Run tests
         run: tox -e unit
 
+  lib-check:
+    name: Check libraries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Check libs
+        uses: canonical/charming-actions/check-libraries@2.2.0
+        with:
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
   integration-test-microk8s-charm:
     name: Integration tests for charm deployment (microk8s)
     needs:
+      - lib-check
       - lint
       - unit-test
     runs-on: ubuntu-latest
@@ -52,6 +67,7 @@ jobs:
   integration-test-microk8s-database-relation:
     name: Integration tests for database relation (microk8s)
     needs:
+      - lib-check
       - lint
       - unit-test
     runs-on: ubuntu-latest
@@ -70,6 +86,7 @@ jobs:
   integration-test-microk8s-db-relation:
     name: Integration tests for db relation (microk8s)
     needs:
+      - lib-check
       - lint
       - unit-test
     runs-on: ubuntu-latest
@@ -88,6 +105,7 @@ jobs:
   integration-test-microk8s-db-admin-relation:
     name: Integration tests for db-admin relation (microk8s)
     needs:
+      - lib-check
       - lint
       - unit-test
     runs-on: ubuntu-latest
@@ -106,6 +124,7 @@ jobs:
   integration-test-microk8s-ha-self-healing:
     name: Integration tests for high availability self healing (microk8s)
     needs:
+      - lib-check
       - lint
       - unit-test
     runs-on: ubuntu-latest
@@ -124,6 +143,7 @@ jobs:
   integration-test-microk8s-password-rotation:
     name: Integration tests for password rotation (microk8s)
     needs:
+      - lib-check
       - lint
       - unit-test
     runs-on: ubuntu-latest
@@ -142,6 +162,7 @@ jobs:
   integration-test-microk8s-tls:
     name: Integration tests for TLS (microk8s)
     needs:
+      - lib-check
       - lint
       - unit-test
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,27 +6,12 @@ on:
       - main
 
 jobs:
-  lib-check:
-    name: Check libraries
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Check libs
-        uses: canonical/charming-actions/check-libraries@2.1.1
-        with:
-          credentials: "${{ secrets.CHARMHUB_TOKEN }}" # FIXME: current token will expire in 2023-07-04
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
   ci-tests:
     uses: ./.github/workflows/ci.yaml
 
   release-to-charmhub:
     name: Release to CharmHub
     needs:
-      - lib-check
       - ci-tests
     runs-on: ubuntu-20.04
     steps:
@@ -35,10 +20,15 @@ jobs:
         with:
           fetch-depth: 0
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@2.1.1
+        uses: canonical/charming-actions/channel@2.2.0
         id: channel
+      - name: Release any bumped charm libs
+        uses: canonical/charming-actions/release-libraries@2.2.0
+        with:
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.1.1
+        uses: canonical/charming-actions/upload-charm@2.2.0
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
# Issue
We do not have a well visible warning for the outdated libraries in use
and we do not publish them automatically.

We need to be sure our libraries are up-2-date on
the new pull-request and pushed to charmhub on
merging PR and publishing the new charm revision.

# Solution
Use new `charming-action/release-libraries` and run `check-libraries` on PR (ci.yaml).

# Testing
GH Actions.

# Release Notes
Use new `charming-action/release-libraries` and run `check-libraries` on PR (ci.yaml).