### PR TITLE
Added `check_tls_replication` for checking replicas encrypted connection

### DIFF
--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -15,6 +15,7 @@ from .helpers import (
     check_database_users_existence,
     check_tls,
     check_tls_patroni_api,
+    check_tls_replication,
     db_connect,
     deploy_and_relate_application_with_postgresql,
     get_password,
@@ -101,6 +102,9 @@ async def test_mattermost_db(ops_test: OpsTest) -> None:
         for member in cluster_info.json()["members"]:
             if member["role"] == "replica":
                 replica = "/".join(member["name"].rsplit("-", 1))
+
+        # Check if TLS enabled for replication
+        assert await check_tls_replication(ops_test, primary, enabled=True)
 
         # Enable additional logs on the PostgreSQL instance to check TLS
         # being used in a later step.


### PR DESCRIPTION
### Issue
As described [here](https://github.com/canonical/postgresql-k8s-operator/issues/445) encrypted connection between replicas should be exists when TLS enabled

### Description
Updated TLS test, added check for replicas encrypted connection

Imported from [VM](https://github.com/canonical/postgresql-operator/pull/437)