### PR TITLE
[MISC] Temporarily disable indico tests on Juju 3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -122,10 +122,10 @@ jobs:
             echo "mark_expression=" >> $GITHUB_OUTPUT
           else
             echo Skipping unstable tests
-            echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
+            echo "mark_expression=and not unstable" >> $GITHUB_OUTPUT
           fi
       - name: Run integration tests
-        run: tox run -e ${{ matrix.tox-environments }}-${{ env.libjuju }} -- -m '${{ steps.select-tests.outputs.mark_expression }}'
+        run: tox run -e ${{ matrix.tox-environments }}-${{ env.libjuju }} -- -m 'not not${{ env.libjuju }} ${{ steps.select-tests.outputs.mark_expression }}' --keep-models
         env:
           AWS_ACCESS_KEY: "${{ secrets.AWS_ACCESS_KEY }}"
           AWS_SECRET_KEY: "${{ secrets.AWS_SECRET_KEY }}"

--- a/tests/integration/test_db.py
+++ b/tests/integration/test_db.py
@@ -4,6 +4,7 @@
 import logging
 from asyncio import gather
 
+import pytest
 from pytest_operator.plugin import OpsTest
 
 from tests.integration.helpers import (
@@ -88,6 +89,7 @@ async def test_finos_waltz_db(ops_test: OpsTest) -> None:
         await ops_test.model.remove_application(DATABASE_APP_NAME, block_until_done=True)
 
 
+@pytest.mark.notjuju3
 async def test_indico_db_blocked(ops_test: OpsTest) -> None:
     """Tests if deploying and relating to Indico charm will block due to requested extensions."""
     async with ops_test.fast_forward(fast_interval="30s"):
@@ -229,6 +231,8 @@ async def test_indico_db_blocked(ops_test: OpsTest) -> None:
 
 async def test_discourse(ops_test: OpsTest):
     database_application_name = f"extensions-{DATABASE_APP_NAME}"
+    if database_application_name not in ops_test.model.applications:
+        await build_and_deploy(ops_test, 1, database_application_name)
 
     # Deploy Discourse and Redis.
     await gather(


### PR DESCRIPTION
## Issue
The indico legacy rel test is failing frequently on juju 3. Indico seems stuck in idle/active until the test times out or is cancelled.

## Solution
Temporarily disable the test.
Checking if things are better in juju 3.1.6 on https://github.com/canonical/postgresql-k8s-operator/pull/249