### PR TITLE
[DPE-2740] Handle tables ownership

### DIFF
--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -22,7 +22,9 @@ import logging
 from typing import Dict, List, Optional, Set, Tuple
 
 import psycopg2
+from ops.model import Relation
 from psycopg2 import sql
+from psycopg2.sql import Composed
 
 # The unique Charmhub library identifier, never change it
 LIBID = "24ee217a54e840a598ff21a079c3e678"
@@ -32,7 +34,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 20
+LIBPATCH = 21
 
 INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE = "invalid role(s) for extra user roles"
 
@@ -117,13 +119,20 @@ class PostgreSQL:
         connection.autocommit = True
         return connection
 
-    def create_database(self, database: str, user: str, plugins: List[str] = []) -> None:
+    def create_database(
+        self,
+        database: str,
+        user: str,
+        plugins: List[str] = [],
+        client_relations: List[Relation] = [],
+    ) -> None:
         """Creates a new database and grant privileges to a user on it.
 
         Args:
             database: database to be created.
             user: user that will have access to the database.
             plugins: extensions to enable in the new database.
+            client_relations: current established client relations.
         """
         try:
             connection = self._connect_to_database()
@@ -142,29 +151,20 @@ class PostgreSQL:
                         sql.Identifier(database), sql.Identifier(user_to_grant_access)
                     )
                 )
+            relations_accessing_this_database = 0
+            for relation in client_relations:
+                for data in relation.data.values():
+                    if data.get("database") == database:
+                        relations_accessing_this_database += 1
             with self._connect_to_database(database=database) as conn:
                 with conn.cursor() as curs:
-                    statements = []
                     curs.execute(
                         "SELECT schema_name FROM information_schema.schemata WHERE schema_name NOT LIKE 'pg_%' and schema_name <> 'information_schema';"
                     )
-                    for row in curs:
-                        schema = sql.Identifier(row[0])
-                        statements.append(
-                            sql.SQL(
-                                "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA {} TO {};"
-                            ).format(schema, sql.Identifier(user))
-                        )
-                        statements.append(
-                            sql.SQL(
-                                "GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA {} TO {};"
-                            ).format(schema, sql.Identifier(user))
-                        )
-                        statements.append(
-                            sql.SQL(
-                                "GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA {} TO {};"
-                            ).format(schema, sql.Identifier(user))
-                        )
+                    schemas = [row[0] for row in curs.fetchall()]
+                    statements = self._generate_database_privileges_statements(
+                        relations_accessing_this_database, schemas, user
+                    )
                     for statement in statements:
                         curs.execute(statement)
         except psycopg2.Error as e:
@@ -307,6 +307,55 @@ class PostgreSQL:
         finally:
             if connection is not None:
                 connection.close()
