### PR TITLE
[DPE-4296] Fix secret label

### DIFF
--- a/src/relations/async_replication.py
+++ b/src/relations/async_replication.py
@@ -40,6 +40,7 @@ from tenacity import RetryError, Retrying, stop_after_delay, wait_fixed
 
 from constants import (
     APP_SCOPE,
+    PEER,
     POSTGRESQL_DATA_PATH,
     WORKLOAD_OS_GROUP,
     WORKLOAD_OS_USER,
@@ -276,7 +277,7 @@ class PostgreSQLAsyncReplication(Object):
             logger.debug("Secret not found, creating a new one")
             pass
 
-        app_secret = self.charm.model.get_secret(label=f"{self.model.app.name}.app")
+        app_secret = self.charm.model.get_secret(label=f"{PEER}.{self.model.app.name}.app")
         content = app_secret.peek_content()
 
         # Filter out unnecessary secrets.


### PR DESCRIPTION
## Issue
When retrieving the app secret containing the operator’s user passwords in the promotion of a cluster in an async replication setup, the charm fails to try to get the secret labelled as `postgresql-k8s.app`  instead of `database-peers.postgresql-k8s.app`.

This happened after merging https://github.com/canonical/postgresql-k8s-operator/pull/447 to the main branch (which had some changes in the secret handling, which were not merged before to that PR branch).

## Solution
Fix the secret label.

This is a quick fix. To improve it, it should be moved to a common `data_interfaces` interface.

There is a revision in the `14/edge/async-replication` channel with the change from this PR.