### PR TITLE
[DPE-4413] Use TLS CA chain for backups

### DIFF
--- a/src/backups.py
+++ b/src/backups.py
@@ -68,6 +68,14 @@ class PostgreSQLBackups(Object):
         """Stanza name, composed by model and cluster name."""
         return f"{self.model.name}.{self.charm.cluster_name}"
 
+    @property
+    def _tls_ca_chain_filename(self) -> str:
+        """Returns the path to the TLS CA chain file."""
+        s3_parameters, _ = self._retrieve_s3_parameters()
+        if s3_parameters.get("tls-ca-chain") is not None:
+            return f"{self.charm._storage_path}/pgbackrest-tls-ca-chain.crt"
+        return ""
+
     def _are_backup_settings_ok(self) -> Tuple[bool, Optional[str]]:
         """Validates whether backup settings are OK."""
         if self.model.get_relation(self.relation_name) is None:
@@ -199,7 +207,11 @@ class PostgreSQLBackups(Object):
         )
 
         try:
-            s3 = session.resource("s3", endpoint_url=self._construct_endpoint(s3_parameters))
+            s3 = session.resource(
+                "s3",
+                endpoint_url=self._construct_endpoint(s3_parameters),
+                verify=(self._tls_ca_chain_filename or None),
+            )
         except ValueError as e:
             logger.exception("Failed to create a session '%s' in region=%s.", bucket_name, region)
             raise e
@@ -826,11 +838,9 @@ Stderr:
             )
             return False
 
-        tls_ca_chain_filename = ""
-        if s3_parameters.get("tls-ca-chain") is not None:
-            tls_ca_chain_filename = f"{self.charm._storage_path}/pgbackrest-tls-ca-chain.crt"
+        if self._tls_ca_chain_filename != "":
             self.container.push(
-                tls_ca_chain_filename,
+                self._tls_ca_chain_filename,
                 "\n".join(s3_parameters["tls-ca-chain"]),
                 user=WORKLOAD_OS_USER,
                 group=WORKLOAD_OS_GROUP,
@@ -848,7 +858,7 @@ Stderr:
             endpoint=s3_parameters["endpoint"],
             bucket=s3_parameters["bucket"],
             s3_uri_style=s3_parameters["s3-uri-style"],
-            tls_ca_chain=tls_ca_chain_filename,
+            tls_ca_chain=self._tls_ca_chain_filename,
             access_key=s3_parameters["access-key"],
             secret_key=s3_parameters["secret-key"],
             stanza=self.stanza_name,
@@ -969,7 +979,11 @@ Stderr:
                 region_name=s3_parameters["region"],
             )
 
-            s3 = session.resource("s3", endpoint_url=self._construct_endpoint(s3_parameters))
+            s3 = session.resource(
+                "s3",
+                endpoint_url=self._construct_endpoint(s3_parameters),
+                verify=(self._tls_ca_chain_filename or None),
+            )
             bucket = s3.Bucket(bucket_name)
 
             with tempfile.NamedTemporaryFile() as temp_file:

--- a/src/backups.py
+++ b/src/backups.py
@@ -826,6 +826,16 @@ Stderr:
             )
             return False
 
+        tls_ca_chain_filename = ""
+        if s3_parameters.get("tls-ca-chain") is not None:
+            tls_ca_chain_filename = f"{self.charm._storage_path}/pgbackrest-tls-ca-chain.crt"
+            self.container.push(
+                tls_ca_chain_filename,
+                "\n".join(s3_parameters["tls-ca-chain"]),
+                user=WORKLOAD_OS_USER,
+                group=WORKLOAD_OS_GROUP,
+            )
+
         # Open the template pgbackrest.conf file.
         with open("templates/pgbackrest.conf.j2", "r") as file:
             template = Template(file.read())
@@ -838,6 +848,7 @@ Stderr:
             endpoint=s3_parameters["endpoint"],
             bucket=s3_parameters["bucket"],
             s3_uri_style=s3_parameters["s3-uri-style"],
+            tls_ca_chain=tls_ca_chain_filename,
             access_key=s3_parameters["access-key"],
             secret_key=s3_parameters["secret-key"],
             stanza=self.stanza_name,

--- a/templates/pgbackrest.conf.j2
+++ b/templates/pgbackrest.conf.j2
@@ -9,6 +9,9 @@ repo1-s3-region={{ region }}
 repo1-s3-endpoint={{ endpoint }}
 repo1-s3-bucket={{ bucket }}
 repo1-s3-uri-style={{ s3_uri_style }}
