### PR TITLE
[DPE-2804] Split off lib-check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,21 +51,6 @@ jobs:
       - name: Run tests
         run: tox run -e unit-${{ matrix.juju-version }}
 
-  lib-check:
-    name: Check libraries
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
-        with:
-          fetch-depth: 0
-      - name: Check libs
-        uses: canonical/charming-actions/check-libraries@2.4.0
-        with:
-          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
   build:
     name: Build charms
     uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v2
@@ -93,7 +78,6 @@ jobs:
           - "3.1.5"  # renovate: latest juju 3
     name: ${{ matrix.tox-environments }} | ${{ matrix.agent-versions }}
     needs:
-      - lib-check
       - lint
       - unit-test
       - build

--- a/.github/workflows/lib-check.yaml
+++ b/.github/workflows/lib-check.yaml
@@ -1,0 +1,38 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+name: Check libs
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    paths-ignore:
+      - '.gitignore'
+      - '.jujuignore'
+      - 'LICENSE'
+      - '**.md'
+      - 'renovate.json'
+  schedule:
+    - cron: '53 0 * * *' # Daily at 00:53 UTC
+  # Triggered on push to branch "main" by .github/workflows/release.yaml
+  workflow_call:
+
+jobs:
+  lib-check:
+    name: Check libraries
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.event.pull_request.head.repo.full_name == 'canonical/postgresql-k8s-operator' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+        with:
+          fetch-depth: 0
+      - name: Check libs
+        uses: canonical/charming-actions/check-libraries@2.4.0
+        with:
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,7 @@ on:
       - pyproject.toml
       - '.github/**.md'
       - '.github/workflows/ci.yaml'
+      - '.github/workflows/lib-check.yaml'
 
 jobs:
   ci-tests:

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -263,7 +263,7 @@ class ZooKeeperCharm(CharmBase):
 import json
 import logging
 from abc import ABC, abstractmethod
-from typing import List, Literal, Optional, Set, Tuple
+from typing import Dict, List, Literal, Optional, Set, Tuple
 
 import poetry.core.constraints.version as poetry_version
 from ops.charm import (
@@ -285,7 +285,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 14
+LIBPATCH = 15
 
 PYDEPS = ["pydantic>=1.10,<2", "poetry-core"]
 
@@ -346,7 +346,7 @@ class DependencyModel(BaseModel):
         print(model.dict())  # exporting back validated deps
     """
 
-    dependencies: dict[str, str]
+    dependencies: Dict[str, str]
     name: str
     upgrade_supported: str
     version: str


### PR DESCRIPTION
## Issue
Checking charm libs requires credentials that are not available to contributors outside of the DPE team.

## Solution
Split the checking action in a separate workflow that is not run on forked PRs.