### PR TITLE
[DPE-556] Add 3rd batch of backup/restore unit tests

### DIFF
--- a/src/backups.py
+++ b/src/backups.py
@@ -683,14 +683,14 @@ Stderr:
             )
             return {}, missing_required_parameters
 
-        # Retrieve the backup path, strip its slashes and add a "/" in the beginning of the path.
-        s3_parameters["path"] = f'/{s3_parameters["path"].strip("/")}'
-
         # Add some sensible defaults (as expected by the code) for missing optional parameters
         s3_parameters.setdefault("endpoint", "https://s3.amazonaws.com")
         s3_parameters.setdefault("region")
         s3_parameters.setdefault("path", "")
         s3_parameters.setdefault("s3-uri-style", "host")
+
+        # Retrieve the backup path, strip its slashes and add a "/" in the beginning of the path.
+        s3_parameters["path"] = f'/{s3_parameters["path"].strip("/")}'
 
         return s3_parameters, []
 

--- a/src/backups.py
+++ b/src/backups.py
@@ -689,8 +689,18 @@ Stderr:
         s3_parameters.setdefault("path", "")
         s3_parameters.setdefault("s3-uri-style", "host")
 
-        # Retrieve the backup path, strip its slashes and add a "/" in the beginning of the path.
-        s3_parameters["path"] = f'/{s3_parameters["path"].strip("/")}'
+        # Strip whitespaces from all parameters.
+        for key, value in s3_parameters.items():
+            if isinstance(value, str):
+                s3_parameters[key] = value.strip()
+
+        # Clean up extra slash symbols to avoid issues on 3rd-party storages
+        # like Ceph Object Gateway (radosgw).
+        s3_parameters["endpoint"] = s3_parameters["endpoint"].rstrip("/")
+        s3_parameters[
+            "path"
+        ] = f'/{s3_parameters["path"].strip("/")}'  # The slash in the beginning is required by pgBackRest.
+        s3_parameters["bucket"] = s3_parameters["bucket"].strip("/")
 
         return s3_parameters, []
 

