### PR TITLE
[DPE-2278] Add libpq's connection string URI format to `uri` field in relation databag

### DIFF
--- a/src/relations/postgresql_provider.py
+++ b/src/relations/postgresql_provider.py
@@ -109,6 +109,12 @@ class PostgreSQLProvider(Object):
                 f"{self.charm.primary_endpoint}:{DATABASE_PORT}",
             )
 
+            # Set connection string URI.
+            self.database_provides.set_uris(
+                event.relation.id,
+                f"postgresql://{user}:{password}@{self.charm.primary_endpoint}:{DATABASE_PORT}/{database}",
+            )
+
             # Update the read-only endpoint.
             self.update_read_only_endpoint(event)
 

--- a/tests/integration/new_relations/test_new_relations.py
+++ b/tests/integration/new_relations/test_new_relations.py
@@ -115,17 +115,9 @@ async def test_database_relation_with_charm_libraries(ops_test: OpsTest, databas
             assert password is None
 
     # Get the connection string to connect to the database using the read/write endpoint.
-    connection_string = await get_application_relation_data(
-        ops_test,
-        APPLICATION_APP_NAME,
-        FIRST_DATABASE_RELATION_NAME,
-        "uris",
-    )
-    old_conn_str = await build_connection_string(
+    connection_string = await build_connection_string(
         ops_test, APPLICATION_APP_NAME, FIRST_DATABASE_RELATION_NAME
     )
-    print(f"old conn string = {old_conn_str}")
-    print(f"connection_string = {connection_string}")
 
     # Connect to the database using the read/write endpoint.
     with psycopg2.connect(connection_string) as connection, connection.cursor() as cursor:

--- a/tests/integration/new_relations/test_new_relations.py
+++ b/tests/integration/new_relations/test_new_relations.py
@@ -115,8 +115,11 @@ async def test_database_relation_with_charm_libraries(ops_test: OpsTest, databas
             assert password is None
 
     # Get the connection string to connect to the database using the read/write endpoint.
-    connection_string = await build_connection_string(
-        ops_test, APPLICATION_APP_NAME, FIRST_DATABASE_RELATION_NAME
+    connection_string = get_application_relation_data(
+        ops_test,
+        APPLICATION_APP_NAME,
+        FIRST_DATABASE_RELATION_NAME,
+        "uris",
     )
 
     # Connect to the database using the read/write endpoint.

--- a/tests/integration/new_relations/test_new_relations.py
+++ b/tests/integration/new_relations/test_new_relations.py
@@ -115,7 +115,7 @@ async def test_database_relation_with_charm_libraries(ops_test: OpsTest, databas
             assert password is None
 
     # Get the connection string to connect to the database using the read/write endpoint.
-    connection_string = get_application_relation_data(
+    connection_string = await get_application_relation_data(
         ops_test,
         APPLICATION_APP_NAME,
         FIRST_DATABASE_RELATION_NAME,

--- a/tests/integration/new_relations/test_new_relations.py
+++ b/tests/integration/new_relations/test_new_relations.py
@@ -121,6 +121,11 @@ async def test_database_relation_with_charm_libraries(ops_test: OpsTest, databas
         FIRST_DATABASE_RELATION_NAME,
         "uris",
     )
+    old_conn_str = await build_connection_string(
+        ops_test, APPLICATION_APP_NAME, FIRST_DATABASE_RELATION_NAME
+    )
+    print(f"old conn string = {old_conn_str}")
+    print(f"connection_string = {connection_string}")
 
     # Connect to the database using the read/write endpoint.
     with psycopg2.connect(connection_string) as connection, connection.cursor() as cursor:

--- a/tests/unit/test_postgresql_provider.py
+++ b/tests/unit/test_postgresql_provider.py
@@ -126,6 +126,7 @@ def test_on_database_requested(harness):
             "username": user,
             "password": "test-password",
             "read-only-endpoints": "postgresql-k8s-replicas.None.svc.cluster.local:5432",
+            "uris": f"postgresql://{user}:test-password@postgresql-k8s-primary.None.svc.cluster.local:5432/{DATABASE}",
             "version": POSTGRESQL_VERSION,
             "database": f"{DATABASE}",
         }
@@ -140,6 +141,7 @@ def test_on_database_requested(harness):
         assert harness.get_relation_data(rel_id, harness.charm.app.name) == {
             "data": f'{{"database": "{DATABASE}", "extra-user-roles": "{EXTRA_USER_ROLES}"}}',
             "endpoints": "postgresql-k8s-primary.None.svc.cluster.local:5432",
+            "uris": f"postgresql://{user}:test-password@postgresql-k8s-primary.None.svc.cluster.local:5432/{DATABASE}",
             "read-only-endpoints": "postgresql-k8s-replicas.None.svc.cluster.local:5432",
         }
 
@@ -151,6 +153,7 @@ def test_on_database_requested(harness):
             "data": f'{{"database": "{DATABASE}", "extra-user-roles": "{EXTRA_USER_ROLES}"}}',
             "endpoints": "postgresql-k8s-primary.None.svc.cluster.local:5432",
             "read-only-endpoints": "postgresql-k8s-replicas.None.svc.cluster.local:5432",
+            "uris": f"postgresql://{user}:test-password@postgresql-k8s-primary.None.svc.cluster.local:5432/{DATABASE}",
         }
 
         # BlockedStatus due to a PostgreSQLGetPostgreSQLVersionError.


### PR DESCRIPTION
## Issue
https://warthogs.atlassian.net/browse/DPE-2278 - Right now, it is up to the client application to build the connection string.

## Solution
Proposed solution: use the already existing `uri` field from the `data_interfaces` lib to pass the correctly formed libpq URI [as described here](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS) to client apps. The read-write primary endpoint is used for it.
