### PR TITLE
[DPE-4571] Add experimental max_connections config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -406,3 +406,7 @@ options:
       Allowed values are: from 0 to 2000000000.
     type: int
     default: 150000000
+  experimental_max_connections:
+    type: int
+    description: |
+      [EXPERIMENTAL] Force set max_connections.

--- a/src/charm.py
+++ b/src/charm.py
@@ -1500,8 +1500,14 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             logger.debug("Early exit update_config: Patroni not started yet")
             return False
 
+        # Use config value if set, calculate otherwise
+        if self.config.experimental_max_connections:
+            max_connections = self.config.experimental_max_connections
+        else:
+            max_connections = max(4 * available_cpu_cores, 100)
+
         self._patroni.bulk_update_parameters_controller_by_patroni({
-            "max_connections": max(4 * available_cpu_cores, 100),
+            "max_connections": max_connections,
             "max_prepared_transactions": self.config.memory_max_prepared_transactions,
         })
 

--- a/src/config.py
+++ b/src/config.py
@@ -98,6 +98,7 @@ class CharmConfig(BaseConfigModel):
     vacuum_autovacuum_vacuum_cost_delay: Optional[float]
     vacuum_autovacuum_vacuum_scale_factor: Optional[float]
     vacuum_vacuum_freeze_table_age: Optional[int]
+    experimental_max_connections: Optional[int]
 
     @classmethod
     def keys(cls) -> list[str]:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -176,6 +176,7 @@ async def test_postgresql_parameters_change(ops_test: OpsTest) -> None:
         "memory_max_prepared_transactions": "100",
         "memory_shared_buffers": "128",
         "response_lc_monetary": "en_GB.utf8",
+        "experimental_max_connections": "200",
     })
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", idle_period=30)
     password = await get_password(ops_test)
@@ -188,7 +189,12 @@ async def test_postgresql_parameters_change(ops_test: OpsTest) -> None:
             with psycopg2.connect(
                 f"dbname='postgres' user='operator' host='{host}' password='{password}' connect_timeout=1"
             ) as connection, connection.cursor() as cursor:
-                settings_names = ["max_prepared_transactions", "shared_buffers", "lc_monetary"]
+                settings_names = [
+                    "max_prepared_transactions",
+                    "shared_buffers",
+                    "lc_monetary",
+                    "max_connections",
+                ]
                 cursor.execute(
                     sql.SQL("SELECT name,setting FROM pg_settings WHERE name IN ({});").format(
                         sql.SQL(", ").join(sql.Placeholder() * len(settings_names))
@@ -202,6 +208,7 @@ async def test_postgresql_parameters_change(ops_test: OpsTest) -> None:
                 assert settings["max_prepared_transactions"] == "100"
                 assert settings["shared_buffers"] == "128"
                 assert settings["lc_monetary"] == "en_GB.utf8"
+                assert settings["max_connections"] == "200"
         finally:
             connection.close()
 


### PR DESCRIPTION
Adds experimental support for force setting max_connections.

Port of https://github.com/canonical/postgresql-operator/pull/472
Related to #499