### PR TITLE
Change Patroni dashboard labels to display unit.

### DIFF
--- a/src/grafana_dashboards/postgresql-patroni-metrics.json
+++ b/src/grafana_dashboards/postgresql-patroni-metrics.json
@@ -1360,7 +1360,7 @@
           "hide": false,
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{service_name}}",
+          "legendFormat": "{{juju_unit}}",
           "range": true,
           "refId": "A"
         }
@@ -1470,7 +1470,7 @@
           "hide": false,
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{service_name}}",
+          "legendFormat": "{{juju_unit}}",
           "range": true,
           "refId": "A"
         }
@@ -1601,7 +1601,7 @@
           "format": "time_series",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{service_name}}",
+          "legendFormat": "{{juju_unit}}",
           "range": true,
           "refId": "A"
         }
@@ -1710,7 +1710,7 @@
           "instant": false,
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{service_name}}",
+          "legendFormat": "{{juju_unit}}",
           "range": true,
           "refId": "A"
         }
@@ -1819,7 +1819,7 @@
           "instant": false,
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{service_name}}",
+          "legendFormat": "{{juju_unit}}",
           "range": true,
           "refId": "A"
         }
@@ -1928,7 +1928,7 @@
           "instant": false,
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{service_name}}",
+          "legendFormat": "{{juju_unit}}",
           "range": true,
           "refId": "A"
         }


### PR DESCRIPTION
## Issue
The Patroni dashboard displays an undecipherable string as the labels for graphs.

## Solution
Switch labels to juju_unit.

<img width="1404" alt="Screenshot 2023-09-29 at 17 42 08" src="https://github.com/canonical/postgresql-k8s-operator/assets/24707086/3eb1fde2-3a0c-4700-bd86-ca966fe57c2c">


Fixes #274 