### PR TITLE
[DPE-2057] Enable Discourse-K8S test

### DIFF
--- a/src/relations/db.py
+++ b/src/relations/db.py
@@ -201,6 +201,8 @@ class DbProvides(Object):
             )
             return False
 
+        self._update_unit_status(relation)
+
         return True
 
     def _check_for_blocking_relations(self, relation_id: int) -> bool:
@@ -277,12 +279,15 @@ class DbProvides(Object):
                 f"Failed to delete user during {self.relation_name} relation broken event"
             )
 
-        # Clean up Blocked status if caused by the departed relation
+        self._update_unit_status(event.relation)
+
+    def _update_unit_status(self, relation: Relation) -> None:
+        """# Clean up Blocked status if it's due to extensions request."""
         if (
             self.charm._has_blocked_status
             and self.charm.unit.status.message == EXTENSIONS_BLOCKING_MESSAGE
         ):
-            if not self._check_for_blocking_relations(event.relation.id):
+            if not self._check_for_blocking_relations(relation.id):
                 self.charm.unit.status = ActiveStatus()
 
     def _get_allowed_subnets(self, relation: Relation) -> str:

--- a/src/relations/db.py
+++ b/src/relations/db.py
@@ -146,6 +146,9 @@ class DbProvides(Object):
             self.charm.postgresql.create_user(user, password, self.admin)
             self.charm.postgresql.create_database(database, user)
 
