### PR TITLE
Mark unstable tests

### DIFF
--- a/tests/integration/ha_tests/test_self_healing.py
+++ b/tests/integration/ha_tests/test_self_healing.py
@@ -29,6 +29,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     await build_and_deploy(ops_test, 3)
 
 
+@pytest.mark.unstable
 @pytest.mark.parametrize("process", [POSTGRESQL_PROCESS])
 async def test_freeze_db_process(
     ops_test: OpsTest, process: str, continuous_writes, master_start_timeout
@@ -85,6 +86,7 @@ async def test_freeze_db_process(
     ), "secondary not up to date with the cluster after restarting."
 
 
+@pytest.mark.unstable
 @pytest.mark.parametrize("process", DB_PROCESSES)
 async def test_restart_db_process(
     ops_test: OpsTest, process: str, continuous_writes, master_start_timeout

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -151,6 +151,7 @@ async def test_cluster_is_stable_after_leader_deletion(ops_test: OpsTest) -> Non
     assert await get_primary(ops_test, down_unit=primary) != "None"
 
 
+@pytest.mark.unstable
 async def test_scale_down_and_up(ops_test: OpsTest):
     """Test data is replicated to new units after a scale up."""
     # Ensure the initial number of units in the application.

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -287,6 +287,7 @@ async def test_application_removal(ops_test: OpsTest) -> None:
     assert APP_NAME not in ops_test.model.applications
 
 
+@pytest.mark.unstable
 async def test_redeploy_charm_same_model(ops_test: OpsTest):
     """Redeploy the charm in the same model to test that it works."""
     charm = await ops_test.build_charm(".")

--- a/tests/integration/test_db.py
+++ b/tests/integration/test_db.py
@@ -3,6 +3,7 @@
 # See LICENSE file for licensing details.
 from asyncio import gather
 
+import pytest
 from pytest_operator.plugin import OpsTest
 
 from tests.integration.helpers import (
@@ -80,6 +81,7 @@ async def test_finos_waltz_db(ops_test: OpsTest) -> None:
         await ops_test.model.remove_application(DATABASE_APP_NAME, block_until_done=True)
 
 
+@pytest.mark.unstable
 async def test_indico_db_blocked(ops_test: OpsTest) -> None:
     """Tests if deploying and relating to Indico charm will block due to requested extensions."""
     async with ops_test.fast_forward():

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
+import pytest as pytest
 from pytest_operator.plugin import OpsTest
 from tenacity import Retrying, stop_after_delay, wait_exponential
 
@@ -28,6 +29,7 @@ APPLICATION_UNITS = 2
 DATABASE_UNITS = 3
 
 
+@pytest.mark.unstable
 async def test_mattermost_db(ops_test: OpsTest) -> None:
     """Deploy Mattermost to test the 'db' relation.
 


### PR DESCRIPTION
# Issue
Jira issue: [DPE-1356](https://warthogs.atlassian.net/browse/DPE-1356)
Some integration tests fail transiently and sometimes make the development slower.


# Solution
Mark them as unstable and create tasks for solving each of them.


# Context
New Jira issues were created for each of the tests that need to be fixed. They're listed on [DPE-1356](https://warthogs.atlassian.net/browse/DPE-1356?focusedCommentId=200066).

The TLS tests was changed to match the text in the logs without all the details related to TLS version or bits (because it may change when updating the database version).


# Testing
Tested on multiple runs locally and on CI.


# Release Notes
Mark unstable tests.


[DPE-1356]: https://warthogs.atlassian.net/browse/DPE-1356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