### PR TITLE
[DPE-3593] Only check config values against the DB in on_config_changed

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -1426,7 +1426,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
     def _validate_config_options(self) -> None:
         """Validates specific config options that need access to the database or to the TLS status."""
         if (
-            self.config.instance_default_text_search_config is not None
+            self.config.instance_default_text_search_config != "pg_catalog.simple"
             and self.config.instance_default_text_search_config
             not in self.postgresql.get_postgresql_text_search_configs()
         ):
@@ -1434,13 +1434,14 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
                 "instance_default_text_search_config config option has an invalid value"
             )
 
-        if self.config.request_date_style is not None and not self.postgresql.validate_date_style(
-            self.config.request_date_style
+        if (
+            self.config.request_date_style != "ISO, MDY"
+            and not self.postgresql.validate_date_style(self.config.request_date_style)
         ):
             raise Exception("request_date_style config option has an invalid value")
 
         if (
-            self.config.request_time_zone is not None
+            self.config.request_time_zone != "UTC"
             and self.config.request_time_zone not in self.postgresql.get_postgresql_timezones()
         ):
             raise Exception("request_time_zone config option has an invalid value")

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -77,6 +77,13 @@ async def test_config_parameters(ops_test: OpsTest) -> None:
         {
             "vacuum_vacuum_freeze_table_age": ["-1", "150000000"]
         },  # config option is between 0 and 2000000000
+        {
+            "instance_default_text_search_config": [test_string, "pg_catalog.simple"]
+        },  # config option is validated against the db
+        {
+            "request_date_style": [test_string, "ISO, MDY"]
+        },  # config option is validated against the db
+        {"request_time_zone": [test_string, "UTC"]},  # config option is validated against the db
     ]
 
     charm_config = {}

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -729,17 +729,11 @@ class TestCharm(unittest.TestCase):
         _charm_lib.return_value.validate_date_style.return_value = []
         _charm_lib.return_value.get_postgresql_timezones.return_value = []
 
-        self.charm._validate_config_options()
-
-        assert not _charm_lib.return_value.get_postgresql_text_search_configs.called
-        assert not _charm_lib.return_value.validate_date_style.called
-        assert not _charm_lib.return_value.get_postgresql_timezones.called
-
         # Test instance_default_text_search_config exception
         with self.harness.hooks_disabled():
             self.harness.update_config({"instance_default_text_search_config": "pg_catalog.test"})
 
-        with self.assertRaises(Exception) as e:
+        with self.assertRaises(ValueError) as e:
             self.charm._validate_config_options()
             assert (
                 e.msg == "instance_default_text_search_config config option has an invalid value"
@@ -754,7 +748,7 @@ class TestCharm(unittest.TestCase):
         with self.harness.hooks_disabled():
             self.harness.update_config({"request_date_style": "ISO, TEST"})
 
-        with self.assertRaises(Exception) as e:
+        with self.assertRaises(ValueError) as e:
             self.charm._validate_config_options()
             assert e.msg == "request_date_style config option has an invalid value"
 
@@ -765,7 +759,7 @@ class TestCharm(unittest.TestCase):
         with self.harness.hooks_disabled():
             self.harness.update_config({"request_time_zone": "TEST_ZONE"})
 
-        with self.assertRaises(Exception) as e:
+        with self.assertRaises(ValueError) as e:
             self.charm._validate_config_options()
             assert e.msg == "request_time_zone config option has an invalid value"
 
@@ -1288,7 +1282,6 @@ class TestCharm(unittest.TestCase):
     @patch("ops.model.Container.get_plan")
     @patch("charm.PostgresqlOperatorCharm._handle_postgresql_restart_need")
     @patch("charm.Patroni.bulk_update_parameters_controller_by_patroni")
-    @patch("charm.PostgresqlOperatorCharm._validate_config_options")
     @patch("charm.Patroni.member_started", new_callable=PropertyMock)
     @patch("charm.PostgresqlOperatorCharm._is_workload_running", new_callable=PropertyMock)
     @patch("charm.Patroni.render_patroni_yml_file")
@@ -1302,7 +1295,6 @@ class TestCharm(unittest.TestCase):
         _is_workload_running,
         _member_started,
         _,
-        __,
         _handle_postgresql_restart_need,
         _get_plan,
     ):


### PR DESCRIPTION
`_validate_config_options` connecting to the database will be done only in on_config_changed

Port of https://github.com/canonical/postgresql-operator/pull/395