--- a/tests/unit/test_backups.py
+++ b/tests/unit/test_backups.py
@@ -1,0 +1,376 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+import unittest
+from unittest.mock import MagicMock, PropertyMock, mock_open, patch
+
+from boto3.exceptions import S3UploadFailedError
+from jinja2 import Template
+from ops import BlockedStatus
+from ops.testing import Harness
+
+from charm import PostgresqlOperatorCharm
+from constants import PEER
+
+ANOTHER_CLUSTER_REPOSITORY_ERROR_MESSAGE = "the S3 repository has backups from another cluster"
+FAILED_TO_ACCESS_CREATE_BUCKET_ERROR_MESSAGE = (
+    "failed to access/create the bucket, check your S3 settings"
+)
+FAILED_TO_INITIALIZE_STANZA_ERROR_MESSAGE = "failed to initialize stanza, check your S3 settings"
+S3_PARAMETERS_RELATION = "s3-parameters"
+
+
+class TestPostgreSQLBackups(unittest.TestCase):
+    @patch("charm.KubernetesServicePatch", lambda x, y: None)
+    def setUp(self):
+        # Mock generic sync client to avoid search to ~/.kube/config.
+        self.patcher = patch("lightkube.core.client.GenericSyncClient")
+        self.mock_k8s_client = self.patcher.start()
+
+        self.harness = Harness(PostgresqlOperatorCharm)
+        self.addCleanup(self.harness.cleanup)
+
+        # Set up the initial relation and hooks.
+        self.peer_rel_id = self.harness.add_relation(PEER, "postgresql-k8s")
+        self.harness.add_relation_unit(self.peer_rel_id, "postgresql-k8s/0")
+        self.harness.begin()
+        self.charm = self.harness.charm
+
+    def relate_to_s3_integrator(self):
+        self.s3_rel_id = self.harness.add_relation(S3_PARAMETERS_RELATION, "s3-integrator")
+
+    def remove_relation_from_s3_integrator(self):
+        self.harness.remove_relation(S3_PARAMETERS_RELATION, "s3-integrator")
+        self.s3_rel_id = None
+
+    @patch("ops.model.Application.planned_units")
+    @patch("charm.PostgreSQLBackups._are_backup_settings_ok")
+    def test_pre_restore_checks(self, _are_backup_settings_ok, _planned_units):
+        # Test when S3 parameters are not ok.
+        mock_event = MagicMock()
+        _are_backup_settings_ok.return_value = (False, "fake error message")
+        self.assertEqual(self.charm.backup._pre_restore_checks(mock_event), False)
+        mock_event.fail.assert_called_once()
+
+        # Test when no backup id is provided.
+        mock_event.reset_mock()
+        _are_backup_settings_ok.return_value = (True, None)
+        self.assertEqual(self.charm.backup._pre_restore_checks(mock_event), False)
+        mock_event.fail.assert_called_once()
+
+        # Test when the workload container is not accessible yet.
+        mock_event.reset_mock()
+        mock_event.params = {"backup-id": "2023-01-01T09:00:00Z"}
+        self.assertEqual(self.charm.backup._pre_restore_checks(mock_event), False)
+        mock_event.fail.assert_called_once()
+
+        # Test when the unit is in a blocked state that is not recoverable by changing
+        # S3 parameters.
+        mock_event.reset_mock()
+        self.harness.set_can_connect("postgresql", True)
+        self.charm.unit.status = BlockedStatus("fake blocked state")
+        self.assertEqual(self.charm.backup._pre_restore_checks(mock_event), False)
+        mock_event.fail.assert_called_once()
+
+        # Test when the unit is in a blocked state that is recoverable by changing S3 parameters,
+        # but the cluster has more than one unit.
+        mock_event.reset_mock()
+        self.charm.unit.status = BlockedStatus(ANOTHER_CLUSTER_REPOSITORY_ERROR_MESSAGE)
+        _planned_units.return_value = 2
+        self.assertEqual(self.charm.backup._pre_restore_checks(mock_event), False)
+        mock_event.fail.assert_called_once()
+
+        # Test when the cluster has only one unit, but it's not the leader yet.
+        mock_event.reset_mock()
+        _planned_units.return_value = 1
+        self.assertEqual(self.charm.backup._pre_restore_checks(mock_event), False)
+        mock_event.fail.assert_called_once()
+
+        # Test when everything is ok to run a restore.
+        mock_event.reset_mock()
+        with self.harness.hooks_disabled():
+            self.harness.set_leader()
+        self.assertEqual(self.charm.backup._pre_restore_checks(mock_event), True)
+        mock_event.fail.assert_not_called()
+
+    @patch("ops.model.Container.push")
+    @patch("charm.PostgreSQLBackups._retrieve_s3_parameters")
+    def test_render_pgbackrest_conf_file(self, _retrieve_s3_parameters, _push):
+        # Set up a mock for the `open` method, set returned data to postgresql.conf template.
+        with open("templates/pgbackrest.conf.j2", "r") as f:
+            mock = mock_open(read_data=f.read())
+
+        # Test when there are missing S3 parameters.
+        _retrieve_s3_parameters.return_value = [], ["bucket", "access-key", "secret-key"]
+
+        # Patch the `open` method with our mock.
+        with patch("builtins.open", mock, create=True):
+            # Call the method
+            self.charm.backup._render_pgbackrest_conf_file()
+
+        mock.assert_not_called()
+        _push.assert_not_called()
+
+        # Test when all parameters are provided.
+        _retrieve_s3_parameters.return_value = {
+            "bucket": "test-bucket",
+            "access-key": "test-access-key",
+            "secret-key": "test-secret-key",
+            "endpoint": "https://storage.googleapis.com",
+            "path": "test-path/",
+            "region": "us-east-1",
+            "s3-uri-style": "path",
+        }, []
+
+        # Get the expected content from a file.
+        with open("templates/pgbackrest.conf.j2") as file:
+            template = Template(file.read())
+        expected_content = template.render(
+            enable_tls=self.charm.is_tls_enabled and len(self.charm.peer_members_endpoints) > 0,
+            peer_endpoints=self.charm.peer_members_endpoints,
+            path="test-path/",
+            region="us-east-1",
+            endpoint="https://storage.googleapis.com",
+            bucket="test-bucket",
+            s3_uri_style="path",
+            access_key="test-access-key",
+            secret_key="test-secret-key",
+            stanza=self.charm.backup.stanza_name,
+            storage_path=self.charm._storage_path,
+            user="backup",
+        )
+
+        # Patch the `open` method with our mock.
+        with patch("builtins.open", mock, create=True):
+            # Call the method
+            self.charm.backup._render_pgbackrest_conf_file()
+
+        # Check the template is opened read-only in the call to open.
+        self.assertEqual(mock.call_args_list[0][0], ("templates/pgbackrest.conf.j2", "r"))
+
+        # Ensure the correct rendered template is sent to _render_file method.
+        _push.assert_called_once_with(
+            "/etc/pgbackrest.conf",
+            expected_content,
+            user="postgres",
+            group="postgres",
+        )
+
+    @patch("ops.model.Container.start")
+    @patch("charm.PostgresqlOperatorCharm.update_config")
+    def test_restart_database(self, _update_config, _start):
+        with self.harness.hooks_disabled():
+            self.harness.update_relation_data(
+                self.peer_rel_id,
+                self.charm.unit.name,
+                {"restoring-backup": "2023-01-01T09:00:00Z"},
+            )
+        self.charm.backup._restart_database()
+
+        # Assert that the backup id is not in the application relation databag anymore.
+        self.assertEqual(self.harness.get_relation_data(self.peer_rel_id, self.charm.app), {})
+
+        _update_config.assert_called_once()
+        _start.assert_called_once_with("postgresql")
+
+    @patch("charms.data_platform_libs.v0.s3.S3Requirer.get_s3_connection_info")
+    def test_retrieve_s3_parameters(self, _get_s3_connection_info):
+        # Test when there are missing S3 parameters.
+        _get_s3_connection_info.return_value = {}
+        self.assertEqual(
+            self.charm.backup._retrieve_s3_parameters(),
+            ({}, ["bucket", "access-key", "secret-key"]),
+        )
+
+        # Test when only the required parameters are provided.
+        _get_s3_connection_info.return_value = {
+            "bucket": "test-bucket",
+            "access-key": "test-access-key",
+            "secret-key": "test-secret-key",
+        }
+        self.assertEqual(
+            self.charm.backup._retrieve_s3_parameters(),
+            (
+                {
+                    "access-key": "test-access-key",
+                    "bucket": "test-bucket",
+                    "endpoint": "https://s3.amazonaws.com",
+                    "path": "/",
+                    "region": None,
+                    "s3-uri-style": "host",
+                    "secret-key": "test-secret-key",
+                },
+                [],
+            ),
+        )
+
+        # Test when all parameters are provided.
+        _get_s3_connection_info.return_value = {
+            "bucket": "test-bucket",
+            "access-key": "test-access-key",
+            "secret-key": "test-secret-key",
+            "endpoint": "https://storage.googleapis.com",
+            "path": "test-path/",
+            "region": "us-east-1",
+            "s3-uri-style": "path",
+        }
+        self.assertEqual(
+            self.charm.backup._retrieve_s3_parameters(),
+            (
+                {
+                    "access-key": "test-access-key",
+                    "bucket": "test-bucket",
+                    "endpoint": "https://storage.googleapis.com",
+                    "path": "/test-path",
+                    "region": "us-east-1",
+                    "s3-uri-style": "path",
+                    "secret-key": "test-secret-key",
+                },
+                [],
+            ),
+        )
+
+    @patch(
+        "charm.PostgreSQLBackups._is_primary_pgbackrest_service_running", new_callable=PropertyMock
+    )
+    @patch("charm.PostgresqlOperatorCharm.is_primary", new_callable=PropertyMock)
+    @patch("ops.model.Container.restart")
+    @patch("ops.model.Container.stop")
+    @patch("charm.PostgresqlOperatorCharm.peer_members_endpoints", new_callable=PropertyMock)
+    @patch("charm.PostgresqlOperatorCharm.is_tls_enabled", new_callable=PropertyMock)
+    @patch("charm.PostgreSQLBackups._render_pgbackrest_conf_file")
+    @patch("charm.PostgreSQLBackups._are_backup_settings_ok")
+    def test_start_stop_pgbackrest_service(
+        self,
+        _are_backup_settings_ok,
+        _render_pgbackrest_conf_file,
+        _is_tls_enabled,
+        _peer_members_endpoints,
+        _stop,
+        _restart,
+        _is_primary,
+        _is_primary_pgbackrest_service_running,
+    ):
+        # Test when S3 parameters are not ok (no operation, but returns success).
+        _are_backup_settings_ok.return_value = (False, "fake error message")
+        self.assertEqual(
+            self.charm.backup.start_stop_pgbackrest_service(),
+            True,
+        )
+        _stop.assert_not_called()
+        _restart.assert_not_called()
+
+        # Test when it was not possible to render the pgBackRest configuration file.
+        _are_backup_settings_ok.return_value = (True, None)
+        _render_pgbackrest_conf_file.return_value = False
+        self.assertEqual(
+            self.charm.backup.start_stop_pgbackrest_service(),
+            False,
+        )
+        _stop.assert_not_called()
+        _restart.assert_not_called()
+
+        # Test when TLS is not enabled (should stop the service).
+        _render_pgbackrest_conf_file.return_value = True
+        _is_tls_enabled.return_value = False
+        self.assertEqual(
+            self.charm.backup.start_stop_pgbackrest_service(),
+            True,
+        )
+        _stop.assert_called_once()
+        _restart.assert_not_called()
+
+        # Test when there are no replicas.
+        _stop.reset_mock()
+        _is_tls_enabled.return_value = True
+        _peer_members_endpoints.return_value = []
+        self.assertEqual(
+            self.charm.backup.start_stop_pgbackrest_service(),
+            True,
+        )
+        _stop.assert_called_once()
+        _restart.assert_not_called()
+
+        # Test when the service hasn't started in the primary yet.
+        _stop.reset_mock()
+        _peer_members_endpoints.return_value = ["fake-member-endpoint"]
+        _is_primary.return_value = False
+        _is_primary_pgbackrest_service_running.return_value = False
+        self.assertEqual(
+            self.charm.backup.start_stop_pgbackrest_service(),
+            False,
+        )
+        _stop.assert_not_called()
+        _restart.assert_not_called()
+
+        # Test when the service has already started in the primary.
+        _is_primary_pgbackrest_service_running.return_value = True
+        self.assertEqual(
+            self.charm.backup.start_stop_pgbackrest_service(),
+            True,
+        )
+        _stop.assert_not_called()
+        _restart.assert_called_once()
+
+        # Test when this unit is the primary.
+        _restart.reset_mock()
+        _is_primary.return_value = True
+        _is_primary_pgbackrest_service_running.return_value = False
+        self.assertEqual(
+            self.charm.backup.start_stop_pgbackrest_service(),
+            True,
+        )
+        _stop.assert_not_called()
+        _restart.assert_called_once()
+
+    @patch("tempfile.NamedTemporaryFile")
+    @patch("charm.PostgreSQLBackups._construct_endpoint")
+    @patch("boto3.session.Session.resource")
+    def test_upload_content_to_s3(self, _resource, _construct_endpoint, _named_temporary_file):
+        # Set some parameters.
+        content = "test-content"
+        s3_path = "test-file."
+        s3_parameters = {
+            "bucket": "test-bucket",
+            "access-key": "test-access-key",
+            "secret-key": "test-secret-key",
+            "endpoint": "https://s3.amazonaws.com",
+            "path": "/test-path",
+            "region": "us-east-1",
+        }
+
+        # Test when any exception happens.
+        upload_file = _resource.return_value.Bucket.return_value.upload_file
+        _resource.side_effect = ValueError
+        _construct_endpoint.return_value = "https://s3.us-east-1.amazonaws.com"
+        _named_temporary_file.return_value.__enter__.return_value.name = "/tmp/test-file"
+        self.assertEqual(
+            self.charm.backup._upload_content_to_s3(content, s3_path, s3_parameters),
+            False,
+        )
+        _resource.assert_called_once_with("s3", endpoint_url="https://s3.us-east-1.amazonaws.com")
+        _named_temporary_file.assert_not_called()
+        upload_file.assert_not_called()
+
+        _resource.reset_mock()
+        _resource.side_effect = None
+        upload_file.side_effect = S3UploadFailedError
+        self.assertEqual(
+            self.charm.backup._upload_content_to_s3(content, s3_path, s3_parameters),
+            False,
+        )
+        _resource.assert_called_once_with("s3", endpoint_url="https://s3.us-east-1.amazonaws.com")
+        _named_temporary_file.assert_called_once()
+        upload_file.assert_called_once_with("/tmp/test-file", "test-path/test-file.")
+
+        # Test when the upload succeeds
+        _resource.reset_mock()
+        _named_temporary_file.reset_mock()
+        upload_file.reset_mock()
+        upload_file.side_effect = None
+        self.assertEqual(
+            self.charm.backup._upload_content_to_s3(content, s3_path, s3_parameters),
+            True,
+        )
+        _resource.assert_called_once_with("s3", endpoint_url="https://s3.us-east-1.amazonaws.com")
+        _named_temporary_file.assert_called_once()
+        upload_file.assert_called_once_with("/tmp/test-file", "test-path/test-file.")

