### PR TITLE
Add new extensions/plugins

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -26,6 +26,98 @@ options:
     default: false
     type: boolean
     description: Enable unaccent extension
+  plugin_bloom_enable:
+    default: false
+    type: boolean
+    description: Enable bloom extension
+  plugin_btree_gin_enable:
+    default: false
+    type: boolean
+    description: Enable btree_gin extension
+  plugin_btree_gist_enable:
+    default: false
+    type: boolean
+    description: Enable btree_gist extension
+  plugin_cube_enable:
+    default: false
+    type: boolean
+    description: Enable cube extension
+  plugin_dict_int_enable:
+    default: false
+    type: boolean
+    description: Enable dict_int extension
+  plugin_dict_xsyn_enable:
+    default: false
+    type: boolean
+    description: Enable dict_xsyn extension
+  plugin_earthdistance_enable:
+    default: false
+    type: boolean
+    description: Enable earthdistance extension
+  plugin_fuzzystrmatch_enable:
+    default: false
+    type: boolean
+    description: Enable fuzzystrmatch extension
+  plugin_intarray_enable:
+    default: false
+    type: boolean
+    description: Enable intarray extension
+  plugin_isn_enable:
+    default: false
+    type: boolean
+    description: Enable isn extension
+  plugin_lo_enable:
+    default: false
+    type: boolean
+    description: Enable lo extension
+  plugin_ltree_enable:
+    default: false
+    type: boolean
+    description: Enable ltree extension
+  plugin_old_snapshot_enable:
+    default: false
+    type: boolean
+    description: Enable old_snapshot extension
+  plugin_pg_freespacemap_enable:
+    default: false
+    type: boolean
+    description: Enable pg_freespacemap extension
+  plugin_pgrowlocks_enable:
+    default: false
+    type: boolean
+    description: Enable pgrowlocks extension
+  plugin_pgstattuple_enable:
+    default: false
+    type: boolean
+    description: Enable pgstattuple extension
+  plugin_pg_visibility_enable:
+    default: false
+    type: boolean
+    description: Enable pg_visibility extension
+  plugin_seg_enable:
+    default: false
+    type: boolean
+    description: Enable seg extension
+  plugin_tablefunc_enable:
+    default: false
+    type: boolean
+    description: Enable tablefunc extension
+  plugin_tcn_enable:
+    default: false
+    type: boolean
+    description: Enable tcn extension
+  plugin_tsm_system_rows_enable:
+    default: false
+    type: boolean
+    description: Enable tsm_system_rows extension
+  plugin_tsm_system_time_enable:
+    default: false
+    type: boolean
+    description: Enable tsm_system_time extension
+  plugin_uuid_ossp_enable:
+    default: false
+    type: boolean
+    description: Enable uuid_ossp extension
   profile:
    description: |
       Profile representing the scope of deployment, and used to tune resource allocation.

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -320,7 +320,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 19
+LIBPATCH = 20
 
 PYDEPS = ["ops>=2.0.0"]
 
@@ -1673,6 +1673,10 @@ class DatabaseRequires(DataRequires):
         relation = self.charm.model.get_relation(self.relation_name, relation_id)
         if relation:
             relation.data[self.local_unit].update({"alias": available_aliases[0]})
