### PR TITLE
[DPE-1916] Backup and restore log messages

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -820,6 +820,7 @@ class PostgresqlOperatorCharm(CharmBase):
 
         if "restoring-backup" in self.app_peer_data:
             if services[0].current != ServiceStatus.ACTIVE:
+                logger.error("Restore failed: database service failed to start")
                 self.unit.status = BlockedStatus("Failed to restore backup")
                 return
 
@@ -830,6 +831,7 @@ class PostgresqlOperatorCharm(CharmBase):
             # Remove the restoring backup flag and the restore stanza name.
             self.app_peer_data.update({"restoring-backup": "", "restore-stanza": ""})
             self.update_config()
+            logger.info("Restore succeeded")
 
             can_use_s3_repository, validation_message = self.backup.can_use_s3_repository()
             if not can_use_s3_repository:


### PR DESCRIPTION
## Issue
We are not logging the success or failure of both the `create-backup` and `restore` actions in a way that is easy for other applications to parse the logs related to success or failure on those operations.

## Solution
Log failures (as errors) and successes (as info) to the debug log. The failures have prefix `Backup failed`/`Restore failed`, the successes have prefix `Backup successful`/`Restore successful`.

The `Restore successful` message can be logged only after Patroni starts (which happens some time after the execution of the `restore` action).