+{%- if tls_ca_chain != '' %}
+repo1-s3-ca-file={{ tls_ca_chain }}
+{%- endif %}
 repo1-s3-key={{ access_key }}
 repo1-s3-key-secret={{ secret_key }}
 repo1-block=y

--- a/tests/unit/test_backups.py
+++ b/tests/unit/test_backups.py
@@ -1529,6 +1529,7 @@ def test_render_pgbackrest_conf_file(harness):
             endpoint="https://storage.googleapis.com",
             bucket="test-bucket",
             s3_uri_style="path",
+            tls_ca_chain=harness.charm.backup._tls_ca_chain_filename,
             access_key="test-access-key",
             secret_key="test-secret-key",
             stanza=harness.charm.backup.stanza_name,
@@ -1762,7 +1763,9 @@ def test_upload_content_to_s3(harness):
             harness.charm.backup._upload_content_to_s3(content, s3_path, s3_parameters),
             False,
         )
-        _resource.assert_called_once_with("s3", endpoint_url="https://s3.us-east-1.amazonaws.com")
+        _resource.assert_called_once_with(
+            "s3", endpoint_url="https://s3.us-east-1.amazonaws.com", verify=None
+        )
         _named_temporary_file.assert_not_called()
         upload_file.assert_not_called()
 
@@ -1773,7 +1776,9 @@ def test_upload_content_to_s3(harness):
             harness.charm.backup._upload_content_to_s3(content, s3_path, s3_parameters),
             False,
         )
-        _resource.assert_called_once_with("s3", endpoint_url="https://s3.us-east-1.amazonaws.com")
+        _resource.assert_called_once_with(
+            "s3", endpoint_url="https://s3.us-east-1.amazonaws.com", verify=None
+        )
         _named_temporary_file.assert_called_once()
         upload_file.assert_called_once_with("/tmp/test-file", "test-path/test-file.")
 
@@ -1786,6 +1791,8 @@ def test_upload_content_to_s3(harness):
             harness.charm.backup._upload_content_to_s3(content, s3_path, s3_parameters),
             True,
         )
-        _resource.assert_called_once_with("s3", endpoint_url="https://s3.us-east-1.amazonaws.com")
+        _resource.assert_called_once_with(
+            "s3", endpoint_url="https://s3.us-east-1.amazonaws.com", verify=None
+        )
         _named_temporary_file.assert_called_once()
         upload_file.assert_called_once_with("/tmp/test-file", "test-path/test-file.")

--- a/tests/unit/test_backups.py
+++ b/tests/unit/test_backups.py
@@ -53,6 +53,33 @@ def test_stanza_name(harness):
     )
 
 
+def test_tls_ca_chain_filename(harness):
+    # Test when the TLS CA chain is not available.
+    tc.assertEqual(
+        harness.charm.backup._tls_ca_chain_filename,
+        "",
+    )
+
+    # Test when the TLS CA chain is available.
+    with harness.hooks_disabled():
+        remote_application = "s3-integrator"
+        s3_rel_id = harness.add_relation(S3_PARAMETERS_RELATION, remote_application)
+        harness.update_relation_data(
+            s3_rel_id,
+            remote_application,
+            {
+                "bucket": "fake-bucket",
+                "access-key": "fake-access-key",
+                "secret-key": "fake-secret-key",
+                "tls-ca-chain": '["fake-tls-ca-chain"]',
+            },
+        )
+    tc.assertEqual(
+        harness.charm.backup._tls_ca_chain_filename,
+        "/var/lib/postgresql/data/pgbackrest-tls-ca-chain.crt",
+    )
+
+
 def test_are_backup_settings_ok(harness):
     # Test without S3 relation.
     tc.assertEqual(
@@ -393,9 +420,16 @@ def test_construct_endpoint(harness):
     )
 
 
-def test_create_bucket_if_not_exists(harness):
+@pytest.mark.parametrize(
+    "tls_ca_chain_filename", ["", "/var/lib/postgresql/data/pgbackrest-tls-ca-chain.crt"]
+)
+def test_create_bucket_if_not_exists(harness, tls_ca_chain_filename):
     with (
         patch("boto3.session.Session.resource") as _resource,
+        patch(
+            "charm.PostgreSQLBackups._tls_ca_chain_filename",
+            new_callable=PropertyMock(return_value=tls_ca_chain_filename),
+        ) as _tls_ca_chain_filename,
         patch("charm.PostgreSQLBackups._retrieve_s3_parameters") as _retrieve_s3_parameters,
     ):
         # Test when there are missing S3 parameters.
