### PR TITLE
[DPE-3594] Fix shared buffers validation

### DIFF
--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -579,9 +579,13 @@ END; $$;"""
                 f"Shared buffers config option should be at most 40% of the available memory, which is {shared_buffers_max_value_in_mb}MB"
             )
         if profile == "production":
-            # Use 25% of the available memory for shared_buffers.
-            # and the remaining as cache memory.
-            shared_buffers = int(available_memory * 0.25)
+            if "shared_buffers" in parameters:
+                # Convert to bytes to use in the calculation.
+                shared_buffers = parameters["shared_buffers"] * 8 * 10**3
+            else:
+                # Use 25% of the available memory for shared_buffers.
+                # and the remaining as cache memory.
+                shared_buffers = int(available_memory * 0.25)
             effective_cache_size = int(available_memory - shared_buffers)
             parameters.setdefault("shared_buffers", f"{int(shared_buffers/10**6)}MB")
             parameters.update({"effective_cache_size": f"{int(effective_cache_size/10**6)}MB"})

--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -35,7 +35,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 22
+LIBPATCH = 23
 
 INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE = "invalid role(s) for extra user roles"
 
@@ -572,10 +572,11 @@ END; $$;"""
             if parameter in ["date_style", "time_zone"]:
                 parameter = "".join(x.capitalize() for x in parameter.split("_"))
             parameters[parameter] = value
-        shared_buffers_max_value = int(int(available_memory * 0.4) / 10**6)
+        shared_buffers_max_value_in_mb = int(available_memory * 0.4 / 10**6)
+        shared_buffers_max_value = int(shared_buffers_max_value_in_mb * 10**3 / 8)
         if parameters.get("shared_buffers", 0) > shared_buffers_max_value:
             raise Exception(
-                f"Shared buffers config option should be at most 40% of the available memory, which is {shared_buffers_max_value}MB"
+                f"Shared buffers config option should be at most 40% of the available memory, which is {shared_buffers_max_value_in_mb}MB"
             )
         if profile == "production":
             # Use 25% of the available memory for shared_buffers.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -20,7 +20,7 @@ from ops.model import (
 from ops.pebble import Change, ChangeError, ChangeID, ServiceStatus
 from ops.testing import Harness
 from parameterized import parameterized
-from tenacity import RetryError
+from tenacity import RetryError, wait_fixed
 
 from charm import PostgresqlOperatorCharm
 from constants import PEER, SECRET_INTERNAL_LABEL
@@ -1234,3 +1234,157 @@ class TestCharm(unittest.TestCase):
             )
             _restart.assert_not_called()
             _reinitialize_postgresql.assert_called_once()
