### PR TITLE
Upgrade to jammy

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Release to CharmHub
     needs:
       - ci-tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ juju model-config logging-config="<root>=INFO;unit=DEBUG"
 # enable Role-Based Access Control on microk8s
 microk8s enable rbac
 # Deploy the charm
-juju deploy ./postgresql-k8s_ubuntu-20.04-amd64.charm \
+juju deploy ./postgresql-k8s_ubuntu-22.04-amd64.charm \
     --resource postgresql-image=dataplatformoci/postgres-patroni \
     --trust
 ```

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -2,10 +2,10 @@ type: "charm"
 bases:
   - build-on:
     - name: "ubuntu"
-      channel: "20.04"
+      channel: "22.04"
     run-on:
     - name: "ubuntu"
-      channel: "20.04"
+      channel: "22.04"
 parts:
   charm:
     build-packages:

--- a/tests/integration/ha_tests/application-charm/charmcraft.yaml
+++ b/tests/integration/ha_tests/application-charm/charmcraft.yaml
@@ -5,10 +5,10 @@ type: charm
 bases:
   - build-on:
       - name: "ubuntu"
-        channel: "20.04"
+        channel: "22.04"
     run-on:
       - name: "ubuntu"
-        channel: "20.04"
+        channel: "22.04"
 parts:
   charm:
     charm-binary-python-packages: [psycopg2-binary==2.9.3]

--- a/tests/integration/ha_tests/conftest.py
+++ b/tests/integration/ha_tests/conftest.py
@@ -10,6 +10,7 @@ from tests.integration.ha_tests.helpers import (
     get_master_start_timeout,
     stop_continuous_writes,
 )
+from tests.integration.helpers import CHARM_SERIES
 
 APPLICATION_NAME = "application"
 
@@ -21,7 +22,7 @@ async def continuous_writes(ops_test: OpsTest) -> None:
     async with ops_test.fast_forward():
         if await app_name(ops_test, APPLICATION_NAME) is None:
             charm = await ops_test.build_charm("tests/integration/ha_tests/application-charm")
-            await ops_test.model.deploy(charm, application_name=APPLICATION_NAME)
+            await ops_test.model.deploy(charm, application_name=APPLICATION_NAME, series=CHARM_SERIES)
             await ops_test.model.wait_for_idle(status="active", timeout=1000)
 
     # Start the continuous writes process by relating the application to the database or

--- a/tests/integration/ha_tests/conftest.py
+++ b/tests/integration/ha_tests/conftest.py
@@ -22,7 +22,9 @@ async def continuous_writes(ops_test: OpsTest) -> None:
     async with ops_test.fast_forward():
         if await app_name(ops_test, APPLICATION_NAME) is None:
             charm = await ops_test.build_charm("tests/integration/ha_tests/application-charm")
-            await ops_test.model.deploy(charm, application_name=APPLICATION_NAME, series=CHARM_SERIES)
+            await ops_test.model.deploy(
+                charm, application_name=APPLICATION_NAME, series=CHARM_SERIES
+            )
             await ops_test.model.wait_for_idle(status="active", timeout=1000)
 
     # Start the continuous writes process by relating the application to the database or

--- a/tests/integration/ha_tests/test_self_healing.py
+++ b/tests/integration/ha_tests/test_self_healing.py
@@ -18,7 +18,7 @@ from tests.integration.ha_tests.helpers import (
     send_signal_to_process,
     stop_continuous_writes,
 )
-from tests.integration.helpers import get_unit_address, CHARM_SERIES
+from tests.integration.helpers import CHARM_SERIES, get_unit_address
 
 PATRONI_PROCESS = "/usr/local/bin/patroni"
 POSTGRESQL_PROCESS = "postgres"

--- a/tests/integration/ha_tests/test_self_healing.py
+++ b/tests/integration/ha_tests/test_self_healing.py
@@ -7,7 +7,6 @@ from pytest_operator.plugin import OpsTest
 from tenacity import Retrying, stop_after_delay, wait_fixed
 
 from tests.integration.ha_tests.helpers import (
-    METADATA,
     count_writes,
     fetch_cluster_members,
     get_primary,
@@ -17,7 +16,7 @@ from tests.integration.ha_tests.helpers import (
     send_signal_to_process,
     stop_continuous_writes,
 )
-from tests.integration.helpers import CHARM_SERIES, app_name, get_unit_address
+from tests.integration.helpers import app_name, build_and_deploy, get_unit_address
 
 PATRONI_PROCESS = "/usr/local/bin/patroni"
 POSTGRESQL_PROCESS = "postgres"
@@ -27,23 +26,7 @@ DB_PROCESSES = [POSTGRESQL_PROCESS, PATRONI_PROCESS]
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest) -> None:
     """Build and deploy three unit of PostgreSQL."""
-    # It is possible for users to provide their own cluster for HA testing. Hence, check if there
-    # is a pre-existing cluster.
-    if await app_name(ops_test):
-        return
-
-    charm = await ops_test.build_charm(".")
-    async with ops_test.fast_forward():
-        await ops_test.model.deploy(
-            charm,
-            resources={
-                "postgresql-image": METADATA["resources"]["postgresql-image"]["upstream-source"]
-            },
-            num_units=3,
-            series=CHARM_SERIES,
-            trust=True,
-        )
-        await ops_test.model.wait_for_idle(status="active", timeout=1000)
+    await build_and_deploy(ops_test, 3)
 
 
 @pytest.mark.parametrize("process", [POSTGRESQL_PROCESS])

--- a/tests/integration/ha_tests/test_self_healing.py
+++ b/tests/integration/ha_tests/test_self_healing.py
@@ -18,7 +18,7 @@ from tests.integration.ha_tests.helpers import (
     send_signal_to_process,
     stop_continuous_writes,
 )
-from tests.integration.helpers import get_unit_address
+from tests.integration.helpers import get_unit_address, CHARM_SERIES
 
 PATRONI_PROCESS = "/usr/local/bin/patroni"
 POSTGRESQL_PROCESS = "postgres"
@@ -42,6 +42,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
                 "postgresql-image": METADATA["resources"]["postgresql-image"]["upstream-source"]
             },
             num_units=3,
+            series=CHARM_SERIES,
             trust=True,
         )
         await ops_test.model.wait_for_idle(status="active", timeout=1000)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -25,6 +25,7 @@ from tenacity import (
     wait_exponential,
 )
 
+CHARM_SERIES = "jammy"
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 DATABASE_APP_NAME = METADATA["name"]
 
@@ -47,6 +48,7 @@ async def build_and_deploy(
         application_name=app_name,
         trust=True,
         num_units=num_units,
+        series=CHARM_SERIES,
     ),
     # Wait until the PostgreSQL charm is successfully deployed.
     await ops_test.model.wait_for_idle(

--- a/tests/integration/new_relations/application-charm/charmcraft.yaml
+++ b/tests/integration/new_relations/application-charm/charmcraft.yaml
@@ -5,7 +5,7 @@ type: charm
 bases:
   - build-on:
       - name: "ubuntu"
-        channel: "20.04"
+        channel: "22.04"
     run-on:
       - name: "ubuntu"
-        channel: "20.04"
+        channel: "22.04"

--- a/tests/integration/new_relations/test_new_relations.py
+++ b/tests/integration/new_relations/test_new_relations.py
@@ -10,7 +10,7 @@ import pytest
 import yaml
 from pytest_operator.plugin import OpsTest
 
-from tests.integration.helpers import check_database_users_existence, scale_application
+from tests.integration.helpers import check_database_users_existence, scale_application, CHARM_SERIES
 from tests.integration.new_relations.helpers import (
     build_connection_string,
     check_relation_data_existence,
@@ -45,6 +45,7 @@ async def test_database_relation_with_charm_libraries(
                 application_charm,
                 application_name=APPLICATION_APP_NAME,
                 num_units=2,
+                series=CHARM_SERIES,
             ),
             ops_test.model.deploy(
                 database_charm,
@@ -55,6 +56,7 @@ async def test_database_relation_with_charm_libraries(
                 },
                 application_name=DATABASE_APP_NAME,
                 num_units=3,
+                series=CHARM_SERIES,
                 trust=True,
             ),
             ops_test.model.deploy(
@@ -66,6 +68,7 @@ async def test_database_relation_with_charm_libraries(
                 },
                 application_name=ANOTHER_DATABASE_APP_NAME,
                 num_units=3,
+                series=CHARM_SERIES,
                 trust=True,
             ),
         )
@@ -155,6 +158,7 @@ async def test_two_applications_doesnt_share_the_same_relation_data(
     await ops_test.model.deploy(
         application_charm,
         application_name=another_application_app_name,
+        series=CHARM_SERIES,
     )
     await ops_test.model.wait_for_idle(apps=all_app_names, status="active")
 

--- a/tests/integration/new_relations/test_new_relations.py
+++ b/tests/integration/new_relations/test_new_relations.py
@@ -10,7 +10,11 @@ import pytest
 import yaml
 from pytest_operator.plugin import OpsTest
 
-from tests.integration.helpers import check_database_users_existence, scale_application, CHARM_SERIES
+from tests.integration.helpers import (
+    CHARM_SERIES,
+    check_database_users_existence,
+    scale_application,
+)
 from tests.integration.new_relations.helpers import (
     build_connection_string,
     check_relation_data_existence,

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -24,7 +24,7 @@ from tests.integration.helpers import (
     get_password,
     get_primary,
     get_unit_address,
-    scale_application,
+    scale_application, CHARM_SERIES,
 )
 
 logger = logging.getLogger(__name__)
@@ -307,6 +307,7 @@ async def test_redeploy_charm_same_model(ops_test: OpsTest):
             },
             application_name=APP_NAME,
             num_units=3,
+            series=CHARM_SERIES,
             trust=True,
         )
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -14,6 +14,7 @@ from pytest_operator.plugin import OpsTest
 
 from tests.helpers import METADATA, STORAGE_PATH
 from tests.integration.helpers import (
+    CHARM_SERIES,
     build_and_deploy,
     convert_records_to_dict,
     db_connect,
@@ -24,7 +25,7 @@ from tests.integration.helpers import (
     get_password,
     get_primary,
     get_unit_address,
-    scale_application, CHARM_SERIES,
+    scale_application,
 )
 
 logger = logging.getLogger(__name__)

--- a/tests/integration/test_db_admin.py
+++ b/tests/integration/test_db_admin.py
@@ -8,10 +8,11 @@ from pytest_operator.plugin import OpsTest
 
 from tests.helpers import METADATA
 from tests.integration.helpers import (
+    CHARM_SERIES,
     DATABASE_APP_NAME,
     check_database_creation,
     check_database_users_existence,
-    get_unit_address, CHARM_SERIES,
+    get_unit_address,
 )
 
 FIRST_DISCOURSE_APP_NAME = "discourse-k8s"

--- a/tests/integration/test_db_admin.py
+++ b/tests/integration/test_db_admin.py
@@ -12,6 +12,7 @@ from tests.integration.helpers import (
     DATABASE_APP_NAME,
     check_database_creation,
     check_database_users_existence,
+    get_primary,
     get_unit_address,
 )
 
@@ -52,9 +53,9 @@ async def test_build_and_deploy(ops_test: OpsTest):
         await ops_test.model.wait_for_idle(
             apps=[DATABASE_APP_NAME, REDIS_APP_NAME], status="active", timeout=1000
         )
-        # Discourse becomes blocked waiting for relations.
+        # Discourse waits for relations.
         await ops_test.model.wait_for_idle(
-            apps=[FIRST_DISCOURSE_APP_NAME], status="blocked", timeout=1000
+            apps=[FIRST_DISCOURSE_APP_NAME], status="waiting", timeout=1000
         )
 
 
@@ -62,7 +63,7 @@ async def test_discourse(ops_test: OpsTest):
     # Test the first Discourse charm.
     # Add both relations to Discourse (PostgreSQL and Redis)
     # and wait for it to be ready.
-    relation = await ops_test.model.add_relation(
+    await ops_test.model.add_relation(
         f"{DATABASE_APP_NAME}:db-admin",
         FIRST_DISCOURSE_APP_NAME,
     )
@@ -70,16 +71,22 @@ async def test_discourse(ops_test: OpsTest):
         REDIS_APP_NAME,
         FIRST_DISCOURSE_APP_NAME,
     )
-    await ops_test.model.wait_for_idle(
-        apps=[DATABASE_APP_NAME, FIRST_DISCOURSE_APP_NAME, REDIS_APP_NAME],
-        status="active",
-        timeout=2000,  # Discourse takes a longer time to become active (a lot of setup).
+
+    # Discourse requests extensions through relation, so check that the PostgreSQL charm
+    # becomes blocked.
+    primary_name = await get_primary(ops_test)
+    await ops_test.model.block_until(
+        lambda: ops_test.model.units[primary_name].workload_status == "blocked", timeout=60
+    )
+    assert (
+        ops_test.model.units[primary_name].workload_status_message
+        == "extensions requested through relation"
     )
 
-    # Check for the correct databases and users creation.
-    await check_database_creation(ops_test, "discourse-k8s")
-    discourse_users = [f"relation_id_{relation.id}"]
-    await check_database_users_existence(ops_test, discourse_users, [], admin=True)
+    # Destroy the relation to remove the blocked status.
+    await ops_test.model.applications[DATABASE_APP_NAME].destroy_relation(
+        f"{DATABASE_APP_NAME}:db-admin", FIRST_DISCOURSE_APP_NAME
+    )
 
 
 async def test_discourse_from_discourse_charmers(ops_test: OpsTest):

--- a/tests/integration/test_db_admin.py
+++ b/tests/integration/test_db_admin.py
@@ -11,7 +11,7 @@ from tests.integration.helpers import (
     DATABASE_APP_NAME,
     check_database_creation,
     check_database_users_existence,
-    get_unit_address,
+    get_unit_address, CHARM_SERIES,
 )
 
 FIRST_DISCOURSE_APP_NAME = "discourse-k8s"
@@ -42,6 +42,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
                 application_name=DATABASE_APP_NAME,
                 trust=True,
                 num_units=DATABASE_UNITS,
+                series=CHARM_SERIES,
             ),
             ops_test.model.deploy(
                 FIRST_DISCOURSE_APP_NAME, application_name=FIRST_DISCOURSE_APP_NAME

--- a/tests/integration/test_password_rotation.py
+++ b/tests/integration/test_password_rotation.py
@@ -8,10 +8,11 @@ from pytest_operator.plugin import OpsTest
 
 from tests.helpers import METADATA
 from tests.integration.helpers import (
+    CHARM_SERIES,
     check_patroni,
     get_password,
     restart_patroni,
-    set_password, CHARM_SERIES,
+    set_password,
 )
 
 APP_NAME = METADATA["name"]

--- a/tests/integration/test_password_rotation.py
+++ b/tests/integration/test_password_rotation.py
@@ -11,7 +11,7 @@ from tests.integration.helpers import (
     check_patroni,
     get_password,
     restart_patroni,
-    set_password,
+    set_password, CHARM_SERIES,
 )
 
 APP_NAME = METADATA["name"]
@@ -31,6 +31,7 @@ async def test_deploy_active(ops_test: OpsTest):
             },
             application_name=APP_NAME,
             num_units=3,
+            series=CHARM_SERIES,
             trust=True,
         )
         await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -19,7 +19,7 @@ from tests.integration.helpers import (
     get_primary,
     get_unit_address,
     primary_changed,
-    run_command_on_unit,
+    run_command_on_unit, CHARM_SERIES,
 )
 
 MATTERMOST_APP_NAME = "mattermost"
@@ -46,6 +46,7 @@ async def test_mattermost_db(ops_test: OpsTest) -> None:
             },
             application_name=DATABASE_APP_NAME,
             num_units=DATABASE_UNITS,
+            series=CHARM_SERIES,
             trust=True,
         )
         # Deploy TLS Certificates operator.

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -7,6 +7,7 @@ from tenacity import Retrying, stop_after_delay, wait_exponential
 
 from tests.helpers import METADATA
 from tests.integration.helpers import (
+    CHARM_SERIES,
     DATABASE_APP_NAME,
     check_database_creation,
     check_database_users_existence,
@@ -19,7 +20,7 @@ from tests.integration.helpers import (
     get_primary,
     get_unit_address,
     primary_changed,
-    run_command_on_unit, CHARM_SERIES,
+    run_command_on_unit,
 )
 
 MATTERMOST_APP_NAME = "mattermost"


### PR DESCRIPTION
# Issue
Jira issue: https://warthogs.atlassian.net/browse/DPE-1411
The charm is still on Focal.


# Solution
Upgrade all the bases and all the deployments to use Jammy.


# Context
The Discourse charm started to request extensions (the version that requests extensions was promoted to stable today - 2023-02-28): https://github.com/canonical/discourse-k8s-operator/commit/08830d595de9bd391e74d5b0740f0390b8861a1e. So, the test was changed in this PR.


# Testing
Used the existing tests to confirm that the charm works on Jammy.


# Release Notes
Upgrade charm to Jammy.
