### PR TITLE
Hide instance on backup

### DIFF
--- a/src/backups.py
+++ b/src/backups.py
@@ -151,14 +151,21 @@ class PostgreSQLBackups(Object):
 
         try:
             self.charm.unit.status = MaintenanceStatus("creating backup")
-            self.charm.patch_pod_labels(self.charm.unit.name, add_labels=False)
+
+            # Remove the pod labels to hide this unit from the replicas K8S service.
+            if self.charm.app.planned_units() > 1:
+                self.charm.patch_pod_labels(self.charm.unit.name, add_labels=False)
+
             self._execute_command(
                 ["pgbackrest", f"--stanza={self.charm.cluster_name}", "--type=full", "backup"]
             )
             event.set_results({"backup-status": "backup created"})
         except pebble.ExecError as e:
             event.fail(f"Failed to backup PostgreSQL with error: {str(e)}")
+
+        # Add the labels back to the pod.
         self.charm.patch_pod_labels(self.charm.unit.name)
+
         self.charm.unit.status = ActiveStatus()
 
     def _on_list_backups_action(self, event) -> None:

--- a/src/backups.py
+++ b/src/backups.py
@@ -151,12 +151,14 @@ class PostgreSQLBackups(Object):
 
         try:
             self.charm.unit.status = MaintenanceStatus("creating backup")
+            self.charm.patch_pod_labels(self.charm.unit.name, add_labels=False)
             self._execute_command(
                 ["pgbackrest", f"--stanza={self.charm.cluster_name}", "--type=full", "backup"]
             )
             event.set_results({"backup-status": "backup created"})
         except pebble.ExecError as e:
             event.fail(f"Failed to backup PostgreSQL with error: {str(e)}")
+        self.charm.patch_pod_labels(self.charm.unit.name)
         self.charm.unit.status = ActiveStatus()
 
     def _on_list_backups_action(self, event) -> None:


### PR DESCRIPTION
# Issue
Jira issue: [DPE-1270](https://warthogs.atlassian.net/browse/DPE-1270)
The PostgreSQL unit that is performing the backup operation isn't being hidden from PgBouncer or other client applications to avoid that the connections are impacted by the backup operation.


# Solution
Temporarily remove the endpoint of the unit that is performing the backup from the k8s service by removing some pod labels (which are used in the label selector of the service).


# Context
The `_patch_pod_labels` method was just renamed to not be private anymore as it's being used outside `charm.py`.


# Testing
Tests will be implemented on [DPE-556](https://warthogs.atlassian.net/browse/DPE-556).


# Release Notes
Hide instance on backup.


[DPE-1270]: https://warthogs.atlassian.net/browse/DPE-1270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DPE-556]: https://warthogs.atlassian.net/browse/DPE-556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