### PR TITLE
Pass on secrets for ci.yaml to run

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   ci-tests:
     uses: ./.github/workflows/ci.yaml
+    secrets: inherit
 
   release-to-charmhub:
     name: Release to CharmHub


### PR DESCRIPTION
# Issue
* CI on the main branch fails due to ci.yaml check libs task not getting its credentials for charmhub

# Solution
* Add a directive to inherit secrets, so charmhub token is present for check libs

# Context
* Tested with a forked version of the repo, change appeared to work and the check libs task seemed to have `credentials` set

# Testing

# Release Notes

