### PR TITLE
[MISC] Unify juju2 and juju3 test suites

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,11 +26,6 @@ jobs:
 
   unit-test:
     name: Unit test charm
-    strategy:
-      matrix:
-        juju-version:
-          - "juju2"
-          - "juju3"
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -41,7 +36,7 @@ jobs:
           pipx install tox
           pipx install poetry
       - name: Run tests
-        run: tox run -e unit-${{ matrix.juju-version }}
+        run: tox run -e unit
 
   build:
     name: Build charm

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,32 +1,13 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
-import os
 from unittest.mock import PropertyMock
 
 import pytest
-from ops import JujuVersion
-from pytest_mock import MockerFixture
 
 
-@pytest.fixture(autouse=True)
-def juju_has_secrets(mocker: MockerFixture):
-    """This fixture will force the usage of secrets whenever run on Juju 3.x.
-
-    NOTE: This is needed, as normally JujuVersion is set to 0.0.0 in tests
-    (i.e. not the real juju version)
-    """
-    if juju_version := os.environ.get("LIBJUJU"):
-        juju_version = juju_version[1:].split(".")[0]
-    else:
-        juju_version = "3"
-
-    if juju_version < "3":
-        mocker.patch.object(
-            JujuVersion, "has_secrets", new_callable=PropertyMock
-        ).return_value = False
-        return False
-    else:
-        mocker.patch.object(
-            JujuVersion, "has_secrets", new_callable=PropertyMock
-        ).return_value = True
-        return True
+# This causes every test defined in this file to run 2 times, each with
+# charm.JujuVersion.has_secrets set as True or as False
+@pytest.fixture(params=[True, False], autouse=True)
+def juju_has_secrets(request, monkeypatch):
+    monkeypatch.setattr("charm.JujuVersion.has_secrets", PropertyMock(return_value=request.param))
+    return request.param

--- a/tox.ini
+++ b/tox.ini
@@ -58,12 +58,10 @@ commands =
     poetry run ruff format --check --diff {[vars]all_path}
     find {[vars]all_path} -type f \( -name "*.sh" -o -name "*.bash" \) -exec poetry run shellcheck --color=always \{\} +
 
-[testenv:unit-{juju2, juju3}]
+[testenv:unit]
 description = Run unit tests
 set_env =
     {[testenv]set_env}
-    juju2: LIBJUJU="2.9.44.1"
-    juju3: LIBJUJU="3.2.0.1"
 commands_pre =
     poetry install --only main,charm-libs,unit --no-root
 commands =


### PR DESCRIPTION
## Issue

No reason for having two separate suites for juju2 and juju3 now that we have pytest structure to easily auto-use fixtures.

## Solution

remove both suites, include auto-use fixture