### PR TITLE
[DPE-4801] Block charm if plugin disable fails due to dependent objects

### DIFF
--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -330,6 +330,8 @@ class PostgreSQL:
                         )
         except psycopg2.errors.UniqueViolation:
             pass
+        except psycopg2.errors.DependentObjectsStillExist:
+            raise
         except psycopg2.Error:
             raise PostgreSQLEnableDisableExtensionError()
         finally:

--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -37,7 +37,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 31
+LIBPATCH = 32
 
 INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE = "invalid role(s) for extra user roles"
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -640,7 +640,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             self.postgresql.enable_disable_extensions(extensions, database)
         except psycopg2.errors.DependentObjectsStillExist as e:
             logger.error(
-                "Failed to disable plugin: %s Was the plugin enabled manually? If so, update charm config with `juju config postgresql-k8s plugin_<plugin name>_enable=True` ",
+                "Failed to disable plugin: %s\nWas the plugin enabled manually? If so, update charm config with `juju config postgresql-k8s plugin_<plugin_name>_enable=True`",
                 str(e),
             )
             self.unit.status = BlockedStatus(EXTENSION_OBJECT_MESSAGE)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -598,6 +598,14 @@ def test_enable_disable_extensions(harness):
             None,
         )
 
+        # Block if extension-dependent object error is raised
+        _enable_disable_extensions.side_effect = [psycopg2.errors.DependentObjectsStillExist, None]
+        harness.charm.enable_disable_extensions()
+        assert isinstance(harness.charm.unit.status, BlockedStatus)
+        # Should resolve afterwards
+        harness.charm.enable_disable_extensions()
+        assert isinstance(harness.charm.unit.status, ActiveStatus)
+
 
 def test_on_peer_relation_departed(harness):
     with (


### PR DESCRIPTION
## Issue

See https://github.com/canonical/postgresql-k8s-operator/issues/536

## Solution

If the charm detects objects that depend on plugins not enabled via config (most likely because the plugin was externally enabled) It will go into blocked state and warn the user. 

The user can then decide to either: Delete the objects and proceed with the plugin disabled (without updating the config) or update the juju config option of the plugin as enabled.

Local testing works, Will add unit/integration tests shortly.