+
+        # We need to set relation alias also on the application level so,
+        # it will be accessible in show-unit juju command, executed for a consumer application unit
+        self.update_relation_data(relation_id, {"alias": available_aliases[0]})
 
     def _emit_aliased_event(self, event: RelationChangedEvent, event_name: str) -> None:
         """Emit an aliased event to a particular relation if it has an alias.

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -285,7 +285,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 PYDEPS = ["pydantic>=1.10,<2", "poetry-core"]
 
@@ -894,6 +894,10 @@ class DataUpgrade(Object, ABC):
                     return
             self.charm.unit.status = WaitingStatus("other units upgrading first...")
             self.peer_relation.data[self.charm.unit].update({"state": "ready"})
+
+            if self.charm.app.planned_units() == 1:
+                # single unit upgrade, emit upgrade_granted event right away
+                getattr(self.on, "upgrade_granted").emit()
 
         else:
             # for k8s run version checks only on highest ordinal unit

--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -32,7 +32,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 16
+LIBPATCH = 17
 
 INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE = "invalid role(s) for extra user roles"
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -28,7 +28,7 @@ resources:
   postgresql-image:
     type: oci-image
     description: OCI image for PostgreSQL
-    upstream-source: ghcr.io/canonical/charmed-postgresql@sha256:1517d0053d6c039b42b5e2820c8f7a3eb13b67eee2b101fd1f562216eb4179ca
+    upstream-source: ghcr.io/canonical/charmed-postgresql@sha256:a6aa592506aa4cda85b63f66e1c9d079088ca7c9d84ed4bba9442dea36ec3f17
 
 peers:
   database-peers:

--- a/src/charm.py
+++ b/src/charm.py
@@ -555,6 +555,8 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             enable = self.config[plugin]
             # Enable or disable the plugin/extension.
             extension = "_".join(plugin.split("_")[1:-1])
+            if extension == "uuid_ossp":
+                extension = '"uuid-ossp"'
             self.unit.status = WaitingStatus(
                 f"{'Enabling' if enable else 'Disabling'} {extension}"
             )

--- a/src/config.py
+++ b/src/config.py
@@ -23,6 +23,29 @@ class CharmConfig(BaseConfigModel):
     plugin_pg_trgm_enable: bool
     plugin_plpython3u_enable: bool
     plugin_unaccent_enable: bool
+    plugin_bloom_enable: bool
+    plugin_btree_gin_enable: bool
+    plugin_btree_gist_enable: bool
+    plugin_cube_enable: bool
+    plugin_dict_int_enable: bool
+    plugin_dict_xsyn_enable: bool
+    plugin_earthdistance_enable: bool
+    plugin_fuzzystrmatch_enable: bool
+    plugin_intarray_enable: bool
+    plugin_isn_enable: bool
+    plugin_lo_enable: bool
+    plugin_ltree_enable: bool
+    plugin_old_snapshot_enable: bool
+    plugin_pg_freespacemap_enable: bool
+    plugin_pgrowlocks_enable: bool
+    plugin_pgstattuple_enable: bool
+    plugin_pg_visibility_enable: bool
+    plugin_seg_enable: bool
+    plugin_tablefunc_enable: bool
+    plugin_tcn_enable: bool
+    plugin_tsm_system_rows_enable: bool
+    plugin_tsm_system_time_enable: bool
+    plugin_uuid_ossp_enable: bool
 
     @classmethod
     def keys(cls) -> list[str]:

--- a/tests/integration/test_db.py
+++ b/tests/integration/test_db.py
@@ -229,6 +229,7 @@ async def test_indico_db_blocked(ops_test: OpsTest) -> None:
         )
 
 
+@pytest.mark.skip(reason="Should be ported and moved to the new relation tests")
 async def test_discourse(ops_test: OpsTest):
     database_application_name = f"extensions-{DATABASE_APP_NAME}"
     if database_application_name not in ops_test.model.applications:

--- a/tests/integration/test_plugins.py
+++ b/tests/integration/test_plugins.py
@@ -24,6 +24,35 @@ HSTORE_EXTENSION_STATEMENT = "CREATE TABLE hstore_test (value hstore);"
 PG_TRGM_EXTENSION_STATEMENT = "SELECT word_similarity('word', 'two words');"
 PLPYTHON3U_EXTENSION_STATEMENT = 'CREATE FUNCTION plpython_test() RETURNS varchar[] AS $$ return "hello" $$ LANGUAGE plpython3u;'
 UNACCENT_EXTENSION_STATEMENT = "SELECT ts_lexize('unaccent','Hôtel');"
+BLOOM_EXTENSION_STATEMENT = (
+    "CREATE TABLE tbloom_test (i int);CREATE INDEX btreeidx ON tbloom_test USING bloom (i);"
+)
+BTREEGIN_EXTENSION_STATEMENT = "CREATE TABLE btree_gin_test (a int4);CREATE INDEX btreeginidx ON btree_gin_test USING GIN (a);"
+BTREEGIST_EXTENSION_STATEMENT = "CREATE TABLE btree_gist_test (a int4);CREATE INDEX btreegistidx ON btree_gist_test USING GIST (a);"
+CUBE_EXTENSION_STATEMENT = "SELECT cube_inter('(0,-1),(1,1)', '(-2),(2)');"
+DICTINT_EXTENSION_STATEMENT = "SELECT ts_lexize('intdict', '12345678');"
+DICTXSYN_EXTENSION_STATEMENT = "SELECT ts_lexize('xsyn', 'word');"
+EARTHDISTANCE_EXTENSION_STATEMENT = "SELECT earth_distance(ll_to_earth(-81.3927381, 30.2918842),ll_to_earth(-87.6473133, 41.8853881));"
+FUZZYSTRMATCH_EXTENSION_STATEMENT = "SELECT soundex('hello world!');"
+INTARRAY_EXTENSION_STATEMENT = "CREATE TABLE intarray_test (mid INT PRIMARY KEY, sections INT[]);SELECT intarray_test.mid FROM intarray_test WHERE intarray_test.sections @> '{1,2}';"
+ISN_EXTENSION_STATEMENT = "SELECT isbn('978-0-393-04002-9');"
+LO_EXTENSION_STATEMENT = "CREATE TABLE lo_test (value lo);"
+LTREE_EXTENSION_STATEMENT = "CREATE TABLE ltree_test (path ltree);"
+OLD_SNAPSHOT_EXTENSION_STATEMENT = "SELECT * from pg_old_snapshot_time_mapping();"
+PG_FREESPACEMAP_EXTENSION_STATEMENT = (
+    "CREATE TABLE pg_freespacemap_test (i int);SELECT * FROM pg_freespace('pg_freespacemap_test');"
+)
+PGROWLOCKS_EXTENSION_STATEMENT = (
+    "CREATE TABLE pgrowlocks_test (i int);SELECT * FROM pgrowlocks('pgrowlocks_test');"
+)
+PGSTATTUPLE_EXTENSION_STATEMENT = "SELECT * FROM pgstattuple('pg_catalog.pg_proc');"
+PG_VISIBILITY_EXTENSION_STATEMENT = "CREATE TABLE pg_visibility_test (i int);SELECT * FROM pg_visibility('pg_visibility_test'::regclass);"
+SEG_EXTENSION_STATEMENT = "SELECT '10(+-)1'::seg as seg;"
+TABLEFUNC_EXTENSION_STATEMENT = "SELECT * FROM normal_rand(1000, 5, 3);"
+TCN_EXTENSION_STATEMENT = "CREATE TABLE tcn_test (i int);CREATE TRIGGER tcn_test_idx AFTER INSERT OR UPDATE OR DELETE ON tcn_test FOR EACH ROW EXECUTE FUNCTION TRIGGERED_CHANGE_NOTIFICATION();"
+TSM_SYSTEM_ROWS_EXTENSION_STATEMENT = "CREATE TABLE tsm_system_rows_test (i int);SELECT * FROM tsm_system_rows_test TABLESAMPLE SYSTEM_ROWS(100);"
+TSM_SYSTEM_TIME_EXTENSION_STATEMENT = "CREATE TABLE tsm_system_time_test (i int);SELECT * FROM tsm_system_time_test TABLESAMPLE SYSTEM_TIME(1000);"
+UUID_OSSP_EXTENSION_STATEMENT = "SELECT uuid_nil();"
 
 
 @pytest.mark.abort_on_fail
@@ -64,6 +93,98 @@ async def test_plugins(ops_test: OpsTest) -> None:
         # Test unaccent extension disabled.
         with pytest.raises(psycopg2.Error):
             connection.cursor().execute(UNACCENT_EXTENSION_STATEMENT)
+
+        # Test bloom extension disabled.
+        with pytest.raises(psycopg2.Error):
+            connection.cursor().execute(BLOOM_EXTENSION_STATEMENT)
+
+        # Test btree_gin extension disabled.
+        with pytest.raises(psycopg2.Error):
+            connection.cursor().execute(BTREEGIN_EXTENSION_STATEMENT)
+
+        # Test btree_gist extension disabled.
+        with pytest.raises(psycopg2.Error):
+            connection.cursor().execute(BTREEGIST_EXTENSION_STATEMENT)
+
+        # Test cube extension disabled.
+        with pytest.raises(psycopg2.Error):
+            connection.cursor().execute(CUBE_EXTENSION_STATEMENT)
+
+        # Test dict_int extension disabled.
+        with pytest.raises(psycopg2.Error):
+            connection.cursor().execute(DICTINT_EXTENSION_STATEMENT)
+
+        # Test dict_xsyn extension disabled.
+        with pytest.raises(psycopg2.Error):
+            connection.cursor().execute(DICTXSYN_EXTENSION_STATEMENT)
+
+        # Test earthdistance extension disabled.
+        with pytest.raises(psycopg2.Error):
+            connection.cursor().execute(EARTHDISTANCE_EXTENSION_STATEMENT)
+
+        # Test fuzzystrmatch extension disabled.
+        with pytest.raises(psycopg2.Error):
+            connection.cursor().execute(FUZZYSTRMATCH_EXTENSION_STATEMENT)
+
+        # Test intarray extension disabled.
+        with pytest.raises(psycopg2.Error):
+            connection.cursor().execute(INTARRAY_EXTENSION_STATEMENT)
+
+        # Test isn extension disabled.
+        with pytest.raises(psycopg2.Error):
+            connection.cursor().execute(ISN_EXTENSION_STATEMENT)
+
+        # Test lo extension disabled.
+        with pytest.raises(psycopg2.Error):
+            connection.cursor().execute(LO_EXTENSION_STATEMENT)
+
+        # Test ltree extension disabled.
+        with pytest.raises(psycopg2.Error):
+            connection.cursor().execute(LTREE_EXTENSION_STATEMENT)
+
+        # Test old_snapshot extension disabled.
+        with pytest.raises(psycopg2.Error):
+            connection.cursor().execute(OLD_SNAPSHOT_EXTENSION_STATEMENT)
+
+        # Test pg_freespacemap extension disabled.
+        with pytest.raises(psycopg2.Error):
+            connection.cursor().execute(PG_FREESPACEMAP_EXTENSION_STATEMENT)
+
+        # Test pgrowlocks extension disabled.
+        with pytest.raises(psycopg2.Error):
+            connection.cursor().execute(PGROWLOCKS_EXTENSION_STATEMENT)
+
+        # Test pgstattuple extension disabled.
+        with pytest.raises(psycopg2.Error):
+            connection.cursor().execute(PGSTATTUPLE_EXTENSION_STATEMENT)
+
+        # Test pg_visibility extension disabled.
+        with pytest.raises(psycopg2.Error):
+            connection.cursor().execute(PG_VISIBILITY_EXTENSION_STATEMENT)
+
+        # Test seg extension disabled.
+        with pytest.raises(psycopg2.Error):
+            connection.cursor().execute(SEG_EXTENSION_STATEMENT)
+
+        # Test tablefunc extension disabled.
+        with pytest.raises(psycopg2.Error):
+            connection.cursor().execute(TABLEFUNC_EXTENSION_STATEMENT)
+
+        # Test tcn extension disabled.
+        with pytest.raises(psycopg2.Error):
+            connection.cursor().execute(TCN_EXTENSION_STATEMENT)
+
+        # Test tsm_system_rows extension disabled.
+        with pytest.raises(psycopg2.Error):
+            connection.cursor().execute(TSM_SYSTEM_ROWS_EXTENSION_STATEMENT)
+
+        # Test tsm_system_time extension disabled.
+        with pytest.raises(psycopg2.Error):
+            connection.cursor().execute(TSM_SYSTEM_TIME_EXTENSION_STATEMENT)
+
+        # Test uuid_ossp extension disabled.
+        with pytest.raises(psycopg2.Error):
+            connection.cursor().execute(UUID_OSSP_EXTENSION_STATEMENT)
     connection.close()
 
     # Enable the plugins.
@@ -75,6 +196,29 @@ async def test_plugins(ops_test: OpsTest) -> None:
         "plugin_pg_trgm_enable": "True",
         "plugin_plpython3u_enable": "True",
         "plugin_unaccent_enable": "True",
+        "plugin_bloom_enable": "True",
+        "plugin_btree_gin_enable": "True",
+        "plugin_btree_gist_enable": "True",
+        "plugin_cube_enable": "True",
+        "plugin_dict_int_enable": "True",
+        "plugin_dict_xsyn_enable": "True",
+        "plugin_earthdistance_enable": "True",
+        "plugin_fuzzystrmatch_enable": "True",
+        "plugin_intarray_enable": "True",
+        "plugin_isn_enable": "True",
+        "plugin_lo_enable": "True",
+        "plugin_ltree_enable": "True",
+        "plugin_old_snapshot_enable": "True",
+        "plugin_pg_freespacemap_enable": "True",
+        "plugin_pgrowlocks_enable": "True",
+        "plugin_pgstattuple_enable": "True",
+        "plugin_pg_visibility_enable": "True",
+        "plugin_seg_enable": "True",
+        "plugin_tablefunc_enable": "True",
+        "plugin_tcn_enable": "True",
+        "plugin_tsm_system_rows_enable": "True",
+        "plugin_tsm_system_time_enable": "True",
+        "plugin_uuid_ossp_enable": "True",
     }
     await ops_test.model.applications[DATABASE_APP_NAME].set_config(config)
     await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME], status="active")
@@ -101,4 +245,73 @@ async def test_plugins(ops_test: OpsTest) -> None:
 
         # Test unaccent extension enabled.
         connection.cursor().execute(UNACCENT_EXTENSION_STATEMENT)
+
+        # Test bloom extension enabled.
+        connection.cursor().execute(BLOOM_EXTENSION_STATEMENT)
+
+        # Test btree_gin extension enabled.
+        connection.cursor().execute(BTREEGIN_EXTENSION_STATEMENT)
+
+        # Test btree_gist extension enabled.
+        connection.cursor().execute(BTREEGIST_EXTENSION_STATEMENT)
+
+        # Test cube extension enabled.
+        connection.cursor().execute(CUBE_EXTENSION_STATEMENT)
+
+        # Test dict_int extension enabled.
+        connection.cursor().execute(DICTINT_EXTENSION_STATEMENT)
+
+        # Test dict_xsyn extension enabled.
+        connection.cursor().execute(DICTXSYN_EXTENSION_STATEMENT)
+
+        # Test earthdistance extension enabled.
+        connection.cursor().execute(EARTHDISTANCE_EXTENSION_STATEMENT)
+
+        # Test fuzzystrmatch extension enabled.
+        connection.cursor().execute(FUZZYSTRMATCH_EXTENSION_STATEMENT)
+
+        # Test intarray extension enabled.
+        connection.cursor().execute(INTARRAY_EXTENSION_STATEMENT)
+
+        # Test isn extension enabled.
+        connection.cursor().execute(ISN_EXTENSION_STATEMENT)
+
+        # Test lo extension enabled.
+        connection.cursor().execute(LO_EXTENSION_STATEMENT)
+
+        # Test ltree extension enabled.
+        connection.cursor().execute(LTREE_EXTENSION_STATEMENT)
+
+        # Test old_snapshot extension enabled.
+        connection.cursor().execute(OLD_SNAPSHOT_EXTENSION_STATEMENT)
+
+        # Test pg_freespacemap extension enabled.
+        connection.cursor().execute(PG_FREESPACEMAP_EXTENSION_STATEMENT)
+
+        # Test pgrowlocks extension enabled.
+        connection.cursor().execute(PGROWLOCKS_EXTENSION_STATEMENT)
+
+        # Test pgstattuple extension enabled.
+        connection.cursor().execute(PGSTATTUPLE_EXTENSION_STATEMENT)
+
+        # Test pg_visibility extension enabled.
+        connection.cursor().execute(PG_VISIBILITY_EXTENSION_STATEMENT)
+
+        # Test seg extension enabled.
+        connection.cursor().execute(SEG_EXTENSION_STATEMENT)
+
+        # Test tablefunc extension enabled.
+        connection.cursor().execute(TABLEFUNC_EXTENSION_STATEMENT)
+
+        # Test tcn extension enabled.
+        connection.cursor().execute(TCN_EXTENSION_STATEMENT)
+
+        # Test tsm_system_rows extension enabled.
+        connection.cursor().execute(TSM_SYSTEM_ROWS_EXTENSION_STATEMENT)
+
+        # Test tsm_system_time extension enabled.
+        connection.cursor().execute(TSM_SYSTEM_TIME_EXTENSION_STATEMENT)
+
+        # Test uuid_ossp extension enabled.
+        connection.cursor().execute(UUID_OSSP_EXTENSION_STATEMENT)
     connection.close()


### PR DESCRIPTION
## Issue
The list of supported plugins was too short: https://charmhub.io/postgresql-k8s/docs/r-supported-plugins-extensions

## Solution
Add new extensions/plugins:

bloom
btree_gin
btree_gist
cube
dict_int
dict_xsyn
earthdistance
fuzzystrmatch
intarray
isn
lo
ltree
old_snapshot
pg_freespacemap
pgrowlocks
pgstattuple
pg_visibility
seg
tablefunc
tcn
tsm_system_rows
tsm_system_time
uuid-ossp