### PR TITLE
[DPE-4336] Reset active status when removing extensions dependency block

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -545,6 +545,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             extensions[extension] = enable
         if self.is_blocked and self.unit.status.message == EXTENSIONS_DEPENDENCY_MESSAGE:
             self._set_active_status()
+            original_status = self.unit.status
         if not isinstance(original_status, UnknownStatus):
             self.unit.status = WaitingStatus("Updating extensions")
         try:

--- a/tests/integration/test_backups.py
+++ b/tests/integration/test_backups.py
@@ -430,7 +430,7 @@ async def test_invalid_config_and_recovery_after_fixing_it(
 
 
 @pytest.mark.group(1)
-async def test_delete_pod(ops_test: OpsTest):
+async def test_delete_pod(ops_test: OpsTest, github_secrets) -> None:
     logger.info("Getting original backup config")
     database_app_name = f"new-{DATABASE_APP_NAME}"
     original_pgbackrest_config = await cat_file_from_unit(


### PR DESCRIPTION
Port of https://github.com/canonical/postgresql-operator/pull/467

* The charm should not restore the blocked status if the blocking condition is no longer valid
* Skip delete pod test in backups if there are no secrets
