### PR TITLE
Update sync_docs.yaml

### DIFF
--- a/.github/workflows/sync_docs.yaml
+++ b/.github/workflows/sync_docs.yaml
@@ -12,8 +12,8 @@ jobs:
     name: Sync docs from Discourse
     uses: canonical/data-platform-workflows/.github/workflows/_sync_docs.yaml@v13.3.0
     secrets:
-      discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}
-      discourse_api_key: ${{ secrets.DISCOURSE_API_KEY }}
+      discourse-api-user: ${{ secrets.DISCOURSE_API_USERNAME }}
+      discourse-api-key: ${{ secrets.DISCOURSE_API_KEY }}
     permissions:
       contents: write  # Needed to push branch & tag
       pull-requests: write  # Needed to create PR


### PR DESCRIPTION
## Issue
Workflow fails due to incorrect input keys for the discourse credentials.

## Solution
Changed the keys to match those defined in [`data-platform-workflows`](https://github.com/canonical/data-platform-workflows/blob/4885220b28fecc7ee684b6b59b55c58cbd92995f/.github/workflows/_sync_docs.yaml#L4-L7).