### PR TITLE
[DPE-3551] Fix large objects ownership

### DIFF
--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -35,7 +35,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 23
+LIBPATCH = 24
 
 INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE = "invalid role(s) for extra user roles"
 

--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -35,7 +35,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 22
+LIBPATCH = 23
 
 INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE = "invalid role(s) for extra user roles"
 
@@ -353,6 +353,13 @@ END; $$;"""
                     sql.Identifier(user),
                     sql.Identifier(user),
                     sql.Identifier(user),
+                )
+            )
+            statements.append(
+                """UPDATE pg_catalog.pg_largeobject_metadata
+SET lomowner = (SELECT oid FROM pg_roles WHERE rolname = '{}')
+WHERE lomowner = (SELECT oid FROM pg_roles WHERE rolname = '{}');""".format(
+                    user, self.user
                 )
             )
         else:

--- a/tests/unit/test_postgresql.py
+++ b/tests/unit/test_postgresql.py
@@ -200,7 +200,8 @@ class TestPostgreSQL(unittest.TestCase):
                             ";' AS statement\nFROM pg_catalog.pg_views WHERE NOT schemaname IN ('pg_catalog', 'information_schema')) AS statements ORDER BY index) LOOP\n      EXECUTE format(r.statement);\n  END LOOP;\nEND; $$;"
                         ),
                     ]
-                )
+                ),
+                "UPDATE pg_catalog.pg_largeobject_metadata\nSET lomowner = (SELECT oid FROM pg_roles WHERE rolname = 'test_user')\nWHERE lomowner = (SELECT oid FROM pg_roles WHERE rolname = 'operator');",
             ],
         )
         # Test with multiple established relations.


### PR DESCRIPTION
## Issue
If we relate a charm like the MAAS operator to the PostgreSQL operator, remove the relation and relate again, then MAAS doesn't have access to the previously created PostgreSQL large objects.

https://github.com/canonical/postgresql-k8s-operator/issues/389

## Solution
When a charm is related again to the PostgreSQL operator, give the ownership of the existing large objects to that charm user, as we already do for tables and other objects.