### PR TITLE
[DPE-2664] Fix empty data files on remote storage

### DIFF
--- a/src/backups.py
+++ b/src/backups.py
@@ -187,11 +187,7 @@ class PostgreSQLBackups(Object):
     def _empty_data_files(self) -> None:
         """Empty the PostgreSQL data directory in preparation of backup restore."""
         try:
-            self.container.exec(
-                "rm -r /var/lib/postgresql/data/pgdata".split(),
-                user="postgres",
-                group="postgres",
-            ).wait_output()
+            self.container.exec("rm -r /var/lib/postgresql/data/pgdata".split()).wait_output()
         except ExecError as e:
             logger.exception(
                 "Failed to empty data directory in prep for backup restore", exc_info=e
@@ -593,6 +589,9 @@ Stderr:
             event.fail(error_message)
             self._restart_database()
             return
+
+        logger.info("Creating PostgreSQL data directory")
+        self.charm._create_pgdata(self.container)
 
         # Mark the cluster as in a restoring backup state and update the Patroni configuration.
         logger.info("Configuring Patroni to restore the backup")

--- a/tests/unit/test_backups.py
+++ b/tests/unit/test_backups.py
@@ -335,13 +335,13 @@ class TestPostgreSQLBackups(unittest.TestCase):
         _exec.side_effect = ExecError(command=command, exit_code=1, stdout="", stderr="fake error")
         with self.assertRaises(ExecError):
             self.charm.backup._empty_data_files()
-        _exec.assert_called_once_with(command, user="postgres", group="postgres")
+        _exec.assert_called_once_with(command)
 
         # Test when data files are successfully removed.
         _exec.reset_mock()
         _exec.side_effect = None
         self.charm.backup._empty_data_files()
-        _exec.assert_called_once_with(command, user="postgres", group="postgres")
+        _exec.assert_called_once_with(command)
 
     @patch("charm.PostgresqlOperatorCharm.update_config")
     def test_change_connectivity_to_database(self, _update_config):
@@ -914,6 +914,7 @@ Juju Version: test-juju-version
 
     @patch("ops.model.Container.start")
     @patch("charm.PostgresqlOperatorCharm.update_config")
+    @patch("charm.PostgresqlOperatorCharm._create_pgdata")
     @patch("charm.PostgreSQLBackups._empty_data_files")
     @patch("charm.PostgreSQLBackups._restart_database")
     @patch("lightkube.Client.delete")
@@ -928,6 +929,7 @@ Juju Version: test-juju-version
         _delete,
         _restart_database,
         _empty_data_files,
+        _create_pgdata,
         _update_config,
         _start,
     ):
@@ -941,6 +943,7 @@ Juju Version: test-juju-version
         _delete.assert_not_called()
         _restart_database.assert_not_called()
         _empty_data_files.assert_not_called()
+        _create_pgdata.assert_not_called()
         _update_config.assert_not_called()
         _start.assert_not_called()
         mock_event.fail.assert_not_called()
@@ -959,6 +962,7 @@ Juju Version: test-juju-version
         _delete.assert_not_called()
         _restart_database.assert_not_called()
         _empty_data_files.assert_not_called()
+        _create_pgdata.assert_not_called()
         _update_config.assert_not_called()
         _start.assert_not_called()
         mock_event.set_results.assert_not_called()
@@ -987,6 +991,7 @@ Juju Version: test-juju-version
         _delete.assert_not_called()
         _restart_database.assert_not_called()
         _empty_data_files.assert_not_called()
+        _create_pgdata.assert_not_called()
         _update_config.assert_not_called()
         _start.assert_not_called()
         mock_event.set_results.assert_not_called()
@@ -1001,6 +1006,7 @@ Juju Version: test-juju-version
         mock_event.fail.assert_called_once()
         _restart_database.assert_called_once()
         _empty_data_files.assert_not_called()
+        _create_pgdata.assert_not_called()
         _update_config.assert_not_called()
         _start.assert_not_called()
         mock_event.set_results.assert_not_called()
@@ -1016,6 +1022,7 @@ Juju Version: test-juju-version
         _empty_data_files.assert_called_once()
         mock_event.fail.assert_called_once()
         _restart_database.assert_called_once()
+        _create_pgdata.assert_not_called()
         _update_config.assert_not_called()
         _start.assert_not_called()
         mock_event.set_results.assert_not_called()
@@ -1034,6 +1041,7 @@ Juju Version: test-juju-version
                 "restore-stanza": f"{self.charm.model.name}.{self.charm.cluster_name}",
             },
         )
+        _create_pgdata.assert_called_once()
         _update_config.assert_called_once()
         _start.assert_called_once_with("postgresql")
         mock_event.fail.assert_not_called()


### PR DESCRIPTION
## Issue
The data directory cannot be deleted during the restore operation on storages provided by external providers (like EBS and cloud storages).

## Solution
Remove and recreate the data directory using the root user, which has privileges in the mounted storage.

Fixes https://github.com/canonical/postgresql-k8s-operator/issues/265.