### PR TITLE
Add IP address to DNS SANs list

### DIFF
--- a/lib/charms/postgresql_k8s/v0/postgresql_tls.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql_tls.py
@@ -45,7 +45,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version.
-LIBPATCH = 5
+LIBPATCH = 6
 
 logger = logging.getLogger(__name__)
 SCOPE = "unit"
@@ -193,7 +193,9 @@ class PostgreSQLTLS(Object):
 
         # Separate IP addresses and DNS names.
         sans_ip = [san for san in sans if is_ip_address(san)]
-        sans_dns = [san for san in sans if not is_ip_address(san)]
+        # IP address need to be part of the DNS SANs list due to
+        # https://github.com/pgbackrest/pgbackrest/issues/1977.
+        sans_dns = sans
 
         return {
             "sans_ip": sans_ip,

--- a/tests/unit/test_postgresql_tls.py
+++ b/tests/unit/test_postgresql_tls.py
@@ -194,6 +194,7 @@ class TestPostgreSQLTLS(unittest.TestCase):
                     "postgresql-k8s-0",
                     "postgresql-k8s-0.postgresql-k8s-endpoints",
                     socket.getfqdn(),
+                    "1.1.1.1",
                     "postgresql-k8s-primary.None.svc.cluster.local",
                     "postgresql-k8s-replicas.None.svc.cluster.local",
                 ],


### PR DESCRIPTION
# Issue
Jira ticket: [DPE-1532](https://warthogs.atlassian.net/browse/DPE-1532)

To implement https://warthogs.atlassian.net/browse/DPE-1271  it’s needed that the TLS Server finds in the certificate the IP address of the unit that is connecting to it.

Currently, it’s not possible due to https://github.com/pgbackrest/pgbackrest/issues/1977.


# Solution
Add the IP address also to the DNS SANs list (like "DNS:1.2.3.4" entries).


# Context
This charm library will be updated later in the VM charm repository.


# Testing
Tested manually in the VM charm.


# Release Notes
Add IP address to DNS SANs list.


[DPE-1532]: https://warthogs.atlassian.net/browse/DPE-1532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