### PR TITLE
Simplify password parsing in action results

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -549,7 +549,7 @@ class PostgresqlOperatorCharm(CharmBase):
                 f" {', '.join(SYSTEM_USERS)} not {username}"
             )
             return
-        event.set_results({f"{username}-password": self.get_secret("app", f"{username}-password")})
+        event.set_results({"password": self.get_secret("app", f"{username}-password")})
 
     def _on_set_password(self, event: ActionEvent) -> None:
         """Set the password for the specified user."""
@@ -572,7 +572,7 @@ class PostgresqlOperatorCharm(CharmBase):
 
         if password == self.get_secret("app", f"{username}-password"):
             event.log("The old and new passwords are equal.")
-            event.set_results({f"{username}-password": password})
+            event.set_results({"password": password})
             return
 
         # Ensure all members are ready before trying to reload Patroni
@@ -601,7 +601,7 @@ class PostgresqlOperatorCharm(CharmBase):
         # Other units Patroni configuration will be reloaded in the peer relation changed event.
         self.update_config()
 
-        event.set_results({f"{username}-password": password})
+        event.set_results({"password": password})
 
     def _on_get_primary(self, event: ActionEvent) -> None:
         """Get primary instance."""

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -467,7 +467,7 @@ async def get_password(
         if unit.name != down_unit:
             action = await unit.run_action("get-password", **{"username": username})
             result = await action.wait()
-            return result.results[f"{username}-password"]
+            return result.results["password"]
 
 
 @retry(

--- a/tests/integration/test_password_rotation.py
+++ b/tests/integration/test_password_rotation.py
@@ -52,7 +52,7 @@ async def test_password_rotation(ops_test: OpsTest):
 
     # Change both passwords.
     result = await set_password(ops_test, unit_name=leader)
-    assert "operator-password" in result.keys()
+    assert "password" in result.keys()
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
 
     # For replication, generate a specific password and pass it to the action.
@@ -60,7 +60,7 @@ async def test_password_rotation(ops_test: OpsTest):
     result = await set_password(
         ops_test, unit_name=leader, username="replication", password=new_replication_password
     )
-    assert "replication-password" in result.keys()
+    assert "password" in result.keys()
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
 
     new_superuser_password = await get_password(ops_test)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -181,15 +181,13 @@ class TestCharm(unittest.TestCase):
         mock_event.reset_mock()
         del mock_event.params["username"]
         self.charm._on_get_password(mock_event)
-        mock_event.set_results.assert_called_once_with({"operator-password": "test-password"})
+        mock_event.set_results.assert_called_once_with({"password": "test-password"})
 
         # Also test providing the username option.
         mock_event.reset_mock()
         mock_event.params["username"] = "replication"
         self.charm._on_get_password(mock_event)
-        mock_event.set_results.assert_called_once_with(
-            {"replication-password": "replication-test-password"}
-        )
+        mock_event.set_results.assert_called_once_with({"password": "replication-test-password"})
 
     @patch("charm.Patroni.reload_patroni_configuration")
     @patch("charm.PostgresqlOperatorCharm.update_config")


### PR DESCRIPTION
# Issue
Jira issue: [DPE-1489](https://warthogs.atlassian.net/browse/DPE-1489)
All the passwords returned by the get and set password actions have the username as a prefix, but who requested it already knows the user, so it's not needed to have it specified in the action result, only the password.


# Solution
Remove the username prefix from the password key in the actions results.


# Context
Reference: https://github.com/canonical/mongodb-operator/pull/172#discussion_r1115859485 (request from Mykola).

I also contacted Marc about the Zookeeper charms.


# Testing
Fixed the existing tests.


# Release Notes
Simplify password parsing in action results.


[DPE-1489]: https://warthogs.atlassian.net/browse/DPE-1489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