### PR TITLE
[DPE-3061] Check system identifier in stanza

### DIFF
--- a/src/backups.py
+++ b/src/backups.py
@@ -116,7 +116,7 @@ class PostgreSQLBackups(Object):
             for stanza in json.loads(output):
                 system_identifier_from_instance, error = self._execute_command(
                     [
-                        "/usr/lib/postgresql/14/bin/pg_controldata",
+                        f'/usr/lib/postgresql/{self.charm._patroni.rock_postgresql_version.split(".")[0]}/bin/pg_controldata',
                         "/var/lib/postgresql/data/pgdata",
                     ]
                 )

--- a/src/backups.py
+++ b/src/backups.py
@@ -114,7 +114,23 @@ class PostgreSQLBackups(Object):
 
         if self.charm.unit.is_leader():
             for stanza in json.loads(output):
-                if stanza.get("name") != self.charm.app_peer_data.get("stanza", self.stanza_name):
+                system_identifier_from_instance, error = self._execute_command(
+                    [
+                        "/usr/lib/postgresql/14/bin/pg_controldata",
+                        "/var/lib/postgresql/data/pgdata",
+                    ]
+                )
+                if error != "":
+                    raise Exception(error)
+                system_identifier_from_instance = [
+                    line
+                    for line in system_identifier_from_instance.splitlines()
+                    if "Database system identifier" in line
+                ][0].split(" ")[-1]
+                system_identifier_from_stanza = str(stanza.get("db")[0]["system-id"])
+                if system_identifier_from_instance != system_identifier_from_stanza or stanza.get(
+                    "name"
+                ) != self.charm.app_peer_data.get("stanza", self.stanza_name):
                     # Prevent archiving of WAL files.
                     self.charm.app_peer_data.update({"stanza": ""})
                     self.charm.update_config()


### PR DESCRIPTION
## Issue
In https://github.com/canonical/postgresql-k8s-operator/issues/335, the new cluster where the user tried to restore the backup had the same name as the cluster the backup was made from. As we're checking only the cluster/stanza name to set the blocked status, informing the user that there are backups from another cluster in the repository, the blocked status is not set for this specific case.

## Solution
Use the PostgreSQL installation system id to differentiate clusters.