### PR TITLE
Fix AWS bucket name and region

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -22,9 +22,9 @@ async def cloud_configs(ops_test: OpsTest) -> None:
     configs = {
         AWS: {
             "endpoint": "https://s3.amazonaws.com",
-            "bucket": "canonical-postgres",
-            "path": f"/{uuid.uuid1()}",
-            "region": "us-east-2",
+            "bucket": "data-charms-testing",
+            "path": f"/postgresql-k8s/{uuid.uuid1()}",
+            "region": "us-east-1",
         },
         GCP: {
             "endpoint": "https://storage.googleapis.com",


### PR DESCRIPTION
# Issue
Jira issue: [DPE-1504](https://warthogs.atlassian.net/browse/DPE-1504)
Yesterday the AWS credentials were changed to the team credentials.
A test failed due to that because those credentials work only for the team bucket (that should be used instead the personal bucket): https://github.com/canonical/postgresql-k8s-operator/actions/runs/4436528202/jobs/7785176423

# Solution
The bucket name and its region were changed in the test code (to use the team bucket).


# Context
In the future we can probably move the bucket and region names to environment variables.


# Testing
Used the existing tests to validate the change.


# Release Notes
Fix AWS bucket name and region in integration test.


[DPE-1504]: https://warthogs.atlassian.net/browse/DPE-1504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