### PR TITLE
Update OCI due to outadate pkgs

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -26,7 +26,7 @@ resources:
   postgresql-image:
     type: oci-image
     description: OCI image for PostgreSQL
-    upstream-source: ghcr.io/canonical/charmed-postgresql@sha256:0c03dd7143a71d276600cffbe1e321de30d5604ea21f6af5bb1e87876fb3d8a2
+    upstream-source: ghcr.io/canonical/charmed-postgresql@sha256:5c411734998e17a66b4cc0217b5741adf8a60dafc590be82cdd3610d0c1a49c8
 
 peers:
   database-peers:


### PR DESCRIPTION
## Issue
Security notification:
```
Revision r57 (amd64; channels: 14/edge)
 * libperl5.34: 6112-2
 * libpython3.10: 6139-1
 * perl: 6112-2
 * perl-modules-5.34: 6112-2
```

## Solution
Bump the OCI to update the packages