### PR TITLE
DPE-2616 Basic profile support

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -26,3 +26,11 @@ options:
     default: false
     type: boolean
     description: Enable unaccent extension
+  profile:
+   description: |
+      Profile representing the scope of deployment, and used to tune resource allocation.
+      Allowed values are: “production” and “testing”.
+      Production will tune postgresql for maximum performance while testing will tune for
+      minimal running performance.
+   type: string
+   default: production

--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -19,7 +19,7 @@ The `postgresql` module provides methods for interacting with the PostgreSQL ins
 Any charm using this library should import the `psycopg2` or `psycopg2-binary` dependency.
 """
 import logging
-from typing import List, Set, Tuple
+from typing import List, Optional, Set, Tuple
 
 import psycopg2
 from psycopg2 import sql
@@ -32,7 +32,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 12
+LIBPATCH = 13
 
 INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE = "invalid role(s) for extra user roles"
 
@@ -419,3 +419,20 @@ class PostgreSQL:
         finally:
             if connection is not None:
                 connection.close()
+
+    @staticmethod
+    def build_postgresql_parameters(
+        profile: str, available_memory: int
+    ) -> Optional[dict[str, str]]:
+        """Builds the PostgreSQL parameters.
+
+        Args:
+            profile: the profile to use.
+            available_memory: available memory to use in calculation
+
+        Returns:
+            Dictionary with the PostgreSQL parameters.
+        """
+        logger.debug(f"Building PostgreSQL parameters for {profile=} and {available_memory=}")
+        if profile == "production":
+            return {"shared_buffers": "987MB", "effective_cache_size": "2958MB"}

--- a/src/charm.py
+++ b/src/charm.py
@@ -1313,6 +1313,7 @@ class PostgresqlOperatorCharm(CharmBase):
             backup_id=self.app_peer_data.get("restoring-backup"),
             stanza=self.app_peer_data.get("stanza"),
             restore_stanza=self.app_peer_data.get("restore-stanza"),
+            parameters=self.postgresql.build_postgresql_parameters(self.config["profile"], 0),
         )
         if not self._is_workload_running:
             # If Patroni/PostgreSQL has not started yet and TLS relations was initialised,

--- a/src/patroni.py
+++ b/src/patroni.py
@@ -290,6 +290,7 @@ class Patroni:
         stanza: str = None,
         restore_stanza: Optional[str] = None,
         backup_id: Optional[str] = None,
+        parameters: Optional[dict[str, str]] = None,
     ) -> None:
         """Render the Patroni configuration file.
 
@@ -302,6 +303,7 @@ class Patroni:
             stanza: name of the stanza created by pgBackRest.
             restore_stanza: name of the stanza used when restoring a backup.
             backup_id: id of the backup that is being restored.
+            parameters: PostgreSQL parameters to be added to the postgresql.conf file.
         """
         # Open the template patroni.yml file.
         with open("templates/patroni.yml.j2", "r") as file:
@@ -327,6 +329,7 @@ class Patroni:
             restore_stanza=restore_stanza,
             minority_count=self._members_count // 2,
             version=self.rock_postgresql_version.split(".")[0],
+            pg_parameters=parameters,
         )
         self._render_file(f"{self._storage_path}/patroni.yml", rendered, 0o644)
 

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -39,7 +39,7 @@ bootstrap:
         wal_level: logical
         {%- if pg_parameters %}
         {%- for key, value in pg_parameters.items() %}
-        {{key}} {{value}}
+        {{key}}: {{value}}
         {%- endfor -%}
         {% endif %}
   {%- if restoring_backup %}

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -37,6 +37,11 @@ bootstrap:
         log_truncate_on_rotation: 'on'
         logging_collector: 'on'
         wal_level: logical
+        {%- if pg_parameters %}
+        {%- for key, value in pg_parameters.items() %}
+        {{key}} {{value}}
+        {%- endfor -%}
+        {% endif %}
   {%- if restoring_backup %}
   method: pgbackrest
   pgbackrest:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -77,6 +77,7 @@ async def build_and_deploy(
         trust=True,
         num_units=num_units,
         series=CHARM_SERIES,
+        config={"profile": "testing"},
     ),
     if wait_for_idle:
         # Wait until the PostgreSQL charm is successfully deployed.

--- a/tests/integration/new_relations/test_new_relations.py
+++ b/tests/integration/new_relations/test_new_relations.py
@@ -65,6 +65,7 @@ async def test_database_relation_with_charm_libraries(ops_test: OpsTest, databas
                 num_units=3,
                 series=CHARM_SERIES,
                 trust=True,
+                config={"profile": "testing"},
             ),
             ops_test.model.deploy(
                 database_charm,
@@ -77,6 +78,7 @@ async def test_database_relation_with_charm_libraries(ops_test: OpsTest, databas
                 num_units=3,
                 series=CHARM_SERIES,
                 trust=True,
+                config={"profile": "testing"},
             ),
         )
         # Relate the charms and wait for them exchanging some connection data.

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -313,6 +313,7 @@ async def test_redeploy_charm_same_model(ops_test: OpsTest):
             num_units=len(UNIT_IDS),
             series=CHARM_SERIES,
             trust=True,
+            config={"profile": "testing"},
         )
 
         # This check is enough to ensure that the charm/workload is working for this specific test.
@@ -339,6 +340,7 @@ async def test_storage_with_more_restrictive_permissions(ops_test: OpsTest):
                 num_units=1,
                 series=CHARM_SERIES,
                 trust=True,
+                config={"profile": "testing"},
             )
 
         # Restrict the permissions of the storage.

--- a/tests/integration/test_password_rotation.py
+++ b/tests/integration/test_password_rotation.py
@@ -33,6 +33,7 @@ async def test_deploy_active(ops_test: OpsTest):
             num_units=3,
             series=CHARM_SERIES,
             trust=True,
+            config={"profile": "testing"},
         )
         await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
 


### PR DESCRIPTION
## Issue

Profiles support missing from PG

## Solution

* Created method to build postgresql parameters, based on profile.
* using patroni template to configure parameters
* defaults to `production` profiles (better performance, as done for mysql)
* parameter building is a MVP:
  * `testing` profile set no extra parameters
  * `production` set's minimal needs for IS scenarios (see follow-up)
  * has `available_memory` input, but is not in use: logic is TBD
* integration tests uses `testing` profile

## Folow-up PRs

1. Proper memory detection for parameter calculation
1. React `on-config-change` to allow inflight profile change