### PR TITLE
[DPE-4401] Add retention time for full backups

### DIFF
--- a/src/backups.py
+++ b/src/backups.py
@@ -765,6 +765,7 @@ Stderr:
             stanza=self.stanza_name,
             storage_path=self.charm._storage_path,
             user=BACKUP_USER,
+            retention_full=s3_parameters["delete-older-than-days"],
         )
         # Delete the original file and render the one with the right info.
         filename = "/etc/pgbackrest.conf"
@@ -805,6 +806,7 @@ Stderr:
         s3_parameters.setdefault("region")
         s3_parameters.setdefault("path", "")
         s3_parameters.setdefault("s3-uri-style", "host")
+        s3_parameters.setdefault("delete-older-than-days", "9999999")
 
         # Strip whitespaces from all parameters.
         for key, value in s3_parameters.items():

--- a/templates/pgbackrest.conf.j2
+++ b/templates/pgbackrest.conf.j2
@@ -1,5 +1,6 @@
 [global]
 backup-standby=y
+repo1-retention-full-type=time
 repo1-retention-full={{ retention_full }}
 repo1-type=s3
 repo1-path={{ path }}

--- a/templates/pgbackrest.conf.j2
+++ b/templates/pgbackrest.conf.j2
@@ -1,6 +1,6 @@
 [global]
 backup-standby=y
-repo1-retention-full=9999999
+repo1-retention-full={{ retention_full }}
 repo1-type=s3
 repo1-path={{ path }}
 repo1-s3-region={{ region }}

--- a/tests/unit/test_backups.py
+++ b/tests/unit/test_backups.py
@@ -1448,6 +1448,7 @@ def test_render_pgbackrest_conf_file(harness):
                 "path": "test-path/",
                 "region": "us-east-1",
                 "s3-uri-style": "path",
+                "delete-older-than-days": "30",
             },
             [],
         )
@@ -1469,6 +1470,7 @@ def test_render_pgbackrest_conf_file(harness):
             stanza=harness.charm.backup.stanza_name,
             storage_path=harness.charm._storage_path,
             user="backup",
+            retention_full=30,
         )
 
         # Patch the `open` method with our mock.
@@ -1534,6 +1536,7 @@ def test_retrieve_s3_parameters(
                 {
                     "access-key": "test-access-key",
                     "bucket": "test-bucket",
+                    "delete-older-than-days": "9999999",
                     "endpoint": "https://s3.amazonaws.com",
                     "path": "/",
                     "region": None,
@@ -1553,6 +1556,7 @@ def test_retrieve_s3_parameters(
             "path": " test-path/ ",
             "region": " us-east-1 ",
             "s3-uri-style": " path ",
+            "delete-older-than-days": "30",
         }
         tc.assertEqual(
             harness.charm.backup._retrieve_s3_parameters(),
@@ -1565,6 +1569,7 @@ def test_retrieve_s3_parameters(
                     "region": "us-east-1",
                     "s3-uri-style": "path",
                     "secret-key": "test-secret-key",
+                    "delete-older-than-days": "30",
                 },
                 [],
             ),


### PR DESCRIPTION
## Issue

Link to issue: https://warthogs.atlassian.net/browse/DPE-4401
Link to spec: https://docs.google.com/document/d/1WWMt_Q71cUIrpfYirp5TRCdkJXMjFSWCH6CTnKrO4YA/edit

The parameter `delete-older-than-days` (from s3-integrator) is used to set up retention time (in days) as a pgBackRest parameter, allowing for uses to configure a retention policy for their backups.

## Solution

- Fetches `delete-older-than-days` parameter from S3-integrator relation data.
- Includes `data_platform_libs` patch from https://github.com/canonical/data-platform-libs/pull/168
- Set pgBackRest parameters `repo1-retention-full` and `repo1-retention-full-type=time`
- Modifies unit tests to check for a retention time in days.

## Testing

- Tested locally,
- Unit tests assures `delete-older-than-days` is correctly fetched from s3 parameters,
- Still in discussion about how to proceed about integration testing this feature.