+
+    @patch("ops.model.Container.get_plan")
+    @patch("charm.PostgresqlOperatorCharm._handle_postgresql_restart_need")
+    @patch("charm.Patroni.bulk_update_parameters_controller_by_patroni")
+    @patch("charm.PostgresqlOperatorCharm._validate_config_options")
+    @patch("charm.Patroni.member_started", new_callable=PropertyMock)
+    @patch("charm.PostgresqlOperatorCharm._is_workload_running", new_callable=PropertyMock)
+    @patch("charm.Patroni.render_patroni_yml_file")
+    @patch("charm.PostgreSQLUpgrade")
+    @patch("charm.PostgresqlOperatorCharm.is_tls_enabled", new_callable=PropertyMock)
+    def test_update_config(
+        self,
+        _is_tls_enabled,
+        _upgrade,
+        _render_patroni_yml_file,
+        _is_workload_running,
+        _member_started,
+        _,
+        __,
+        _handle_postgresql_restart_need,
+        _get_plan,
+    ):
+        with patch.object(PostgresqlOperatorCharm, "postgresql", Mock()) as postgresql_mock:
+            # Mock some properties.
+            self.harness.set_can_connect(self._postgresql_container, True)
+            self.upgrade_relation = self.harness.add_relation("upgrade", self.charm.app.name)
+            postgresql_mock.is_tls_enabled = PropertyMock(side_effect=[False, False, False, False])
+            _is_workload_running.side_effect = [False, False, True, True, False, True]
+            _member_started.side_effect = [True, True, False]
+            postgresql_mock.build_postgresql_parameters.return_value = {"test": "test"}
+
+            # Test when only one of the two config options for profile limit memory is set.
+            self.harness.update_config({"profile-limit-memory": 1000})
+            self.charm.update_config()
+
+            # Test when only one of the two config options for profile limit memory is set.
+            self.harness.update_config(
+                {"profile_limit_memory": 1000}, unset={"profile-limit-memory"}
+            )
+            self.charm.update_config()
+
+            # Test when the two config options for profile limit memory are set at the same time.
+            _render_patroni_yml_file.reset_mock()
+            self.harness.update_config({"profile-limit-memory": 1000})
+            with self.assertRaises(ValueError):
+                self.charm.update_config()
+
+            # Test without TLS files available.
+            self.harness.update_config(unset={"profile-limit-memory", "profile_limit_memory"})
+            with self.harness.hooks_disabled():
+                self.harness.update_relation_data(self.rel_id, self.charm.unit.name, {"tls": ""})
+            _is_tls_enabled.return_value = False
+            self.charm.update_config()
+            _render_patroni_yml_file.assert_called_once_with(
+                connectivity=True,
+                is_creating_backup=False,
+                enable_tls=False,
+                is_no_sync_member=False,
+                backup_id=None,
+                stanza=None,
+                restore_stanza=None,
+                parameters={"test": "test"},
+            )
+            _handle_postgresql_restart_need.assert_called_once()
+            self.assertNotIn(
+                "tls", self.harness.get_relation_data(self.rel_id, self.charm.unit.name)
+            )
+
+            # Test with TLS files available.
+            _handle_postgresql_restart_need.reset_mock()
+            self.harness.update_relation_data(
+                self.rel_id, self.charm.unit.name, {"tls": ""}
+            )  # Mock some data in the relation to test that it change.
+            _is_tls_enabled.return_value = True
+            _render_patroni_yml_file.reset_mock()
+            self.charm.update_config()
+            _render_patroni_yml_file.assert_called_once_with(
+                connectivity=True,
+                is_creating_backup=False,
+                enable_tls=True,
+                is_no_sync_member=False,
+                backup_id=None,
+                stanza=None,
+                restore_stanza=None,
+                parameters={"test": "test"},
+            )
+            _handle_postgresql_restart_need.assert_called_once()
+            self.assertNotIn(
+                "tls",
+                self.harness.get_relation_data(
+                    self.rel_id, self.charm.unit.name
+                ),  # The "tls" flag is set in handle_postgresql_restart_need.
+            )
+
+            # Test with workload not running yet.
+            self.harness.update_relation_data(
+                self.rel_id, self.charm.unit.name, {"tls": ""}
+            )  # Mock some data in the relation to test that it change.
+            _handle_postgresql_restart_need.reset_mock()
+            self.charm.update_config()
+            _handle_postgresql_restart_need.assert_not_called()
+            self.assertEqual(
+                self.harness.get_relation_data(self.rel_id, self.charm.unit.name)["tls"], "enabled"
+            )
+
+            # Test with member not started yet.
+            self.harness.update_relation_data(
+                self.rel_id, self.charm.unit.name, {"tls": ""}
+            )  # Mock some data in the relation to test that it doesn't change.
+            self.charm.update_config()
+            _handle_postgresql_restart_need.assert_not_called()
+            self.assertNotIn(
+                "tls", self.harness.get_relation_data(self.rel_id, self.charm.unit.name)
+            )
+
+    @patch("charms.rolling_ops.v0.rollingops.RollingOpsManager._on_acquire_lock")
+    @patch("charm.PostgresqlOperatorCharm._generate_metrics_jobs")
+    @patch("charm.wait_fixed", return_value=wait_fixed(0))
+    @patch("charm.Patroni.reload_patroni_configuration")
+    @patch("charm.PostgresqlOperatorCharm.is_tls_enabled", new_callable=PropertyMock)
+    def test_handle_postgresql_restart_need(
+        self, _is_tls_enabled, _reload_patroni_configuration, _, _generate_metrics_jobs, _restart
+    ):
+        with patch.object(PostgresqlOperatorCharm, "postgresql", Mock()) as postgresql_mock:
+            for values in itertools.product([True, False], [True, False], [True, False]):
+                _reload_patroni_configuration.reset_mock()
+                _generate_metrics_jobs.reset_mock()
+                _restart.reset_mock()
+                with self.harness.hooks_disabled():
+                    self.harness.update_relation_data(
+                        self.rel_id, self.charm.unit.name, {"tls": ""}
+                    )
+
+                _is_tls_enabled.return_value = values[0]
+                postgresql_mock.is_tls_enabled = PropertyMock(return_value=values[1])
+                postgresql_mock.is_restart_pending = PropertyMock(return_value=values[2])
+
+                self.charm._handle_postgresql_restart_need()
+                _reload_patroni_configuration.assert_called_once()
+                (
+                    self.assertIn(
+                        "tls", self.harness.get_relation_data(self.rel_id, self.charm.unit)
+                    )
+                    if values[0]
+                    else self.assertNotIn(
+                        "tls", self.harness.get_relation_data(self.rel_id, self.charm.unit)
+                    )
+                )
+                if (values[0] != values[1]) or values[2]:
+                    _generate_metrics_jobs.assert_called_once_with(values[0])
+                    _restart.assert_called_once()
+                else:
+                    _generate_metrics_jobs.assert_not_called()
+                    _restart.assert_not_called()

