### PR TITLE
Add `test_config_parameters` test

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -197,8 +197,7 @@ class CharmConfig(BaseConfigModel):
 
         return value
 
-    @validator("optimizer_from_collapse_limit", allow_reuse=True)
-    @validator("optimizer_join_collapse_limit", allow_reuse=True)
+    @validator("optimizer_from_collapse_limit", "optimizer_join_collapse_limit")
     @classmethod
     def optimizer_collapse_limit_values(cls, value: int) -> Optional[int]:
         """Check optimizer collapse_limit config option is between 1 and 2147483647."""
@@ -236,8 +235,7 @@ class CharmConfig(BaseConfigModel):
 
         return value
 
-    @validator("vacuum_autovacuum_analyze_scale_factor", allow_reuse=True)
-    @validator("vacuum_autovacuum_vacuum_scale_factor", allow_reuse=True)
+    @validator("vacuum_autovacuum_analyze_scale_factor", "vacuum_autovacuum_vacuum_scale_factor")
     @classmethod
     def vacuum_autovacuum_vacuum_scale_factor_values(cls, value: float) -> Optional[float]:
         """Check autovacuum scale_factor config option is between 0 and 100."""

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -8,9 +8,9 @@ import pytest as pytest
 from pytest_operator.plugin import OpsTest
 
 from .helpers import (
-    CHARM_SERIES,
     DATABASE_APP_NAME,
-    get_leader_unit, build_and_deploy,
+    build_and_deploy,
+    get_leader_unit,
 )
 
 logger = logging.getLogger(__name__)

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -10,7 +10,7 @@ from pytest_operator.plugin import OpsTest
 from .helpers import (
     CHARM_SERIES,
     DATABASE_APP_NAME,
-    get_leader_unit,
+    get_leader_unit, build_and_deploy,
 )
 
 logger = logging.getLogger(__name__)
@@ -22,14 +22,9 @@ async def test_config_parameters(ops_test: OpsTest) -> None:
     """Build and deploy one unit of PostgreSQL and then test config with wrong parameters."""
     # Build and deploy the PostgreSQL charm.
     async with ops_test.fast_forward():
-        charm = await ops_test.build_charm(".")
-        await ops_test.model.deploy(
-            charm,
-            num_units=1,
-            series=CHARM_SERIES,
-            config={"profile": "testing"},
-        )
-        await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME], status="active", timeout=1500)
+        await build_and_deploy(ops_test, 1)
+
+    await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME], status="active")
 
     leader_unit = await get_leader_unit(ops_test, DATABASE_APP_NAME)
     test_string = "abcXYZ123"

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+
+import pytest as pytest
+from pytest_operator.plugin import OpsTest
+
+from .helpers import (
+    CHARM_SERIES,
+    DATABASE_APP_NAME,
+    get_leader_unit,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_config_parameters(ops_test: OpsTest) -> None:
+    """Build and deploy one unit of PostgreSQL and then test config with wrong parameters."""
+    # Build and deploy the PostgreSQL charm.
+    async with ops_test.fast_forward():
+        charm = await ops_test.build_charm(".")
+        await ops_test.model.deploy(
+            charm,
+            num_units=1,
+            series=CHARM_SERIES,
+            config={"profile": "testing"},
+        )
+        await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME], status="active", timeout=1500)
+
+    leader_unit = await get_leader_unit(ops_test, DATABASE_APP_NAME)
+    test_string = "abcXYZ123"
+
+    configs = [
+        {
+            "durability_synchronous_commit": [test_string, "on"]
+        },  # config option is one of `on`, `remote_apply` or `remote_write`
+        {
+            "instance_password_encryption": [test_string, "scram-sha-256"]
+        },  # config option is one of `md5` or `scram-sha-256`
+        {
+            "logging_log_min_duration_statement": ["-2", "-1"]
+        },  # config option is between -1 and 2147483647
+        {
+            "memory_maintenance_work_mem": ["1023", "65536"]
+        },  # config option is between 1024 and 2147483647
+        {"memory_max_prepared_transactions": ["-1", "0"]},  # config option is between 0 and 262143
+        {"memory_shared_buffers": ["15", "1024"]},  # config option is greater or equal than 16
+        {"memory_temp_buffers": ["99", "1024"]},  # config option is between 100 and 1073741823
+        {"memory_work_mem": ["63", "4096"]},  # config option is between 64 and 2147483647
+        {
+            "optimizer_constraint_exclusion": [test_string, "partition"]
+        },  # config option is one of `on`, `off` or `partition`
+        {
+            "optimizer_default_statistics_target": ["0", "100"]
+        },  # config option is between 1 and 10000
+        {"optimizer_from_collapse_limit": ["0", "8"]},  # config option is between 1 and 2147483647
+        {"optimizer_join_collapse_limit": ["0", "8"]},  # config option is between 1 and 2147483647
+        {"profile": [test_string, "testing"]},  # config option is one of `testing` or `production`
+        # {"profile_limit_memory": {"127", "128"}},  # config option is between 128 and 9999999
+        {
+            "response_bytea_output": [test_string, "hex"]
+        },  # config option is one of `escape` or `hex`
+        {
+            "vacuum_autovacuum_analyze_scale_factor": ["-1", "0.1"]
+        },  # config option is between 0 and 100
+        {
+            "vacuum_autovacuum_vacuum_scale_factor": ["-1", "0.2"]
+        },  # config option is between 0 and 100
+        {
+            "vacuum_autovacuum_analyze_threshold": ["-1", "50"]
+        },  # config option is between 0 and 2147483647
+        {
+            "vacuum_autovacuum_freeze_max_age": ["99999", "200000000"]
+        },  # config option is between 100000 and 2000000000
+        {
+            "vacuum_autovacuum_vacuum_cost_delay": ["-2", "2.0"]
+        },  # config option is between -1 and 100
+        {
+            "vacuum_vacuum_freeze_table_age": ["-1", "150000000"]
+        },  # config option is between 0 and 2000000000
+    ]
+
+    charm_config = {}
+    for config in configs:
+        for k, v in config.items():
+            logger.info(k)
+            charm_config[k] = v[0]
+            await ops_test.model.applications[DATABASE_APP_NAME].set_config(charm_config)
+            await ops_test.model.wait_for_idle(
+                apps=[DATABASE_APP_NAME], status="blocked", timeout=100
+            )
+            assert "Configuration Error" in leader_unit.workload_status_message
+            charm_config[k] = v[1]
+
+    await ops_test.model.applications[DATABASE_APP_NAME].set_config(charm_config)
+    await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME], status="active", timeout=100)


### PR DESCRIPTION
### Issue
All this cases should be covered:
- Charge each charm config option using clusterized app and make sure changes are 
applied without error (and without downtime if possible):
  - check values boundaries (e.g. try 42 where 1-10 are allowed)
  - check types (e.g. try 42 where boolean true/false are expected)
  - check invalid config values (see the “test string” below)