### PR TITLE
[DPE-4227] Fix storage ownership

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -822,6 +822,12 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             container.make_dir(
                 path, permissions=0o770, user=WORKLOAD_OS_USER, group=WORKLOAD_OS_GROUP
             )
+        # Also, fix the permissions from the parent directory.
+        container.exec([
+            "chown",
+            f"{WORKLOAD_OS_USER}:{WORKLOAD_OS_GROUP}",
+            self._storage_path,
+        ]).wait()
 
     def _on_postgresql_pebble_ready(self, event: WorkloadEvent) -> None:
         """Event handler for PostgreSQL container on PebbleReadyEvent."""


### PR DESCRIPTION
## Issue
If Patroni needs to reinitialise the data directory in the replicas and the storage where the data directory is created is mounted without permission for the `postgres` users to write on it, Patroni will fail its operation.

## Solution
Fix the permissions of the data directory parent directory to enable Patroni to move/remove directories when needed.

Fixes https://github.com/canonical/postgresql-k8s-operator/issues/460.