### PR TITLE
[DPE-2392] Fix storage for upgrade

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -68,7 +68,6 @@ storage:
   pgdata:
     type: filesystem
     location: /var/lib/postgresql/data
-    description: Persistent storage for PostgreSQL data
 
 assumes:
   - k8s-api


### PR DESCRIPTION
## Issue
We cannot upgrade from `14/stable` to `14/edge` due to storage changes:
```sh
➜  ~ juju deploy postgresql-k8s --channel 14/stable --trust
Located charm "postgresql-k8s" in charm-hub, revision 73
Deploying "postgresql-k8s" from charm-hub charm "postgresql-k8s", revision 73 in channel 14/stable on jammy

➜  ~ juju refresh postgresql-k8s --channel 14/edge
Added charm-hub charm "postgresql-k8s", revision 117 in channel 14/edge, to the model
ERROR Juju on containers does not support updating storage on a statefulset.
The new charm's metadata contains updated storage declarations.
You'll need to deploy a new charm rather than upgrading if you need this change.
 not supported (not supported)
```

Juju issue: https://bugs.launchpad.net/juju/+bug/1995074

## Solution
The change that broke the possibility of the upgrade was only the addition of the storage description, so it was removed in this PR to allow the charm to upgrade from `14/stable` to the revision that will be published to `14/edge`.

Users already using revisions from channels other than `14/stable` will then see the above error message when they try to upgrade to the latest revision from the `14/edge` channel.