+            # Enable/disable extensions in the new database.
+            self.charm.enable_disable_extensions(database)
+
             # Build the primary's connection string.
             primary = str(
                 ConnectionString(

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -132,16 +132,19 @@ async def check_database_users_existence(
         assert user not in output
 
 
-async def check_database_creation(ops_test: OpsTest, database: str) -> None:
+async def check_database_creation(
+    ops_test: OpsTest, database: str, database_app_name: str = DATABASE_APP_NAME
+) -> None:
     """Checks that database and tables are successfully created for the application.
 
     Args:
         ops_test: The ops test framework
         database: Name of the database that should have been created
+        database_app_name: Application name of the database charm
     """
-    password = await get_password(ops_test)
+    password = await get_password(ops_test, database_app_name=database_app_name)
 
-    for unit in ops_test.model.applications[DATABASE_APP_NAME].units:
+    for unit in ops_test.model.applications[database_app_name].units:
         unit_address = await get_unit_address(ops_test, unit.name)
 
         # Ensure database exists in PostgreSQL.

--- a/tests/integration/test_db.py
+++ b/tests/integration/test_db.py
@@ -198,8 +198,11 @@ async def test_indico_db_blocked(ops_test: OpsTest) -> None:
             f"{database_application_name}:db", "indico1:db"
         )
         wait_for_relation_removed_between(ops_test, database_application_name, "indico1")
-        await ops_test.model.wait_for_idle(
-            apps=[database_application_name], status="active", idle_period=15, timeout=2000
+        await gather(
+            ops_test.model.wait_for_idle(
+                apps=[database_application_name], status="active", idle_period=15
+            ),
+            ops_test.model.wait_for_idle(apps=["indico1"], status="waiting", idle_period=15),
         )
 
         await ops_test.model.relate(f"{database_application_name}:db", "indico1:db")

--- a/tests/integration/test_db.py
+++ b/tests/integration/test_db.py
@@ -12,12 +12,15 @@ from tests.integration.helpers import (
     check_database_creation,
     check_database_users_existence,
     deploy_and_relate_application_with_postgresql,
+    get_primary,
     wait_for_relation_removed_between,
 )
 
 EXTENSIONS_BLOCKING_MESSAGE = "extensions requested through relation"
 FINOS_WALTZ_APP_NAME = "finos-waltz"
 ANOTHER_FINOS_WALTZ_APP_NAME = "another-finos-waltz"
+DISCOURSE_APP_NAME = "discourse-k8s"
+REDIS_APP_NAME = "redis-k8s"
 APPLICATION_UNITS = 1
 DATABASE_UNITS = 3
 
@@ -217,9 +220,62 @@ async def test_indico_db_blocked(ops_test: OpsTest) -> None:
 
         # Cleanup
         await gather(
-            ops_test.model.remove_application(database_application_name, block_until_done=True),
             ops_test.model.remove_application("indico1", block_until_done=True),
             ops_test.model.remove_application("indico2", block_until_done=True),
             ops_test.model.remove_application("redis-broker", block_until_done=True),
             ops_test.model.remove_application("redis-cache", block_until_done=True),
+        )
+
+
+async def test_discourse(ops_test: OpsTest):
+    database_application_name = f"extensions-{DATABASE_APP_NAME}"
+
+    # Deploy Discourse and Redis.
+    await gather(
+        ops_test.model.deploy(DISCOURSE_APP_NAME, application_name=DISCOURSE_APP_NAME),
+        ops_test.model.deploy(REDIS_APP_NAME, application_name=REDIS_APP_NAME),
+    )
+
+    # Add both relations to Discourse (PostgreSQL and Redis)
+    # and wait for it to be ready.
+    relation = await ops_test.model.add_relation(
+        f"{database_application_name}:db",
+        DISCOURSE_APP_NAME,
+    )
+    await ops_test.model.add_relation(
+        REDIS_APP_NAME,
+        DISCOURSE_APP_NAME,
+    )
+
+    # Discourse requests extensions through relation, so check that the PostgreSQL charm
+    # becomes blocked.
+    primary_name = await get_primary(ops_test, database_app_name=database_application_name)
+    async with ops_test.fast_forward():
+        await gather(
+            ops_test.model.block_until(
+                lambda: ops_test.model.units[primary_name].workload_status == "blocked", timeout=60
+            ),
+            ops_test.model.wait_for_idle(
+                apps=[REDIS_APP_NAME], status="active", timeout=2000
+            ),  # Redis sometimes takes a longer time to become active.
+        )
+        assert (
+            ops_test.model.units[primary_name].workload_status_message
+            == EXTENSIONS_BLOCKING_MESSAGE
+        )
+
+        # Enable the plugins/extensions required by Discourse.
+        config = {"plugin_hstore_enable": "True", "plugin_pg_trgm_enable": "True"}
+        await ops_test.model.applications[database_application_name].set_config(config)
+        await ops_test.model.wait_for_idle(
+            apps=[database_application_name, DISCOURSE_APP_NAME, REDIS_APP_NAME], status="active"
+        )
+
+        # Check for the correct databases and users creation.
+        await check_database_creation(
+            ops_test, "discourse", database_app_name=database_application_name
+        )
+        discourse_users = [f"relation_id_{relation.id}"]
+        await check_database_users_existence(
+            ops_test, discourse_users, [], database_app_name=database_application_name
         )

--- a/tests/integration/test_db.py
+++ b/tests/integration/test_db.py
@@ -198,11 +198,8 @@ async def test_indico_db_blocked(ops_test: OpsTest) -> None:
             f"{database_application_name}:db", "indico1:db"
         )
         wait_for_relation_removed_between(ops_test, database_application_name, "indico1")
-        await gather(
-            ops_test.model.wait_for_idle(
-                apps=[database_application_name], status="active", idle_period=15
-            ),
-            ops_test.model.wait_for_idle(apps=["indico1"], status="waiting", idle_period=15),
+        await ops_test.model.wait_for_idle(
+            apps=[database_application_name, "indico1"], status="active", idle_period=15
         )
 
         await ops_test.model.relate(f"{database_application_name}:db", "indico1:db")

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -1,0 +1,453 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import unittest
+from unittest.mock import Mock, PropertyMock, patch
+
+from charms.postgresql_k8s.v0.postgresql import (
+    PostgreSQLCreateDatabaseError,
+    PostgreSQLCreateUserError,
+    PostgreSQLGetPostgreSQLVersionError,
+)
+from ops.framework import EventBase
+from ops.model import ActiveStatus, BlockedStatus
+from ops.testing import Harness
+
+from charm import PostgresqlOperatorCharm
+from constants import DATABASE_PORT, PEER
+
+DATABASE = "test_database"
+RELATION_NAME = "db"
+POSTGRESQL_VERSION = "14"
+
+
+class TestDbProvides(unittest.TestCase):
+    @patch("charm.KubernetesServicePatch", lambda x, y: None)
+    def setUp(self):
+        self.harness = Harness(PostgresqlOperatorCharm)
+        self.addCleanup(self.harness.cleanup)
+
+        # Set up the initial relation and hooks.
+        self.harness.set_leader(True)
+        self.harness.begin()
+        self.app = self.harness.charm.app.name
+        self.unit = self.harness.charm.unit.name
+
+        # Define some relations.
+        self.rel_id = self.harness.add_relation(RELATION_NAME, "application")
+        self.harness.add_relation_unit(self.rel_id, "application/0")
+        self.peer_rel_id = self.harness.add_relation(PEER, self.app)
+        self.harness.add_relation_unit(self.peer_rel_id, f"{self.app}/1")
+        self.harness.add_relation_unit(self.peer_rel_id, self.unit)
+        self.harness.update_relation_data(
+            self.peer_rel_id,
+            self.app,
+            {"cluster_initialised": "True"},
+        )
+        self.legacy_db_relation = self.harness.charm.legacy_db_relation
+
+    def clear_relation_data(self):
+        data = {
+            "allowed-subnets": "",
+            "allowed-units": "",
+            "host": "",
+            "port": "",
+            "master": "",
+            "standbys": "",
+            "version": "",
+            "user": "",
+            "password": "",
+            "database": "",
+            "extensions": "",
+        }
+        self.harness.update_relation_data(self.rel_id, self.app, data)
+        self.harness.update_relation_data(self.rel_id, self.unit, data)
+
+    def request_database(self):
+        # Reset the charm status.
+        self.harness.model.unit.status = ActiveStatus()
+
+        with self.harness.hooks_disabled():
+            # Reset the application databag.
+            self.harness.update_relation_data(
+                self.rel_id,
+                "application/0",
+                {"database": ""},
+            )
+
+            # Reset the database databag.
+            self.clear_relation_data()
+
+        # Simulate the request of a new database.
+        self.harness.update_relation_data(
+            self.rel_id,
+            "application/0",
+            {"database": DATABASE},
+        )
+
+    @patch("charm.DbProvides.set_up_relation")
+    @patch.object(EventBase, "defer")
+    @patch("charm.Patroni.member_started", new_callable=PropertyMock)
+    def test_on_relation_changed(
+        self,
+        _member_started,
+        _defer,
+        _set_up_relation,
+    ):
+        # Set some side effects to test multiple situations.
+        _member_started.side_effect = [False, False, True, True]
+
+        # Request a database before the cluster is initialised.
+        self.request_database()
+        _defer.assert_called_once()
+        _set_up_relation.assert_not_called()
+
+        # Request a database before the database is ready.
+        with self.harness.hooks_disabled():
+            self.harness.update_relation_data(
+                self.peer_rel_id,
+                self.harness.charm.app.name,
+                {"cluster_initialised": "True"},
+            )
+        self.request_database()
+        self.assertEqual(_defer.call_count, 2)
+        _set_up_relation.assert_not_called()
+
+        # Request a database to a non leader unit.
+        _defer.reset_mock()
+        with self.harness.hooks_disabled():
+            self.harness.set_leader(False)
+        self.request_database()
+        _defer.assert_not_called()
+        _set_up_relation.assert_not_called()
+
+        # Request it again in a leader unit.
+        with self.harness.hooks_disabled():
+            self.harness.set_leader()
+        self.request_database()
+        _defer.assert_not_called()
+        _set_up_relation.assert_called_once()
+
+    @patch("charm.KubernetesServicePatch", lambda x, y: None)
+    def test_get_extensions(self):
+        # Test when there are no extensions in the relation databags.
+        relation = self.harness.model.get_relation(RELATION_NAME, self.rel_id)
+        self.assertEqual(
+            self.harness.charm.legacy_db_relation._get_extensions(relation), ([], set())
+        )
+
+        # Test when there are extensions in the application relation databag.
+        extensions = ["", "citext:public", "debversion"]
+        with self.harness.hooks_disabled():
+            self.harness.update_relation_data(
+                self.rel_id,
+                "application",
+                {"extensions": ",".join(extensions)},
+            )
+        self.assertEqual(
+            self.harness.charm.legacy_db_relation._get_extensions(relation),
+            ([extensions[1], extensions[2]], {extensions[1].split(":")[0], extensions[2]}),
+        )
+
+        # Test when there are extensions in the unit relation databag.
+        with self.harness.hooks_disabled():
+            self.harness.update_relation_data(
+                self.rel_id,
+                "application",
+                {"extensions": ""},
+            )
+            self.harness.update_relation_data(
+                self.rel_id,
+                "application/0",
+                {"extensions": ",".join(extensions)},
+            )
+        self.assertEqual(
+            self.harness.charm.legacy_db_relation._get_extensions(relation),
+            ([extensions[1], extensions[2]], {extensions[1].split(":")[0], extensions[2]}),
+        )
+
+        # Test when one of the plugins/extensions is enabled.
+        config = """options:
+          plugin_citext_enable:
+            default: true
+            type: boolean
+          plugin_debversion_enable:
+            default: false
+            type: boolean"""
+        harness = Harness(PostgresqlOperatorCharm, config=config)
+        self.addCleanup(harness.cleanup)
+        harness.begin()
+        self.assertEqual(
+            harness.charm.legacy_db_relation._get_extensions(relation),
+            ([extensions[1], extensions[2]], {extensions[2]}),
+        )
+
+    @patch("relations.db.DbProvides._update_unit_status")
+    @patch("charm.PostgresqlOperatorCharm.enable_disable_extensions")
+    @patch("relations.db.new_password", return_value="test-password")
+    @patch("relations.db.DbProvides._get_extensions")
+    def test_set_up_relation(
+        self,
+        _get_extensions,
+        _new_password,
+        _enable_disable_extensions,
+        _update_unit_status,
+    ):
+        with patch.object(PostgresqlOperatorCharm, "postgresql", Mock()) as postgresql_mock:
+            # Define some mocks' side effects.
+            extensions = ["citext:public", "debversion"]
+            _get_extensions.side_effect = [
+                (extensions, {"debversion"}),
+                (extensions, set()),
+                (extensions, set()),
+                (extensions, set()),
+                (extensions, set()),
+                (extensions, set()),
+                (extensions, set()),
+            ]
+            postgresql_mock.create_user = PropertyMock(
+                side_effect=[None, None, PostgreSQLCreateUserError, None, None]
+            )
+            postgresql_mock.create_database = PropertyMock(
+                side_effect=[None, None, PostgreSQLCreateDatabaseError, None]
+            )
+            postgresql_mock.get_postgresql_version = PropertyMock(
+                side_effect=[
+                    POSTGRESQL_VERSION,
+                    POSTGRESQL_VERSION,
+                    POSTGRESQL_VERSION,
+                    POSTGRESQL_VERSION,
+                    POSTGRESQL_VERSION,
+                    PostgreSQLGetPostgreSQLVersionError,
+                ]
+            )
+
+            # Assert no operation is done when at least one of the requested extensions
+            # is disabled.
+            relation = self.harness.model.get_relation(RELATION_NAME, self.rel_id)
+            self.assertFalse(self.harness.charm.legacy_db_relation.set_up_relation(relation))
+            postgresql_mock.create_user.assert_not_called()
+            postgresql_mock.create_database.assert_not_called()
+            _enable_disable_extensions.assert_not_called()
+            postgresql_mock.get_postgresql_version.assert_not_called()
+            _update_unit_status.assert_not_called()
+
+            # Assert that the correct calls were made in a successful setup.
+            self.harness.charm.unit.status = ActiveStatus()
+            with self.harness.hooks_disabled():
+                self.harness.update_relation_data(
+                    self.rel_id,
+                    "application",
+                    {"database": DATABASE},
+                )
+            self.assertTrue(self.harness.charm.legacy_db_relation.set_up_relation(relation))
+            user = f"relation_id_{self.rel_id}"
+            postgresql_mock.create_user.assert_called_once_with(user, "test-password", False)
+            postgresql_mock.create_database.assert_called_once_with(DATABASE, user)
+            _enable_disable_extensions.assert_called_once()
+            self.assertEqual(postgresql_mock.get_postgresql_version.call_count, 2)
+            _update_unit_status.assert_called_once()
+            expected_data = {
+                "allowed-units": "application/0",
+                "database": DATABASE,
+                "extensions": ",".join(extensions),
+                "host": f"postgresql-k8s-0.postgresql-k8s-endpoints.{self.harness.model.name}.svc.cluster.local",
+                "master": f"dbname={DATABASE} fallback_application_name=application "
+                f"host=postgresql-k8s-primary.{self.harness.model.name}.svc.cluster.local "
+                f"password=test-password port=5432 user=relation_id_{self.rel_id}",
+                "password": "test-password",
+                "port": DATABASE_PORT,
+                "standbys": f"dbname={DATABASE} fallback_application_name=application "
+                f"host=postgresql-k8s-replicas.{self.harness.model.name}.svc.cluster.local "
+                f"password=test-password port=5432 user=relation_id_{self.rel_id}",
+                "user": f"relation_id_{self.rel_id}",
+                "version": POSTGRESQL_VERSION,
+            }
+            self.assertEqual(self.harness.get_relation_data(self.rel_id, self.app), expected_data)
+            self.assertEqual(self.harness.get_relation_data(self.rel_id, self.unit), expected_data)
+            self.assertNotIsInstance(self.harness.model.unit.status, BlockedStatus)
+
+            # Assert that the correct calls were made when the database name is
+            # provided only in the unit databag.
+            postgresql_mock.create_user.reset_mock()
+            postgresql_mock.create_database.reset_mock()
+            _enable_disable_extensions.reset_mock()
+            postgresql_mock.get_postgresql_version.reset_mock()
+            _update_unit_status.reset_mock()
+            with self.harness.hooks_disabled():
+                self.harness.update_relation_data(
+                    self.rel_id,
+                    "application",
+                    {"database": ""},
+                )
+                self.harness.update_relation_data(
+                    self.rel_id,
+                    "application/0",
+                    {"database": DATABASE},
+                )
+                self.clear_relation_data()
+            self.assertTrue(self.harness.charm.legacy_db_relation.set_up_relation(relation))
+            postgresql_mock.create_user.assert_called_once_with(user, "test-password", False)
+            postgresql_mock.create_database.assert_called_once_with(DATABASE, user)
+            _enable_disable_extensions.assert_called_once()
+            self.assertEqual(postgresql_mock.get_postgresql_version.call_count, 2)
+            _update_unit_status.assert_called_once()
+            self.assertEqual(self.harness.get_relation_data(self.rel_id, self.app), expected_data)
+            self.assertEqual(self.harness.get_relation_data(self.rel_id, self.unit), expected_data)
+            self.assertNotIsInstance(self.harness.model.unit.status, BlockedStatus)
+
+            # Assert that the correct calls were made when the database name is not provided.
+            postgresql_mock.create_user.reset_mock()
+            postgresql_mock.create_database.reset_mock()
+            _enable_disable_extensions.reset_mock()
+            postgresql_mock.get_postgresql_version.reset_mock()
+            _update_unit_status.reset_mock()
+            with self.harness.hooks_disabled():
+                self.harness.update_relation_data(
+                    self.rel_id,
+                    "application/0",
+                    {"database": ""},
+                )
+                self.clear_relation_data()
+            self.assertFalse(self.harness.charm.legacy_db_relation.set_up_relation(relation))
+            postgresql_mock.create_user.assert_not_called()
+            postgresql_mock.create_database.assert_not_called()
+            _enable_disable_extensions.assert_not_called()
+            postgresql_mock.get_postgresql_version.assert_not_called()
+            _update_unit_status.assert_not_called()
+            # No data is set in the databags by the database.
+            self.assertEqual(self.harness.get_relation_data(self.rel_id, self.app), {})
+            self.assertEqual(self.harness.get_relation_data(self.rel_id, self.unit), {})
+            self.assertNotIsInstance(self.harness.model.unit.status, BlockedStatus)
+
+            # BlockedStatus due to a PostgreSQLCreateUserError.
+            with self.harness.hooks_disabled():
+                self.harness.update_relation_data(
+                    self.rel_id,
+                    "application",
+                    {"database": DATABASE},
+                )
+            self.assertFalse(self.harness.charm.legacy_db_relation.set_up_relation(relation))
+            postgresql_mock.create_database.assert_not_called()
+            _enable_disable_extensions.assert_not_called()
+            postgresql_mock.get_postgresql_version.assert_not_called()
+            _update_unit_status.assert_not_called()
+            self.assertIsInstance(self.harness.model.unit.status, BlockedStatus)
+            # No data is set in the databags by the database.
+            self.assertEqual(self.harness.get_relation_data(self.rel_id, self.app), {})
+            self.assertEqual(self.harness.get_relation_data(self.rel_id, self.unit), {})
+
+            # BlockedStatus due to a PostgreSQLCreateDatabaseError.
+            self.harness.charm.unit.status = ActiveStatus()
+            self.assertFalse(self.harness.charm.legacy_db_relation.set_up_relation(relation))
+            _enable_disable_extensions.assert_not_called()
+            postgresql_mock.get_postgresql_version.assert_not_called()
+            _update_unit_status.assert_not_called()
+            self.assertIsInstance(self.harness.model.unit.status, BlockedStatus)
+            # No data is set in the databags by the database.
+            self.assertEqual(self.harness.get_relation_data(self.rel_id, self.app), {})
+            self.assertEqual(self.harness.get_relation_data(self.rel_id, self.unit), {})
+
+            # BlockedStatus due to a PostgreSQLGetPostgreSQLVersionError.
+            self.harness.charm.unit.status = ActiveStatus()
+            self.assertFalse(self.harness.charm.legacy_db_relation.set_up_relation(relation))
+            _update_unit_status.assert_not_called()
+            self.assertIsInstance(self.harness.model.unit.status, BlockedStatus)
+
+    @patch("relations.db.DbProvides._check_for_blocking_relations")
+    @patch("charm.PostgresqlOperatorCharm._has_blocked_status", new_callable=PropertyMock)
+    def test_update_unit_status(self, _has_blocked_status, _check_for_blocking_relations):
+        # Test when the charm is not blocked.
+        relation = self.harness.model.get_relation(RELATION_NAME, self.rel_id)
+        _has_blocked_status.return_value = False
+        self.harness.charm.legacy_db_relation._update_unit_status(relation)
+        _check_for_blocking_relations.assert_not_called()
+        self.assertNotIsInstance(self.harness.charm.unit.status, ActiveStatus)
+
+        # Test when the charm is blocked but not due to extensions request.
+        _has_blocked_status.return_value = True
+        self.harness.charm.unit.status = BlockedStatus("fake message")
+        self.harness.charm.legacy_db_relation._update_unit_status(relation)
+        _check_for_blocking_relations.assert_not_called()
+        self.assertNotIsInstance(self.harness.charm.unit.status, ActiveStatus)
+
+        # Test when there are relations causing the blocked status.
+        self.harness.charm.unit.status = BlockedStatus("extensions requested through relation")
+        _check_for_blocking_relations.return_value = True
+        self.harness.charm.legacy_db_relation._update_unit_status(relation)
+        _check_for_blocking_relations.assert_called_once_with(relation.id)
+        self.assertNotIsInstance(self.harness.charm.unit.status, ActiveStatus)
+
+        # Test when there are no relations causing the blocked status anymore.
+        _check_for_blocking_relations.reset_mock()
+        _check_for_blocking_relations.return_value = False
+        self.harness.charm.legacy_db_relation._update_unit_status(relation)
+        _check_for_blocking_relations.assert_called_once_with(relation.id)
+        self.assertIsInstance(self.harness.charm.unit.status, ActiveStatus)
+
+    @patch(
+        "charm.PostgresqlOperatorCharm.primary_endpoint",
+        new_callable=PropertyMock,
+    )
+    @patch("charm.PostgresqlOperatorCharm._has_blocked_status", new_callable=PropertyMock)
+    @patch("charm.Patroni.member_started", new_callable=PropertyMock)
+    @patch("charm.DbProvides._on_relation_departed")
+    def test_on_relation_broken_extensions_unblock(
+        self, _on_relation_departed, _member_started, _primary_endpoint, _has_blocked_status
+    ):
+        with patch.object(PostgresqlOperatorCharm, "postgresql", Mock()) as postgresql_mock:
+            # Set some side effects to test multiple situations.
+            _has_blocked_status.return_value = True
+            _member_started.return_value = True
+            _primary_endpoint.return_value = {"1.1.1.1"}
+            postgresql_mock.delete_user = PropertyMock(return_value=None)
+            self.harness.model.unit.status = BlockedStatus("extensions requested through relation")
+            with self.harness.hooks_disabled():
+                self.harness.update_relation_data(
+                    self.rel_id,
+                    "application",
+                    {"database": DATABASE, "extensions": "test"},
+                )
+
+            # Break the relation that blocked the charm.
+            self.harness.remove_relation(self.rel_id)
+            self.assertTrue(isinstance(self.harness.model.unit.status, ActiveStatus))
+
+    @patch(
+        "charm.PostgresqlOperatorCharm.primary_endpoint",
+        new_callable=PropertyMock,
+    )
+    @patch("charm.PostgresqlOperatorCharm.is_blocked", new_callable=PropertyMock)
+    @patch("charm.Patroni.member_started", new_callable=PropertyMock)
+    @patch("charm.DbProvides._on_relation_departed")
+    def test_on_relation_broken_extensions_keep_block(
+        self, _on_relation_departed, _member_started, _primary_endpoint, is_blocked
+    ):
+        with patch.object(PostgresqlOperatorCharm, "postgresql", Mock()) as postgresql_mock:
+            # Set some side effects to test multiple situations.
+            is_blocked.return_value = True
+            _member_started.return_value = True
+            _primary_endpoint.return_value = {"1.1.1.1"}
+            postgresql_mock.delete_user = PropertyMock(return_value=None)
+            self.harness.model.unit.status = BlockedStatus(
+                "extensions requested through relation, enable them through config options"
+            )
+            with self.harness.hooks_disabled():
+                first_rel_id = self.harness.add_relation(RELATION_NAME, "application1")
+                self.harness.update_relation_data(
+                    first_rel_id,
+                    "application1",
+                    {"database": DATABASE, "extensions": "test"},
+                )
+                second_rel_id = self.harness.add_relation(RELATION_NAME, "application2")
+                self.harness.update_relation_data(
+                    second_rel_id,
+                    "application2",
+                    {"database": DATABASE, "extensions": "test"},
+                )
+
+            event = Mock()
+            event.relation.id = first_rel_id
+            # Break one of the relations that block the charm.
+            self.harness.charm.legacy_db_relation._on_relation_broken(event)
+            self.assertTrue(isinstance(self.harness.model.unit.status, BlockedStatus))


### PR DESCRIPTION
## Issue
The Discourse K8S charm test was disabled on https://github.com/canonical/postgresql-k8s-operator/pull/94 because it started to request extensions through the relation.

## Solution
In this PR, we enable the test back again and use the [new plugins/extensions support](https://github.com/canonical/postgresql-k8s-operator/pull/170) to make it work back again.

Now, Discourse needs only the `db` relations (rather than the `db-admin` relations, that was previously used by Discourse itself to install the extensions). So, the test was moved to the `db` relation integration test file.

Some unit tests were copied from https://github.com/canonical/postgresql-operator/pull/139 to improve the coverage of this charm.