### PR TITLE
Internal changes to the charm shouldn't be released

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,7 @@ on:
       - main
     paths-ignore:
       - 'tests/**'
+      - 'docs/**'
       - renovate.json
       - poetry.lock
       - pyproject.toml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,12 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'tests/**'
+      - renovate.json
+      - poetry.lock
+      - pyproject.toml
+      - '.github/**.md'
 
 jobs:
   ci-tests:


### PR DESCRIPTION
## Issue
Charm is published to charmhub on each push to main even if there are no changes to the charm itself

## Solution
Try to limit the amount of releases based on the content of the push