### PR TITLE
[DPE-2626][DPE-2627] Create bucket once and clear up blocked statuses

### DIFF
--- a/src/backups.py
+++ b/src/backups.py
@@ -34,6 +34,12 @@ FAILED_TO_ACCESS_CREATE_BUCKET_ERROR_MESSAGE = (
 )
 FAILED_TO_INITIALIZE_STANZA_ERROR_MESSAGE = "failed to initialize stanza, check your S3 settings"
 
+S3_BLOCK_MESSAGES = [
+    ANOTHER_CLUSTER_REPOSITORY_ERROR_MESSAGE,
+    FAILED_TO_ACCESS_CREATE_BUCKET_ERROR_MESSAGE,
+    FAILED_TO_INITIALIZE_STANZA_ERROR_MESSAGE,
+]
+
 
 class PostgreSQLBackups(Object):
     """In this class, we manage PostgreSQL backups."""
@@ -50,6 +56,7 @@ class PostgreSQLBackups(Object):
         self.framework.observe(
             self.s3_client.on.credentials_changed, self._on_s3_credential_changed
         )
+        self.framework.observe(self.s3_client.on.credentials_gone, self._on_s3_credential_gone)
         self.framework.observe(self.charm.on.create_backup_action, self._on_create_backup_action)
         self.framework.observe(self.charm.on.list_backups_action, self._on_list_backups_action)
         self.framework.observe(self.charm.on.restore_action, self._on_restore_action)
@@ -140,6 +147,9 @@ class PostgreSQLBackups(Object):
         return endpoint
 
     def _create_bucket_if_not_exists(self) -> None:
+        if not self.charm.unit.is_leader():
+            return
+
         s3_parameters, missing_parameters = self._retrieve_s3_parameters()
         if missing_parameters:
             return
@@ -501,6 +511,10 @@ Stderr:
 
         self.charm.update_config(is_creating_backup=False)
         self.charm.unit.status = ActiveStatus()
+
+    def _on_s3_credential_gone(self, _) -> None:
+        if self.charm.is_blocked and self.charm.unit.status.message in S3_BLOCK_MESSAGES:
+            self.charm.unit.status = ActiveStatus()
 
     def _on_list_backups_action(self, event) -> None:
         """List the previously created backups."""

--- a/src/backups.py
+++ b/src/backups.py
@@ -147,9 +147,6 @@ class PostgreSQLBackups(Object):
         return endpoint
 
     def _create_bucket_if_not_exists(self) -> None:
-        if not self.charm.unit.is_leader():
-            return
-
         s3_parameters, missing_parameters = self._retrieve_s3_parameters()
         if missing_parameters:
             return
@@ -377,6 +374,10 @@ class PostgreSQLBackups(Object):
 
         if not self._render_pgbackrest_conf_file():
             logger.debug("Cannot set pgBackRest configurations, missing configurations.")
+            return
+
+        # Verify the s3 relation only on the leader
+        if not self.charm.unit.is_leader():
             return
 
         try:

--- a/tests/unit/test_backups.py
+++ b/tests/unit/test_backups.py
@@ -278,7 +278,7 @@ class TestPostgreSQLBackups(unittest.TestCase):
         self.charm.backup._create_bucket_if_not_exists()
         _resource.assert_not_called()
 
-        # Test when the charm fails to create a boto3 session.
+        # Test when unit is not leader.
         _retrieve_s3_parameters.return_value = (
             {
                 "bucket": "test-bucket",
@@ -289,6 +289,16 @@ class TestPostgreSQLBackups(unittest.TestCase):
             },
             [],
         )
+
+        create = _resource.return_value.Bucket.return_value.create
+        self.charm.backup._create_bucket_if_not_exists()
+        create.assert_not_called()
+        create.reset_mock()
+
+        # Test when the charm fails to create a boto3 session.
+        with self.harness.hooks_disabled():
+            self.harness.set_leader()
+
         _resource.side_effect = ValueError
         with self.assertRaises(ValueError):
             self.charm.backup._create_bucket_if_not_exists()


### PR DESCRIPTION
## Issue
* All units try to create a bucket and all units will block if it fails
* Backup blocked statuses are not cleared if the s3 relation is removed.

## Solution
* Only the leader should check the s3 creds and bucket
* Clear up the blocked statuses when the s3 creds are gone