--- a/tests/unit/test_backups.py
+++ b/tests/unit/test_backups.py
@@ -1157,13 +1157,13 @@ Juju Version: test-juju-version
 
         # Test when all parameters are provided.
         _get_s3_connection_info.return_value = {
-            "bucket": "test-bucket",
-            "access-key": "test-access-key",
-            "secret-key": "test-secret-key",
-            "endpoint": "https://storage.googleapis.com",
-            "path": "test-path/",
-            "region": "us-east-1",
-            "s3-uri-style": "path",
+            "bucket": " /test-bucket/ ",
+            "access-key": " test-access-key ",
+            "secret-key": " test-secret-key ",
+            "endpoint": " https://storage.googleapis.com// ",
+            "path": " test-path/ ",
+            "region": " us-east-1 ",
+            "s3-uri-style": " path ",
         }
         self.assertEqual(
             self.charm.backup._retrieve_s3_parameters(),


### PR DESCRIPTION
## Issue
The backup and restore features don't have unit tests.

## Solution
Add unit tests for 1/3 of the implemented methods.

The remaining 2/3 of unit tests were implemented on https://github.com/canonical/postgresql-k8s-operator/pull/164 and https://github.com/canonical/postgresql-k8s-operator/pull/165 to keep this PR small.

The logic that fixes slashes in the S3 path was moved in `src/backups.py` to handle that in the right place (after a default path is set).