--- a/tests/unit/test_postgresql.py
+++ b/tests/unit/test_postgresql.py
@@ -307,17 +307,26 @@ class TestPostgreSQL(unittest.TestCase):
         self.assertEqual(parameters["shared_buffers"], "150MB")
         self.assertEqual(parameters["effective_cache_size"], "450MB")
 
-        # Test when the profile is set to "testing".
-        config_options["profile"] = "testing"
-        parameters = self.charm.postgresql.build_postgresql_parameters(config_options, 1000000000)
-        self.assertEqual(parameters["shared_buffers"], "128MB")
-
         # Test when the requested shared buffers are greater than 40% of the available memory.
         config_options["memory_shared_buffers"] = 50001
         with self.assertRaises(Exception):
             self.charm.postgresql.build_postgresql_parameters(config_options, 1000000000)
 
-        # Test when the requested shared buffers are lower than 40% of the available memory.
+        # Test when the requested shared buffers are lower than 40% of the available memory
+        # (also check that it's used when calculating the effective cache size value).
         config_options["memory_shared_buffers"] = 50000
         parameters = self.charm.postgresql.build_postgresql_parameters(config_options, 1000000000)
         self.assertEqual(parameters["shared_buffers"], 50000)
+        self.assertEqual(parameters["effective_cache_size"], "600MB")
+
+        # Test when the profile is set to "testing".
+        config_options["profile"] = "testing"
+        parameters = self.charm.postgresql.build_postgresql_parameters(config_options, 1000000000)
+        self.assertEqual(parameters["shared_buffers"], 50000)
+        self.assertNotIn("effective_cache_size", parameters)
+
+        # Test when there is no shared_buffers value set in the config option.
+        del config_options["memory_shared_buffers"]
+        parameters = self.charm.postgresql.build_postgresql_parameters(config_options, 1000000000)
+        self.assertEqual(parameters["shared_buffers"], "128MB")
+        self.assertNotIn("effective_cache_size", parameters)

--- a/tests/unit/test_postgresql.py
+++ b/tests/unit/test_postgresql.py
@@ -311,3 +311,13 @@ class TestPostgreSQL(unittest.TestCase):
         config_options["profile"] = "testing"
         parameters = self.charm.postgresql.build_postgresql_parameters(config_options, 1000000000)
         self.assertEqual(parameters["shared_buffers"], "128MB")
+
+        # Test when the requested shared buffers are greater than 40% of the available memory.
+        config_options["memory_shared_buffers"] = 50001
+        with self.assertRaises(Exception):
+            self.charm.postgresql.build_postgresql_parameters(config_options, 1000000000)
+
+        # Test when the requested shared buffers are lower than 40% of the available memory.
+        config_options["memory_shared_buffers"] = 50000
+        parameters = self.charm.postgresql.build_postgresql_parameters(config_options, 1000000000)
+        self.assertEqual(parameters["shared_buffers"], 50000)


### PR DESCRIPTION
## Issue
The validation for the `shared_buffers` parameter was not correct. The calculus of the maximum allowed shared buffers value was not correctly converting the available memory for that to the same unit as the `shared_buffers` parameter that the user informs.

Also, the `effective_cache_size` parameter did not consider the user-provided `shared_buffers` value.

One last issue: sometimes, the restart of the PostgreSQL database was not triggered because Patroni hadn't finished reloading the configuration (even after 10 seconds).

## Solution
Fix the calculus of the maximum allowed shared buffers value to be in the same unit as the user-provided value.

Considered the user-provided shared buffers value for the effective cache size parameter calculus.

An improved retry mechanism was added to check whether a restart is needed after a configuration change.