### PR TITLE
Setting workload version to snap in rock version

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -413,6 +413,8 @@ class PostgresqlOperatorCharm(CharmBase):
         # Create a new config layer.
         new_layer = self._postgresql_layer()
 
+        self.unit.set_workload_version(self._patroni.rock_postgresql_version)
+
         # Defer the initialization of the workload in the replicas
         # if the cluster hasn't been bootstrap on the primary yet.
         # Otherwise, each unit will create a different cluster and


### PR DESCRIPTION
# Issue
* [DPE-1514](https://warthogs.atlassian.net/browse/DPE-1514)
* Sets the workload version to what Pgbouncer reports as it's version

# Solution
<!-- A summary of the solution addressing the above issue -->


# Context
* Using the version set in the snap manifest


# Testing
<!-- What steps need to be taken to test this PR? -->


# Release Notes
* Sets the workload version


[DPE-1514]: https://warthogs.atlassian.net/browse/DPE-1514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