### PR TITLE
[DPE-4369] SQL queries exposing passwords on postgresql logs

### DIFF
--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -36,7 +36,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 26
+LIBPATCH = 27
 
 INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE = "invalid role(s) for extra user roles"
 

--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -36,7 +36,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 27
+LIBPATCH = 28
 
 INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE = "invalid role(s) for extra user roles"
 

--- a/tests/integration/new_relations/test_new_relations.py
+++ b/tests/integration/new_relations/test_new_relations.py
@@ -591,11 +591,7 @@ async def test_discourse(ops_test: OpsTest):
     await gather(
         ops_test.model.deploy(DISCOURSE_APP_NAME, application_name=DISCOURSE_APP_NAME),
         ops_test.model.deploy(
-            REDIS_APP_NAME,
-            application_name=REDIS_APP_NAME,
-            channel="latest/edge",
-            revision=28,
-            series="jammy",
+            REDIS_APP_NAME, application_name=REDIS_APP_NAME, channel="latest/edge"
         ),
     )
 

--- a/tests/integration/new_relations/test_new_relations.py
+++ b/tests/integration/new_relations/test_new_relations.py
@@ -590,7 +590,6 @@ async def test_discourse(ops_test: OpsTest):
     # Deploy Discourse and Redis.
     await gather(
         ops_test.model.deploy(DISCOURSE_APP_NAME, application_name=DISCOURSE_APP_NAME),
-        # Revision 28 is being used due to https://github.com/canonical/redis-k8s-operator/issues/87.
         ops_test.model.deploy(
             REDIS_APP_NAME,
             application_name=REDIS_APP_NAME,

--- a/tests/integration/new_relations/test_new_relations.py
+++ b/tests/integration/new_relations/test_new_relations.py
@@ -590,8 +590,9 @@ async def test_discourse(ops_test: OpsTest):
     # Deploy Discourse and Redis.
     await gather(
         ops_test.model.deploy(DISCOURSE_APP_NAME, application_name=DISCOURSE_APP_NAME),
+        # Revision 28 is being used due to https://github.com/canonical/redis-k8s-operator/issues/87.
         ops_test.model.deploy(
-            REDIS_APP_NAME, application_name=REDIS_APP_NAME, channel="latest/edge"
+            REDIS_APP_NAME, application_name=REDIS_APP_NAME, channel="latest/edge", revision=28
         ),
     )
 


### PR DESCRIPTION
## Issue

config value `log_statement = 'ddl'` logs queries such as `ALTER USER/ROLE`, `CREATE USER/ROLE` that expose users passwords on log files.

## Solution

set `log_statement='none'` when submitting sensitive queries:

```
BEGIN;
SET LOCAL log_statement = 'none';
CREATE ROLE "backup" WITH LOGIN SUPERUSER ENCRYPTED PASSWORD 'MRiT223dummy2322nHESx';
...
COMMIT;
```

## Test

New integration test failing before the change: https://github.com/canonical/postgresql-k8s-operator/actions/runs/9483057657/job/26129752923#step:21:386
... and passing after the change: https://github.com/canonical/postgresql-k8s-operator/actions/runs/9483490912/job/26131217890?pr=506#step:21:182