### PR TITLE
[MISC] Fine-tune test_backup.py + Ignore secret remove hook

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -142,7 +142,6 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         self.framework.observe(self.on.leader_elected, self._on_leader_elected)
         self.framework.observe(self.on[PEER].relation_changed, self._on_peer_relation_changed)
         self.framework.observe(self.on.secret_changed, self._on_peer_relation_changed)
-        self.framework.observe(self.on.secret_remove, self._on_peer_relation_changed)
         self.framework.observe(self.on[PEER].relation_departed, self._on_peer_relation_departed)
         self.framework.observe(self.on.postgresql_pebble_ready, self._on_postgresql_pebble_ready)
         self.framework.observe(self.on.stop, self._on_stop)

--- a/src/patroni.py
+++ b/src/patroni.py
@@ -456,7 +456,7 @@ class Patroni:
         )
         self._render_file(f"{self._storage_path}/patroni.yml", rendered, 0o644)
 
-    @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=2, max=10))
+    @retry(stop=stop_after_attempt(10), wait=wait_exponential(multiplier=1, min=2, max=30))
     def reload_patroni_configuration(self) -> None:
         """Reloads the configuration after it was updated in the file."""
         requests.post(f"{self._patroni_url}/reload", verify=self._verify)

--- a/tests/integration/test_backups.py
+++ b/tests/integration/test_backups.py
@@ -107,7 +107,7 @@ async def test_backup_and_restore(ops_test: OpsTest, cloud_configs: Tuple[Dict, 
         # (to be able to create backups from replicas).
         database_app_name = f"{DATABASE_APP_NAME}-{cloud.lower()}"
         await build_and_deploy(
-            ops_test, 2, database_app_name=database_app_name, wait_for_idle=True
+            ops_test, 2, database_app_name=database_app_name, wait_for_idle=False
         )
         await ops_test.model.relate(database_app_name, S3_INTEGRATOR_APP_NAME)
         await ops_test.model.relate(database_app_name, TLS_CERTIFICATES_APP_NAME)
@@ -366,9 +366,9 @@ async def test_restore_on_new_cluster(ops_test: OpsTest, github_secrets) -> None
     previous_database_app_name = f"{DATABASE_APP_NAME}-gcp"
     database_app_name = f"new-{DATABASE_APP_NAME}"
     await build_and_deploy(
-        ops_test, 1, database_app_name=previous_database_app_name, wait_for_idle=True
+        ops_test, 1, database_app_name=previous_database_app_name, wait_for_idle=False
     )
-    await build_and_deploy(ops_test, 1, database_app_name=database_app_name, wait_for_idle=True)
+    await build_and_deploy(ops_test, 1, database_app_name=database_app_name, wait_for_idle=False)
     await ops_test.model.relate(previous_database_app_name, S3_INTEGRATOR_APP_NAME)
     await ops_test.model.relate(database_app_name, S3_INTEGRATOR_APP_NAME)
     async with ops_test.fast_forward():


### PR DESCRIPTION
## Issue

Tests are failing much more frequently in the CI: https://github.com/canonical/postgresql-k8s-operator/actions/runs/9174854748/job/25300990262 and https://github.com/canonical/postgresql-k8s-operator/actions/runs/9174950263/job/25327421131

## Solution

3 changes:

- https://github.com/canonical/postgresql-k8s-operator/pull/457: for errors related to event of TLS removal
- revert `wait_for_idle=True` change implemented in [this commit](https://github.com/canonical/postgresql-k8s-operator/commit/1a25c3929747beea7e78467b169b2b345b29d470#diff-8086ca56f97e29bae41b7541a1852d62cf6a6c5b475a9f375a1f6a6b7174c3f0)
- Increase retries on `reload_patroni_configuration` to avoid connectivity errors like the one [here](https://github.com/canonical/postgresql-k8s-operator/actions/runs/9174854748/job/25291314964)