### PR TITLE
[DPE-2903] Toggle plugins in one go

### DIFF
--- a/src/relations/db.py
+++ b/src/relations/db.py
@@ -152,9 +152,6 @@ class DbProvides(Object):
 
             self.charm.postgresql.create_database(database, user, plugins=plugins)
 
-            # Enable/disable extensions in the new database.
-            self.charm.enable_disable_extensions(database)
-
             # Build the primary's connection string.
             primary = str(
                 ConnectionString(

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -183,14 +183,12 @@ class TestDbProvides(unittest.TestCase):
         )
 
     @patch("relations.db.DbProvides._update_unit_status")
-    @patch("charm.PostgresqlOperatorCharm.enable_disable_extensions")
     @patch("relations.db.new_password", return_value="test-password")
     @patch("relations.db.DbProvides._get_extensions")
     def test_set_up_relation(
         self,
         _get_extensions,
         _new_password,
-        _enable_disable_extensions,
         _update_unit_status,
     ):
         with patch.object(PostgresqlOperatorCharm, "postgresql", Mock()) as postgresql_mock:
@@ -228,7 +226,6 @@ class TestDbProvides(unittest.TestCase):
             self.assertFalse(self.harness.charm.legacy_db_relation.set_up_relation(relation))
             postgresql_mock.create_user.assert_not_called()
             postgresql_mock.create_database.assert_not_called()
-            _enable_disable_extensions.assert_not_called()
             postgresql_mock.get_postgresql_version.assert_not_called()
             _update_unit_status.assert_not_called()
 
@@ -244,7 +241,6 @@ class TestDbProvides(unittest.TestCase):
             user = f"relation_id_{self.rel_id}"
             postgresql_mock.create_user.assert_called_once_with(user, "test-password", False)
             postgresql_mock.create_database.assert_called_once_with(DATABASE, user, plugins=[])
-            _enable_disable_extensions.assert_called_once()
             self.assertEqual(postgresql_mock.get_postgresql_version.call_count, 2)
             _update_unit_status.assert_called_once()
             expected_data = {
@@ -271,7 +267,6 @@ class TestDbProvides(unittest.TestCase):
             # provided only in the unit databag.
             postgresql_mock.create_user.reset_mock()
             postgresql_mock.create_database.reset_mock()
-            _enable_disable_extensions.reset_mock()
             postgresql_mock.get_postgresql_version.reset_mock()
             _update_unit_status.reset_mock()
             with self.harness.hooks_disabled():
@@ -289,7 +284,6 @@ class TestDbProvides(unittest.TestCase):
             self.assertTrue(self.harness.charm.legacy_db_relation.set_up_relation(relation))
             postgresql_mock.create_user.assert_called_once_with(user, "test-password", False)
             postgresql_mock.create_database.assert_called_once_with(DATABASE, user, plugins=[])
-            _enable_disable_extensions.assert_called_once()
             self.assertEqual(postgresql_mock.get_postgresql_version.call_count, 2)
             _update_unit_status.assert_called_once()
             self.assertEqual(self.harness.get_relation_data(self.rel_id, self.app), expected_data)
@@ -299,7 +293,6 @@ class TestDbProvides(unittest.TestCase):
             # Assert that the correct calls were made when the database name is not provided.
             postgresql_mock.create_user.reset_mock()
             postgresql_mock.create_database.reset_mock()
-            _enable_disable_extensions.reset_mock()
             postgresql_mock.get_postgresql_version.reset_mock()
             _update_unit_status.reset_mock()
             with self.harness.hooks_disabled():
@@ -312,7 +305,6 @@ class TestDbProvides(unittest.TestCase):
             self.assertFalse(self.harness.charm.legacy_db_relation.set_up_relation(relation))
             postgresql_mock.create_user.assert_not_called()
             postgresql_mock.create_database.assert_not_called()
-            _enable_disable_extensions.assert_not_called()
             postgresql_mock.get_postgresql_version.assert_not_called()
             _update_unit_status.assert_not_called()
             # No data is set in the databags by the database.
@@ -329,7 +321,6 @@ class TestDbProvides(unittest.TestCase):
                 )
             self.assertFalse(self.harness.charm.legacy_db_relation.set_up_relation(relation))
             postgresql_mock.create_database.assert_not_called()
-            _enable_disable_extensions.assert_not_called()
             postgresql_mock.get_postgresql_version.assert_not_called()
             _update_unit_status.assert_not_called()
             self.assertIsInstance(self.harness.model.unit.status, BlockedStatus)
@@ -340,7 +331,6 @@ class TestDbProvides(unittest.TestCase):
             # BlockedStatus due to a PostgreSQLCreateDatabaseError.
             self.harness.charm.unit.status = ActiveStatus()
             self.assertFalse(self.harness.charm.legacy_db_relation.set_up_relation(relation))
-            _enable_disable_extensions.assert_not_called()
             postgresql_mock.get_postgresql_version.assert_not_called()
             _update_unit_status.assert_not_called()
             self.assertIsInstance(self.harness.model.unit.status, BlockedStatus)


### PR DESCRIPTION
## Issue
Starting a connection for each db to enable or disable plugins will take more and more time as the number of plugins increases.

## Solution
Open a single connection per db and enable or disable the plugins in one go.