### PR TITLE
[DPE-2671] Rerender and reenable pgbackrest config and service

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -736,6 +736,9 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         # was fully initialised.
         self.enable_disable_extensions()
 
+        # Enable pgbackrest service
+        self.backup.start_stop_pgbackrest_service()
+
         # All is well, set an ActiveStatus.
         self._set_active_status()
 


### PR DESCRIPTION
## Issue
Pgbackrest service and configuration are not enabled if a pod is recreated

## Solution
Render and start pgbackrest ssl service on pebble ready