+
+    def _generate_database_privileges_statements(
+        self, relations_accessing_this_database: int, schemas: List[str], user: str
+    ) -> List[Composed]:
+        """Generates a list of databases privileges statements."""
+        statements = []
+        if relations_accessing_this_database == 1:
+            statements.append(
+                sql.SQL(
+                    """DO $$
+DECLARE r RECORD;
+BEGIN
+  FOR r IN (SELECT statement FROM (SELECT 1 AS index,'ALTER TABLE '|| schemaname || '."' || tablename ||'" OWNER TO {};' AS statement
+FROM pg_tables WHERE NOT schemaname IN ('pg_catalog', 'information_schema')
+UNION SELECT 2 AS index,'ALTER SEQUENCE '|| sequence_schema || '."' || sequence_name ||'" OWNER TO {};' AS statement
+FROM information_schema.sequences WHERE NOT sequence_schema IN ('pg_catalog', 'information_schema')
+UNION SELECT 3 AS index,'ALTER FUNCTION '|| nsp.nspname || '."' || p.proname ||'"('||pg_get_function_identity_arguments(p.oid)||') OWNER TO {};' AS statement
+FROM pg_proc p JOIN pg_namespace nsp ON p.pronamespace = nsp.oid WHERE NOT nsp.nspname IN ('pg_catalog', 'information_schema')
+UNION SELECT 4 AS index,'ALTER VIEW '|| schemaname || '."' || viewname ||'" OWNER TO {};' AS statement
+FROM pg_catalog.pg_views WHERE NOT schemaname IN ('pg_catalog', 'information_schema')) AS statements ORDER BY index) LOOP
+      EXECUTE format(r.statement);
+  END LOOP;
+END; $$;"""
+                ).format(
+                    sql.Identifier(user),
+                    sql.Identifier(user),
+                    sql.Identifier(user),
+                    sql.Identifier(user),
+                )
+            )
+        else:
+            for schema in schemas:
+                schema = sql.Identifier(schema)
+                statements.append(
+                    sql.SQL("GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA {} TO {};").format(
+                        schema, sql.Identifier(user)
+                    )
+                )
+                statements.append(
+                    sql.SQL("GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA {} TO {};").format(
+                        schema, sql.Identifier(user)
+                    )
+                )
+                statements.append(
+                    sql.SQL("GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA {} TO {};").format(
+                        schema, sql.Identifier(user)
+                    )
+                )
+        return statements
 
     def get_postgresql_text_search_configs(self) -> Set[str]:
         """Returns the PostgreSQL available text search configs.

--- a/src/charm.py
+++ b/src/charm.py
@@ -1512,6 +1512,15 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
 
         return cpu_cores, allocable_memory
 
+    @property
+    def client_relations(self) -> List[Relation]:
+        """Return the list of established client relations."""
+        relations = []
+        for relation_name in ["database", "db", "db-admin"]:
+            for relation in self.model.relations.get(relation_name, []):
+                relations.append(relation)
+        return relations
+
 
 if __name__ == "__main__":
     main(PostgresqlOperatorCharm, use_juju_for_storage=True)

--- a/src/relations/db.py
+++ b/src/relations/db.py
@@ -150,7 +150,9 @@ class DbProvides(Object):
                 if self.charm.config[plugin]
             ]
 
-            self.charm.postgresql.create_database(database, user, plugins=plugins)
+            self.charm.postgresql.create_database(
+                database, user, plugins=plugins, client_relations=self.charm.client_relations
+            )
 
             # Build the primary's connection string.
             primary = str(

--- a/src/relations/postgresql_provider.py
+++ b/src/relations/postgresql_provider.py
@@ -91,7 +91,9 @@ class PostgreSQLProvider(Object):
                 if self.charm.config[plugin]
             ]
 
-            self.charm.postgresql.create_database(database, user, plugins=plugins)
+            self.charm.postgresql.create_database(
+                database, user, plugins=plugins, client_relations=self.charm.client_relations
+            )
 
             # Share the credentials with the application.
             self.database_provides.set_credentials(event.relation.id, user, password)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -716,6 +716,21 @@ class TestCharm(unittest.TestCase):
             self.assertEqual(_client.return_value.apply.call_count, 2)
             self.assertIn("failed to patch k8s MagicMock", "".join(logs.output))
 
+    def test_client_relations(self):
+        # Test when the charm has no relations.
+        self.assertEqual(self.charm.client_relations, [])
+
+        # Test when the charm has some relations.
+        self.harness.add_relation("database", "application")
+        self.harness.add_relation("db", "legacy-application")
+        self.harness.add_relation("db-admin", "legacy-admin-application")
+        database_relation = self.harness.model.get_relation("database")
+        db_relation = self.harness.model.get_relation("db")
+        db_admin_relation = self.harness.model.get_relation("db-admin")
+        self.assertEqual(
+            self.charm.client_relations, [database_relation, db_relation, db_admin_relation]
+        )
+
     @parameterized.expand([("app"), ("unit")])
     @pytest.mark.usefixtures("only_with_juju_secrets")
     def test_set_secret_returning_secret_label(self, scope):

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -240,7 +240,9 @@ class TestDbProvides(unittest.TestCase):
             self.assertTrue(self.harness.charm.legacy_db_relation.set_up_relation(relation))
             user = f"relation_id_{self.rel_id}"
             postgresql_mock.create_user.assert_called_once_with(user, "test-password", False)
-            postgresql_mock.create_database.assert_called_once_with(DATABASE, user, plugins=[])
+            postgresql_mock.create_database.assert_called_once_with(
+                DATABASE, user, plugins=[], client_relations=[relation]
+            )
             self.assertEqual(postgresql_mock.get_postgresql_version.call_count, 2)
             _update_unit_status.assert_called_once()
             expected_data = {
@@ -283,7 +285,9 @@ class TestDbProvides(unittest.TestCase):
                 self.clear_relation_data()
             self.assertTrue(self.harness.charm.legacy_db_relation.set_up_relation(relation))
             postgresql_mock.create_user.assert_called_once_with(user, "test-password", False)
-            postgresql_mock.create_database.assert_called_once_with(DATABASE, user, plugins=[])
+            postgresql_mock.create_database.assert_called_once_with(
+                DATABASE, user, plugins=[], client_relations=[relation]
+            )
             self.assertEqual(postgresql_mock.get_postgresql_version.call_count, 2)
             _update_unit_status.assert_called_once()
             self.assertEqual(self.harness.get_relation_data(self.rel_id, self.app), expected_data)

--- a/tests/unit/test_postgresql.py
+++ b/tests/unit/test_postgresql.py
@@ -1,0 +1,267 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+import unittest
+from unittest.mock import call, patch
+
+import psycopg2
+from charms.postgresql_k8s.v0.postgresql import PostgreSQLCreateDatabaseError
+from ops.testing import Harness
+from psycopg2.sql import SQL, Composed, Identifier
+
+from charm import PostgresqlOperatorCharm
+from constants import PEER
+
+
+class TestPostgreSQL(unittest.TestCase):
+    @patch("charm.KubernetesServicePatch", lambda x, y: None)
+    def setUp(self):
+        self.harness = Harness(PostgresqlOperatorCharm)
+        self.addCleanup(self.harness.cleanup)
+
+        # Set up the initial relation and hooks.
+        self.peer_rel_id = self.harness.add_relation(PEER, "postgresql-k8s")
+        self.harness.add_relation_unit(self.peer_rel_id, "postgresql-k8s/0")
+        self.harness.begin()
+        self.charm = self.harness.charm
+
+    @patch("charms.postgresql_k8s.v0.postgresql.PostgreSQL.enable_disable_extensions")
+    @patch(
+        "charms.postgresql_k8s.v0.postgresql.PostgreSQL._generate_database_privileges_statements"
+    )
+    @patch("charms.postgresql_k8s.v0.postgresql.PostgreSQL._connect_to_database")
+    def test_create_database(
+        self,
+        _connect_to_database,
+        _generate_database_privileges_statements,
+        _enable_disable_extensions,
+    ):
+        # Test a successful database creation.
+        database = "test_database"
+        user = "test_user"
+        plugins = ["test_plugin_1", "test_plugin_2"]
+        with self.harness.hooks_disabled():
+            rel_id = self.harness.add_relation("database", "application")
+            self.harness.add_relation_unit(rel_id, "application/0")
+            self.harness.update_relation_data(rel_id, "application", {"database": database})
+        database_relation = self.harness.model.get_relation("database")
+        client_relations = [database_relation]
+        schemas = [("test_schema_1",), ("test_schema_2",)]
+        _connect_to_database.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value.fetchall.return_value = (
+            schemas
+        )
+        self.charm.postgresql.create_database(database, user, plugins, client_relations)
+        execute = _connect_to_database.return_value.cursor.return_value.execute
+        execute.assert_has_calls(
+            [
+                call(
+                    Composed(
+                        [
+                            SQL("REVOKE ALL PRIVILEGES ON DATABASE "),
+                            Identifier(database),
+                            SQL(" FROM PUBLIC;"),
+                        ]
+                    )
+                ),
+                call(
+                    Composed(
+                        [
+                            SQL("GRANT ALL PRIVILEGES ON DATABASE "),
+                            Identifier(database),
+                            SQL(" TO "),
+                            Identifier(user),
+                            SQL(";"),
+                        ]
+                    )
+                ),
+                call(
+                    Composed(
+                        [
+                            SQL("GRANT ALL PRIVILEGES ON DATABASE "),
+                            Identifier(database),
+                            SQL(" TO "),
+                            Identifier("admin"),
+                            SQL(";"),
+                        ]
+                    )
+                ),
+                call(
+                    Composed(
+                        [
+                            SQL("GRANT ALL PRIVILEGES ON DATABASE "),
+                            Identifier(database),
+                            SQL(" TO "),
+                            Identifier("backup"),
+                            SQL(";"),
+                        ]
+                    )
+                ),
+                call(
+                    Composed(
+                        [
+                            SQL("GRANT ALL PRIVILEGES ON DATABASE "),
+                            Identifier(database),
+                            SQL(" TO "),
+                            Identifier("replication"),
+                            SQL(";"),
+                        ]
+                    )
+                ),
+                call(
+                    Composed(
+                        [
+                            SQL("GRANT ALL PRIVILEGES ON DATABASE "),
+                            Identifier(database),
+                            SQL(" TO "),
+                            Identifier("rewind"),
+                            SQL(";"),
+                        ]
+                    )
+                ),
+                call(
+                    Composed(
+                        [
+                            SQL("GRANT ALL PRIVILEGES ON DATABASE "),
+                            Identifier(database),
+                            SQL(" TO "),
+                            Identifier("operator"),
+                            SQL(";"),
+                        ]
+                    )
+                ),
+                call(
+                    Composed(
+                        [
+                            SQL("GRANT ALL PRIVILEGES ON DATABASE "),
+                            Identifier(database),
+                            SQL(" TO "),
+                            Identifier("monitoring"),
+                            SQL(";"),
+                        ]
+                    )
+                ),
+            ]
+        )
+        _generate_database_privileges_statements.assert_called_once_with(
+            1, [schemas[0][0], schemas[1][0]], user
+        )
+        _enable_disable_extensions.assert_called_once_with(
+            {plugins[0]: True, plugins[1]: True}, database
+        )
+
+        # Test when two relations request the same database.
+        _connect_to_database.reset_mock()
+        _generate_database_privileges_statements.reset_mock()
+        with self.harness.hooks_disabled():
+            other_rel_id = self.harness.add_relation("database", "other-application")
+            self.harness.add_relation_unit(other_rel_id, "other-application/0")
+            self.harness.update_relation_data(
+                other_rel_id, "other-application", {"database": database}
+            )
+        other_database_relation = self.harness.model.get_relation("database", other_rel_id)
+        client_relations = [database_relation, other_database_relation]
+        self.charm.postgresql.create_database(database, user, plugins, client_relations)
+        _generate_database_privileges_statements.assert_called_once_with(
+            2, [schemas[0][0], schemas[1][0]], user
+        )
+
+        # Test a failed database creation.
+        _enable_disable_extensions.reset_mock()
+        execute.side_effect = psycopg2.Error
+        with self.assertRaises(PostgreSQLCreateDatabaseError):
+            self.charm.postgresql.create_database(database, user, plugins, client_relations)
+        _enable_disable_extensions.assert_not_called()
+
+    def test_generate_database_privileges_statements(self):
+        # Test with only one established relation.
+        self.assertEqual(
+            self.charm.postgresql._generate_database_privileges_statements(
+                1, ["test_schema_1", "test_schema_2"], "test_user"
+            ),
+            [
+                Composed(
+                    [
+                        SQL(
+                            "DO $$\nDECLARE r RECORD;\nBEGIN\n  FOR r IN (SELECT statement FROM (SELECT 1 AS index,'ALTER TABLE '|| schemaname || '.\"' || tablename ||'\" OWNER TO "
+                        ),
+                        Identifier("test_user"),
+                        SQL(
+                            ";' AS statement\nFROM pg_tables WHERE NOT schemaname IN ('pg_catalog', 'information_schema')\nUNION SELECT 2 AS index,'ALTER SEQUENCE '|| sequence_schema || '.\"' || sequence_name ||'\" OWNER TO "
+                        ),
+                        Identifier("test_user"),
+                        SQL(
+                            ";' AS statement\nFROM information_schema.sequences WHERE NOT sequence_schema IN ('pg_catalog', 'information_schema')\nUNION SELECT 3 AS index,'ALTER FUNCTION '|| nsp.nspname || '.\"' || p.proname ||'\"('||pg_get_function_identity_arguments(p.oid)||') OWNER TO "
+                        ),
+                        Identifier("test_user"),
+                        SQL(
+                            ";' AS statement\nFROM pg_proc p JOIN pg_namespace nsp ON p.pronamespace = nsp.oid WHERE NOT nsp.nspname IN ('pg_catalog', 'information_schema')\nUNION SELECT 4 AS index,'ALTER VIEW '|| schemaname || '.\"' || viewname ||'\" OWNER TO "
+                        ),
+                        Identifier("test_user"),
+                        SQL(
+                            ";' AS statement\nFROM pg_catalog.pg_views WHERE NOT schemaname IN ('pg_catalog', 'information_schema')) AS statements ORDER BY index) LOOP\n      EXECUTE format(r.statement);\n  END LOOP;\nEND; $$;"
+                        ),
+                    ]
+                )
+            ],
+        )
+        # Test with multiple established relations.
+        self.assertEqual(
+            self.charm.postgresql._generate_database_privileges_statements(
+                2, ["test_schema_1", "test_schema_2"], "test_user"
+            ),
+            [
+                Composed(
+                    [
+                        SQL("GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA "),
+                        Identifier("test_schema_1"),
+                        SQL(" TO "),
+                        Identifier("test_user"),
+                        SQL(";"),
+                    ]
+                ),
+                Composed(
+                    [
+                        SQL("GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA "),
+                        Identifier("test_schema_1"),
+                        SQL(" TO "),
+                        Identifier("test_user"),
+                        SQL(";"),
+                    ]
+                ),
+                Composed(
+                    [
+                        SQL("GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA "),
+                        Identifier("test_schema_1"),
+                        SQL(" TO "),
+                        Identifier("test_user"),
+                        SQL(";"),
+                    ]
+                ),
+                Composed(
+                    [
+                        SQL("GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA "),
+                        Identifier("test_schema_2"),
+                        SQL(" TO "),
+                        Identifier("test_user"),
+                        SQL(";"),
+                    ]
+                ),
+                Composed(
+                    [
+                        SQL("GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA "),
+                        Identifier("test_schema_2"),
+                        SQL(" TO "),
+                        Identifier("test_user"),
+                        SQL(";"),
+                    ]
+                ),
+                Composed(
+                    [
+                        SQL("GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA "),
+                        Identifier("test_schema_2"),
+                        SQL(" TO "),
+                        Identifier("test_user"),
+                        SQL(";"),
+                    ]
+                ),
+            ],
+        )

--- a/tests/unit/test_postgresql_provider.py
+++ b/tests/unit/test_postgresql_provider.py
@@ -1,0 +1,160 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import unittest
+from unittest.mock import Mock, PropertyMock, patch
+
+from charms.postgresql_k8s.v0.postgresql import (
+    PostgreSQLCreateDatabaseError,
+    PostgreSQLCreateUserError,
+    PostgreSQLGetPostgreSQLVersionError,
+)
+from ops.framework import EventBase
+from ops.model import ActiveStatus, BlockedStatus
+from ops.testing import Harness
+
+from charm import PostgresqlOperatorCharm
+from constants import PEER
+from tests.helpers import patch_network_get
+
+DATABASE = "test_database"
+EXTRA_USER_ROLES = "CREATEDB,CREATEROLE"
+RELATION_NAME = "database"
+POSTGRESQL_VERSION = "14"
+
+
+@patch_network_get(private_address="1.1.1.1")
+class TestPostgreSQLProvider(unittest.TestCase):
+    @patch("charm.KubernetesServicePatch", lambda x, y: None)
+    def setUp(self):
+        self.harness = Harness(PostgresqlOperatorCharm)
+        self.addCleanup(self.harness.cleanup)
+
+        # Set up the initial relation and hooks.
+        self.harness.set_leader(True)
+        self.harness.begin()
+        self.app = self.harness.charm.app.name
+        self.unit = self.harness.charm.unit.name
+
+        # Define some relations.
+        self.rel_id = self.harness.add_relation(RELATION_NAME, "application")
+        self.harness.add_relation_unit(self.rel_id, "application/0")
+        self.peer_rel_id = self.harness.add_relation(PEER, self.app)
+        self.harness.add_relation_unit(self.peer_rel_id, self.unit)
+        self.harness.update_relation_data(
+            self.peer_rel_id,
+            self.app,
+            {"cluster_initialised": "True"},
+        )
+        self.provider = self.harness.charm.postgresql_client_relation
+
+    def request_database(self):
+        # Reset the charm status.
+        self.harness.model.unit.status = ActiveStatus()
+
+        # Reset the application databag.
+        self.harness.update_relation_data(
+            self.rel_id,
+            "application",
+            {"database": "", "extra-user-roles": ""},
+        )
+
+        # Reset the database databag.
+        self.harness.update_relation_data(
+            self.rel_id,
+            self.app,
+            {"data": "", "username": "", "password": "", "version": "", "database": ""},
+        )
+
+        # Simulate the request of a new database plus extra user roles.
+        self.harness.update_relation_data(
+            self.rel_id,
+            "application",
+            {"database": DATABASE, "extra-user-roles": EXTRA_USER_ROLES},
+        )
+
+    @patch("relations.postgresql_provider.new_password", return_value="test-password")
+    @patch.object(EventBase, "defer")
+    @patch("charm.Patroni.member_started", new_callable=PropertyMock)
+    def test_on_database_requested(self, _member_started, _defer, _new_password):
+        with patch.object(PostgresqlOperatorCharm, "postgresql", Mock()) as postgresql_mock:
+            # Set some side effects to test multiple situations.
+            _member_started.side_effect = [False, True, True, True, True, True]
+            postgresql_mock.create_user = PropertyMock(
+                side_effect=[None, PostgreSQLCreateUserError, None, None]
+            )
+            postgresql_mock.create_database = PropertyMock(
+                side_effect=[None, PostgreSQLCreateDatabaseError, None]
+            )
+            postgresql_mock.get_postgresql_version = PropertyMock(
+                side_effect=[
+                    POSTGRESQL_VERSION,
+                    PostgreSQLGetPostgreSQLVersionError,
+                ]
+            )
+
+            # Request a database before the database is ready.
+            self.request_database()
+            _defer.assert_called_once()
+
+            # Request it again when the database is ready.
+            self.request_database()
+
+            # Assert that the correct calls were made.
+            user = f"relation_id_{self.rel_id}"
+            postgresql_mock.create_user.assert_called_once_with(
+                user, "test-password", extra_user_roles=EXTRA_USER_ROLES
+            )
+            database_relation = self.harness.model.get_relation(RELATION_NAME)
+            client_relations = [database_relation]
+            postgresql_mock.create_database.assert_called_once_with(
+                DATABASE, user, plugins=[], client_relations=client_relations
+            )
+            postgresql_mock.get_postgresql_version.assert_called_once()
+
+            # Assert that the relation data was updated correctly.
+            self.assertEqual(
+                self.harness.get_relation_data(self.rel_id, self.app),
+                {
+                    "data": f'{{"database": "{DATABASE}", "extra-user-roles": "{EXTRA_USER_ROLES}"}}',
+                    "endpoints": "postgresql-k8s-primary.None.svc.cluster.local:5432",
+                    "username": user,
+                    "password": "test-password",
+                    "read-only-endpoints": "postgresql-k8s-replicas.None.svc.cluster.local:5432",
+                    "version": POSTGRESQL_VERSION,
+                    "database": f"{DATABASE}",
+                },
+            )
+
+            # Assert no BlockedStatus was set.
+            self.assertFalse(isinstance(self.harness.model.unit.status, BlockedStatus))
+
+            # BlockedStatus due to a PostgreSQLCreateUserError.
+            self.request_database()
+            self.assertTrue(isinstance(self.harness.model.unit.status, BlockedStatus))
+            # No data is set in the databag by the database.
+            self.assertEqual(
+                self.harness.get_relation_data(self.rel_id, self.app),
+                {
+                    "data": f'{{"database": "{DATABASE}", "extra-user-roles": "{EXTRA_USER_ROLES}"}}',
+                    "endpoints": "postgresql-k8s-primary.None.svc.cluster.local:5432",
+                    "read-only-endpoints": "postgresql-k8s-replicas.None.svc.cluster.local:5432",
+                },
+            )
+
+            # BlockedStatus due to a PostgreSQLCreateDatabaseError.
+            self.request_database()
+            self.assertTrue(isinstance(self.harness.model.unit.status, BlockedStatus))
+            # No data is set in the databag by the database.
+            self.assertEqual(
+                self.harness.get_relation_data(self.rel_id, self.app),
+                {
+                    "data": f'{{"database": "{DATABASE}", "extra-user-roles": "{EXTRA_USER_ROLES}"}}',
+                    "endpoints": "postgresql-k8s-primary.None.svc.cluster.local:5432",
+                    "read-only-endpoints": "postgresql-k8s-replicas.None.svc.cluster.local:5432",
+                },
+            )
+
+            # BlockedStatus due to a PostgreSQLGetPostgreSQLVersionError.
+            self.request_database()
+            self.assertTrue(isinstance(self.harness.model.unit.status, BlockedStatus))


### PR DESCRIPTION
## Issue
Some charms like Discourse-K8S need to have the ownership of the tables and other objects in a database to correctly run its migrations if a database from a previous Discourse installation is used, otherwise it will not complete the migrations and will throw an error. Also, the existing Discourse K8S test was marked as `unstable` in the past because that charm was migrated from the legacy to the modern relation interface.

## Solution
If the relation between PostgreSQL and Discourse K8S (or any other charm), continue with the same behaviour, but after another instance of the charm is related to the PostgreSQL again, requesting the same database, check if there is no other application related and that previously requested the same database. If so, change the ownership of the objects in the database to the new user created for this relation. If there is already another application related to this database, just give permission to the database object, as we are already doing.