### PR TITLE
DPE-3695 support cpu in millis

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -79,7 +79,7 @@ from patroni import NotReadyError, Patroni
 from relations.db import EXTENSIONS_BLOCKING_MESSAGE, DbProvides
 from relations.postgresql_provider import PostgreSQLProvider
 from upgrade import PostgreSQLUpgrade, get_postgresql_k8s_dependencies_model
-from utils import any_memory_to_bytes, new_password
+from utils import any_cpu_to_cores, any_memory_to_bytes, new_password
 
 logger = logging.getLogger(__name__)
 
@@ -1549,7 +1549,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         """Return the number of CPU cores for the current K8S node."""
         client = Client()
         node = client.get(Node, name=self._get_node_name_for_pod(), namespace=self._namespace)
-        return int(node.status.allocatable["cpu"])
+        return any_cpu_to_cores(node.status.allocatable["cpu"])
 
     def get_available_resources(self) -> Tuple[int, int]:
         """Get available CPU cores and memory (in bytes) for the container."""

--- a/src/utils.py
+++ b/src/utils.py
@@ -58,3 +58,15 @@ def any_memory_to_bytes(mem_str) -> int:
 
         num = int(memory)
         return int(num * units[unit])
+
+
+def any_cpu_to_cores(cpu_str) -> int:
+    """Convert a CPU string to cores.
+
+    Args:
+        cpu_str: a string representing a CPU value, as integer or millis
+    """
+    if cpu_str.endswith("m"):
+        # convert millis to cores, undercommited
+        return int(cpu_str[:-1]) // 1000
+    return int(cpu_str)


### PR DESCRIPTION
## Issue

support for k8s allocatable cpu is only considering core count (as integer, microk8s default), and not millis (e.g. 7500m)

## Solution

Add support for k8s allocatable cpu in millis

fixes #409
