### PR TITLE
[DPE-2569] Extensions not enabled when database is created

### DIFF
--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -285,7 +285,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 PYDEPS = ["pydantic>=1.10,<2", "poetry-core"]
 
@@ -894,6 +894,10 @@ class DataUpgrade(Object, ABC):
                     return
             self.charm.unit.status = WaitingStatus("other units upgrading first...")
             self.peer_relation.data[self.charm.unit].update({"state": "ready"})
+
+            if self.charm.app.planned_units() == 1:
+                # single unit upgrade, emit upgrade_granted event right away
+                getattr(self.on, "upgrade_granted").emit()
 
         else:
             # for k8s run version checks only on highest ordinal unit

--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -117,12 +117,13 @@ class PostgreSQL:
         connection.autocommit = True
         return connection
 
-    def create_database(self, database: str, user: str) -> None:
+    def create_database(self, database: str, user: str, plugins: List[str] = []) -> None:
         """Creates a new database and grant privileges to a user on it.
 
         Args:
             database: database to be created.
             user: user that will have access to the database.
+            plugins: extensions to enable in the new database.
         """
         try:
             connection = self._connect_to_database()
@@ -169,6 +170,10 @@ class PostgreSQL:
         except psycopg2.Error as e:
             logger.error(f"Failed to create database: {e}")
             raise PostgreSQLCreateDatabaseError()
+
+        # Enable preset extensions
+        for plugin in plugins:
+            self.enable_disable_extension(plugin, True, database)
 
     def create_user(
         self, user: str, password: str = None, admin: bool = False, extra_user_roles: str = None

--- a/src/relations/db.py
+++ b/src/relations/db.py
@@ -144,7 +144,13 @@ class DbProvides(Object):
             user = f"relation_id_{relation.id}"
             password = unit_relation_databag.get("password", new_password())
             self.charm.postgresql.create_user(user, password, self.admin)
-            self.charm.postgresql.create_database(database, user)
+            plugins = [
+                "_".join(plugin.split("_")[1:-1])
+                for plugin in self.charm.config.plugin_keys()
+                if self.charm.config[plugin]
+            ]
+
+            self.charm.postgresql.create_database(database, user, plugins=plugins)
 
             # Enable/disable extensions in the new database.
             self.charm.enable_disable_extensions(database)

--- a/src/relations/postgresql_provider.py
+++ b/src/relations/postgresql_provider.py
@@ -85,7 +85,13 @@ class PostgreSQLProvider(Object):
             user = f"relation_id_{event.relation.id}"
             password = new_password()
             self.charm.postgresql.create_user(user, password, extra_user_roles=extra_user_roles)
-            self.charm.postgresql.create_database(database, user)
+            plugins = [
+                "_".join(plugin.split("_")[1:-1])
+                for plugin in self.charm.config.plugin_keys()
+                if self.charm.config[plugin]
+            ]
+
+            self.charm.postgresql.create_database(database, user, plugins=plugins)
 
             # Share the credentials with the application.
             self.database_provides.set_credentials(event.relation.id, user, password)

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -243,7 +243,7 @@ class TestDbProvides(unittest.TestCase):
             self.assertTrue(self.harness.charm.legacy_db_relation.set_up_relation(relation))
             user = f"relation_id_{self.rel_id}"
             postgresql_mock.create_user.assert_called_once_with(user, "test-password", False)
-            postgresql_mock.create_database.assert_called_once_with(DATABASE, user)
+            postgresql_mock.create_database.assert_called_once_with(DATABASE, user, plugins=[])
             _enable_disable_extensions.assert_called_once()
             self.assertEqual(postgresql_mock.get_postgresql_version.call_count, 2)
             _update_unit_status.assert_called_once()
@@ -288,7 +288,7 @@ class TestDbProvides(unittest.TestCase):
                 self.clear_relation_data()
             self.assertTrue(self.harness.charm.legacy_db_relation.set_up_relation(relation))
             postgresql_mock.create_user.assert_called_once_with(user, "test-password", False)
-            postgresql_mock.create_database.assert_called_once_with(DATABASE, user)
+            postgresql_mock.create_database.assert_called_once_with(DATABASE, user, plugins=[])
             _enable_disable_extensions.assert_called_once()
             self.assertEqual(postgresql_mock.get_postgresql_version.call_count, 2)
             _update_unit_status.assert_called_once()


### PR DESCRIPTION
## Issue
New databases do not consider already enabled extensions.

## Solution
Check extensions conf when creating a database and enable extensions.