### PR TITLE
[DPE-2355] Fix upgrade changed event executing too early

### DIFF
--- a/src/upgrade.py
+++ b/src/upgrade.py
@@ -115,7 +115,7 @@ class PostgreSQLUpgrade(DataUpgrade):
 
     def _on_upgrade_changed(self, _) -> None:
         """Update the Patroni nosync tag in the unit if needed."""
-        if not self.peer_relation:
+        if not self.peer_relation or not self.charm._patroni.member_started:
             return
 
         self.charm.update_config()

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -149,8 +149,14 @@ class TestUpgrade(unittest.TestCase):
         _set_unit_failed.assert_not_called()
 
     @patch("charm.PostgresqlOperatorCharm.update_config")
-    def test_on_upgrade_changed(self, _update_config):
+    @patch("charm.Patroni.member_started", new_callable=PropertyMock)
+    def test_on_upgrade_changed(self, _member_started, _update_config):
+        _member_started.return_value = False
         relation = self.harness.model.get_relation("upgrade")
+        self.charm.on.upgrade_relation_changed.emit(relation)
+        _update_config.assert_not_called()
+
+        _member_started.return_value = True
         self.charm.on.upgrade_relation_changed.emit(relation)
         _update_config.assert_called_once()
 


### PR DESCRIPTION
## Issue
The upgrade changed event is being fired too early on https://github.com/canonical/pgbouncer-k8s-operator/actions/runs/5808523985/job/15745553754#step:7:228, which causes the errors, when the container is not available yet to connect and retrieve the ROCK PostgreSQL version.

## Solution
Run the event logic (call to `update_config`) only when needed (when the member is ready - during an pre upgrade check), and not when the charm starts.

Tested through https://github.com/canonical/pgbouncer-k8s-operator/pull/126.