### PR TITLE
Fix duplicate K8S service ports names

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -98,8 +98,8 @@ class PostgresqlOperatorCharm(CharmBase):
             charm=self, relation="restart", callback=self._restart
         )
 
-        postgresql_db_port = ServicePort(5432, name=f"{self.app.name}")
-        patroni_api_port = ServicePort(8008, name=f"{self.app.name}")
+        postgresql_db_port = ServicePort(5432, name="database")
+        patroni_api_port = ServicePort(8008, name="api")
         self.service_patcher = KubernetesServicePatch(self, [postgresql_db_port, patroni_api_port])
 
     @property

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -447,9 +447,11 @@ def get_expected_k8s_resources(namespace: str, application: str) -> set:
         [
             f"Endpoints/patroni-{application}-config",
             f"Endpoints/patroni-{application}",
+            f"Endpoints/{application}",
             f"Endpoints/{application}-primary",
             f"Endpoints/{application}-replicas",
             f"Service/patroni-{application}-config",
+            f"Service/{application}",
         ]
     )
 


### PR DESCRIPTION
# Issue
Jira issues: [DPE-1127](https://warthogs.atlassian.net/browse/DPE-1127) and [DPE-1378](https://warthogs.atlassian.net/browse/DPE-1378)


# Solution
Use unique DNS names for each service port (using the same names that are already being used by the primary and replicas k8s services).


# Context
The test helpers functions got some new k8s resources added because they were already created before this change, but without the right labels. This PR also fixed it.

Closes #99.


# Testing
Tested manually and checked the logs.


# Release Notes
Use unique DNS names for each service port.


[DPE-1127]: https://warthogs.atlassian.net/browse/DPE-1127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DPE-1378]: https://warthogs.atlassian.net/browse/DPE-1378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