@@ -419,11 +453,15 @@ def test_create_bucket_if_not_exists(harness):
             harness.charm.backup._create_bucket_if_not_exists()
 
         # Test when the bucket already exists.
+        _resource.reset_mock()
         _resource.side_effect = None
         head_bucket = _resource.return_value.Bucket.return_value.meta.client.head_bucket
         create = _resource.return_value.Bucket.return_value.create
         wait_until_exists = _resource.return_value.Bucket.return_value.wait_until_exists
         harness.charm.backup._create_bucket_if_not_exists()
+        _resource.assert_called_once_with(
+            "s3", endpoint_url="test-endpoint", verify=(tls_ca_chain_filename or None)
+        )
         head_bucket.assert_called_once()
         create.assert_not_called()
         wait_until_exists.assert_not_called()
@@ -1482,9 +1520,16 @@ def test_pre_restore_checks(harness):
         mock_event.fail.assert_not_called()
 
 
-def test_render_pgbackrest_conf_file(harness):
+@pytest.mark.parametrize(
+    "tls_ca_chain_filename", ["", "/var/lib/postgresql/data/pgbackrest-tls-ca-chain.crt"]
+)
+def test_render_pgbackrest_conf_file(harness, tls_ca_chain_filename):
     with (
         patch("ops.model.Container.push") as _push,
+        patch(
+            "charm.PostgreSQLBackups._tls_ca_chain_filename",
+            new_callable=PropertyMock(return_value=tls_ca_chain_filename),
+        ) as _tls_ca_chain_filename,
         patch("charm.PostgreSQLBackups._retrieve_s3_parameters") as _retrieve_s3_parameters,
     ):
         # Set up a mock for the `open` method, set returned data to postgresql.conf template.
@@ -1513,6 +1558,7 @@ def test_render_pgbackrest_conf_file(harness):
                 "region": "us-east-1",
                 "s3-uri-style": "path",
                 "delete-older-than-days": "30",
+                "tls-ca-chain": (["fake-tls-ca-chain"] if tls_ca_chain_filename != "" else ""),
             },
             [],
         )
@@ -1529,7 +1575,7 @@ def test_render_pgbackrest_conf_file(harness):
             endpoint="https://storage.googleapis.com",
             bucket="test-bucket",
             s3_uri_style="path",
-            tls_ca_chain=harness.charm.backup._tls_ca_chain_filename,
+            tls_ca_chain=(tls_ca_chain_filename or ""),
             access_key="test-access-key",
             secret_key="test-secret-key",
             stanza=harness.charm.backup.stanza_name,
@@ -1547,12 +1593,15 @@ def test_render_pgbackrest_conf_file(harness):
         tc.assertEqual(mock.call_args_list[0][0], ("templates/pgbackrest.conf.j2", "r"))
 
         # Ensure the correct rendered template is sent to _render_file method.
-        _push.assert_called_once_with(
-            "/etc/pgbackrest.conf",
-            expected_content,
-            user="postgres",
-            group="postgres",
-        )
+        calls = [call("/etc/pgbackrest.conf", expected_content, user="postgres", group="postgres")]
+        if tls_ca_chain_filename != "":
+            calls.insert(
+                0,
+                call(
+                    tls_ca_chain_filename, "fake-tls-ca-chain", user="postgres", group="postgres"
+                ),
+            )
+        _push.assert_has_calls(calls)
 
 
 def test_restart_database(harness):
@@ -1736,11 +1785,18 @@ def test_start_stop_pgbackrest_service(harness):
         _restart.assert_called_once()
 
 
-def test_upload_content_to_s3(harness):
+@pytest.mark.parametrize(
+    "tls_ca_chain_filename", ["", "/var/lib/postgresql/data/pgbackrest-tls-ca-chain.crt"]
+)
+def test_upload_content_to_s3(harness, tls_ca_chain_filename):
     with (
         patch("tempfile.NamedTemporaryFile") as _named_temporary_file,
         patch("charm.PostgreSQLBackups._construct_endpoint") as _construct_endpoint,
         patch("boto3.session.Session.resource") as _resource,
+        patch(
+            "charm.PostgreSQLBackups._tls_ca_chain_filename",
+            new_callable=PropertyMock(return_value=tls_ca_chain_filename),
+        ) as _tls_ca_chain_filename,
     ):
         # Set some parameters.
         content = "test-content"
@@ -1764,7 +1820,9 @@ def test_upload_content_to_s3(harness):
             False,
         )
         _resource.assert_called_once_with(
-            "s3", endpoint_url="https://s3.us-east-1.amazonaws.com", verify=None
+            "s3",
+            endpoint_url="https://s3.us-east-1.amazonaws.com",
+            verify=(tls_ca_chain_filename or None),
         )
         _named_temporary_file.assert_not_called()
         upload_file.assert_not_called()
@@ -1777,7 +1835,9 @@ def test_upload_content_to_s3(harness):
             False,
         )
         _resource.assert_called_once_with(
-            "s3", endpoint_url="https://s3.us-east-1.amazonaws.com", verify=None
+            "s3",
+            endpoint_url="https://s3.us-east-1.amazonaws.com",
+            verify=(tls_ca_chain_filename or None),
         )
         _named_temporary_file.assert_called_once()
         upload_file.assert_called_once_with("/tmp/test-file", "test-path/test-file.")
@@ -1792,7 +1852,9 @@ def test_upload_content_to_s3(harness):
             True,
         )
         _resource.assert_called_once_with(
-            "s3", endpoint_url="https://s3.us-east-1.amazonaws.com", verify=None
+            "s3",
+            endpoint_url="https://s3.us-east-1.amazonaws.com",
+            verify=(tls_ca_chain_filename or None),
         )
         _named_temporary_file.assert_called_once()
         upload_file.assert_called_once_with("/tmp/test-file", "test-path/test-file.")


### PR DESCRIPTION
## Issue
It's possible to configure a TLS CA chain in the S3 integrator charm. However, the PostgreSQL charm doesn't use that, so right now, it's not possible to connect to S3-compatible storages which provide a self-signed SSL certificate.

## Solution

Push the TLS CA chain contents to a file and reference it in the pgBackRest configuration (and also in the boto3 calls), so it uses that CA when communicating with the S3-compatible storage.

Manual testing:
1. Build and install the MicroCeph snap from the https://github.com/marceloneppel/microceph/tree/rgw-https-support branch.
```sh
snapcraft -v
sudo snap install --dangerous microceph_*.snap
```
2. Generate the SSL files.
```sh
sudo openssl genrsa -out /var/snap/microceph/common/ca.key 2048
sudo openssl req -x509 -new -nodes -key /var/snap/microceph/common/ca.key -days 1024 -out /var/snap/microceph/common/ca.crt -outform PEM
sudo openssl genrsa -out /var/snap/microceph/common/server.key 2048
sudo openssl req -new -key /var/snap/microceph/common/server.key -out /var/snap/microceph/common/server.csr
sudo nano /var/snap/microceph/common/extfile.cnf # and put the following content: subjectAltName = IP:10.0.1.1,DNS:10.0.1.1
sudo openssl x509 -req -in /var/snap/microceph/common/server.csr -CA /var/snap/microceph/common/ca.crt -CAkey /var/snap/microceph/common/ca.key -CAcreateserial -out /var/snap/microceph/common/server.crt -days 365 -extfile /var/snap/microceph/common/extfile.cnf
```
3. Bootstrap the MicroCeph cluster, enable RadosGW, and create a user for RadosGW:
```sh
sudo microceph cluster bootstrap
sudo microceph disk add loop,4G,3
sudo microceph enable rgw --ssl-certificate=/var/snap/microceph/common/server.crt --ssl-private-key=/var/snap/microceph/common/server.key
sudo microceph.radosgw-admin user create --uid test --display-name test
```
4. Configure your access and secret keys in the AWS CLI, then create a bucket:
```sh
aws configure
aws --endpoint-url=http://localhost s3 mb s3://test --region ""
```
5. Enable microk8s host-access add-on:
```sh
sudo microk8s enable host-access
```
6. Deploy the charm from this PR along with the S3 integrator charm:
```sh
juju deploy s3-integrator

tox -e build-production && juju deploy ./*.charm --resource postgresql-image=ghcr.io/canonical/charmed-postgresql@sha256:76ef26c7d11a524bcac206d5cb042ebc3c8c8ead73fa0cd69d21921552db03b6 --trust

juju config s3-integrator endpoint="https://10.0.1.1" bucket="test" path="/local" region="" s3-uri-style="path" tls-ca-chain="$(base64 -w0 /var/snap/microceph/common/ca.crt)"

juju run s3-integrator/leader sync-s3-credentials access-key=****** secret-key=******

juju relate postgresql-k8s s3-integrator
```
7. Run backup actions (like `create-backup`, `list-backups` and `restore`) as usual.

An integration test using MicroCeph will be added in another PR (because it depends on https://github.com/canonical/microceph/pull/355).

Fixes https://github.com/canonical/postgresql-k8s-operator/issues/479.