### PR TITLE
Check user existence after relation broken for `db` and `db-admin` interfaces

### DIFF
--- a/tests/integration/test_db.py
+++ b/tests/integration/test_db.py
@@ -81,13 +81,14 @@ async def test_finos_waltz_db(ops_test: OpsTest) -> None:
             ANOTHER_FINOS_WALTZ_APP_NAME, block_until_done=True
         )
 
-        another_finos_waltz_users = []
         await check_database_users_existence(
             ops_test, finos_waltz_users, another_finos_waltz_users
         )
 
         # Remove the first deployment of Finos Waltz.
         await ops_test.model.remove_application(FINOS_WALTZ_APP_NAME, block_until_done=True)
+
+        await check_database_users_existence(ops_test, [], finos_waltz_users)
 
 
 @pytest.mark.group(1)

--- a/tests/integration/test_db.py
+++ b/tests/integration/test_db.py
@@ -75,20 +75,27 @@ async def test_finos_waltz_db(ops_test: OpsTest) -> None:
             ops_test, finos_waltz_users + another_finos_waltz_users, []
         )
 
-        # Scale down the second deployment of Finos Waltz and confirm that the first deployment
-        # is still active.
-        await ops_test.model.remove_application(
-            ANOTHER_FINOS_WALTZ_APP_NAME, block_until_done=True
+        # Remove second relation and validate that related users were deleted
+        await ops_test.model.applications[DATABASE_APP_NAME].remove_relation(
+            f"{DATABASE_APP_NAME}:db", f"{ANOTHER_FINOS_WALTZ_APP_NAME}"
         )
-
+        await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME], status="active", timeout=1000)
         await check_database_users_existence(
             ops_test, finos_waltz_users, another_finos_waltz_users
         )
 
-        # Remove the first deployment of Finos Waltz.
-        await ops_test.model.remove_application(FINOS_WALTZ_APP_NAME, block_until_done=True)
-
+        # Remove first relation and validate that related users were deleted
+        await ops_test.model.applications[DATABASE_APP_NAME].remove_relation(
+            f"{DATABASE_APP_NAME}:db", f"{FINOS_WALTZ_APP_NAME}"
+        )
+        await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME], status="active", timeout=1000)
         await check_database_users_existence(ops_test, [], finos_waltz_users)
+
+        # Remove the first and second deployment of Finos Waltz.
+        await ops_test.model.remove_application(FINOS_WALTZ_APP_NAME, block_until_done=True)
+        await ops_test.model.remove_application(
+            ANOTHER_FINOS_WALTZ_APP_NAME, block_until_done=True
+        )
 
 
 @pytest.mark.group(1)

--- a/tests/integration/test_db_admin.py
+++ b/tests/integration/test_db_admin.py
@@ -67,3 +67,7 @@ async def test_discourse_from_discourse_charmers(ops_test: OpsTest):
     await check_database_creation(ops_test, "discourse-charmers-discourse-k8s")
     discourse_users = [f"relation_id_{relation.id}"]
     await check_database_users_existence(ops_test, discourse_users, [], admin=True)
+
+    # Remove the deployment of Discourse.
+    await ops_test.model.remove_application(DISCOURSE_APP_NAME, block_until_done=True)
+    await check_database_users_existence(ops_test, [], discourse_users, admin=True)

--- a/tests/integration/test_db_admin.py
+++ b/tests/integration/test_db_admin.py
@@ -73,9 +73,7 @@ async def test_discourse_from_discourse_charmers(ops_test: OpsTest):
         f"{DATABASE_APP_NAME}:db-admin", f"{DISCOURSE_APP_NAME}"
     )
     await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME], status="active", timeout=1000)
-    await check_database_users_existence(
-        ops_test, [], discourse_users
-    )
+    await check_database_users_existence(ops_test, [], discourse_users)
 
     # Remove the deployment of Discourse.
     await ops_test.model.remove_application(DISCOURSE_APP_NAME, block_until_done=True)

--- a/tests/integration/test_db_admin.py
+++ b/tests/integration/test_db_admin.py
@@ -68,6 +68,14 @@ async def test_discourse_from_discourse_charmers(ops_test: OpsTest):
     discourse_users = [f"relation_id_{relation.id}"]
     await check_database_users_existence(ops_test, discourse_users, [], admin=True)
 
+    # Remove Discourse relation and validate that related users were deleted
+    await ops_test.model.applications[DATABASE_APP_NAME].remove_relation(
+        f"{DATABASE_APP_NAME}:db-admin", f"{DISCOURSE_APP_NAME}"
+    )
+    await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME], status="active", timeout=1000)
+    await check_database_users_existence(
+        ops_test, [], discourse_users
+    )
+
     # Remove the deployment of Discourse.
     await ops_test.model.remove_application(DISCOURSE_APP_NAME, block_until_done=True)
-    await check_database_users_existence(ops_test, [], discourse_users, admin=True)


### PR DESCRIPTION
### Issue
User should be created on a relation-joined event, and the user should be dropped on a relation-departed event

### Solution
Added missed for checking user existence after application removed