### PR TITLE
[DPE-2657] Fix replication after restore

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -464,14 +464,13 @@ class PostgresqlOperatorCharm(CharmBase):
 
         # Restart the workload if it's stuck on the starting state after a timeline divergence
         # due to a backup that was restored.
-        if (
-            not self.is_primary
-            and (self._patroni.member_replication_lag == "unknown"
-            or int(self._patroni.member_replication_lag) > 1000)
+        if not self.is_primary and (
+            self._patroni.member_replication_lag == "unknown"
+            or int(self._patroni.member_replication_lag) > 1000
         ):
             self._patroni.reinitialize_postgresql()
-            logger.debug("Deferring on_peer_relation_changed: reinitializing replica")
-            self.unit.status = WaitingStatus("reinitializing replica")
+            logger.debug("Deferring on_peer_relation_changed: reinitialising replica")
+            self.unit.status = WaitingStatus("reinitialising replica")
             event.defer()
             return
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -462,6 +462,19 @@ class PostgresqlOperatorCharm(CharmBase):
             event.defer()
             return
 
+        # Restart the workload if it's stuck on the starting state after a timeline divergence
+        # due to a backup that was restored.
+        if (
+            not self.is_primary
+            and (self._patroni.member_replication_lag == "unknown"
+            or int(self._patroni.member_replication_lag) > 1000)
+        ):
+            self._patroni.reinitialize_postgresql()
+            logger.debug("Deferring on_peer_relation_changed: reinitializing replica")
+            self.unit.status = WaitingStatus("reinitializing replica")
+            event.defer()
+            return
+
         self.postgresql_client_relation.update_read_only_endpoint()
 
         self.backup.check_stanza()


### PR DESCRIPTION
## Issue
If we have a cluster of two or more units, scale it down to 1 unit, create a backup, restore the backup and scale up back again, the replication stop working due to reuse of the storage.

## Solution
In that situation, as we see a huge replication lag, we need to reinitialise the replicas.

Fixes https://github.com/canonical/postgresql-k8s-operator/issues/262.