### PR TITLE
[DPE-4990] Fix PITR test on Juju 2.9

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -1356,8 +1356,9 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
                 self.unit.status = BlockedStatus(CANNOT_RESTORE_PITR)
                 return False
 
-            logger.error("Restore failed: database service failed to start")
-            self.unit.status = BlockedStatus("Failed to restore backup")
+            if self.unit.status.message != CANNOT_RESTORE_PITR:
+                logger.error("Restore failed: database service failed to start")
+                self.unit.status = BlockedStatus("Failed to restore backup")
             return False
 
         if not self._patroni.member_started:


### PR DESCRIPTION
## Issue
The new PITR test is failing on Juju 2.9 (https://github.com/canonical/postgresql-k8s-operator/actions/runs/10116043301/job/27978532633#step:26:974):
```sh
unit-postgresql-k8s-aws-0: 12:51:44 ERROR unit.postgresql-k8s-aws/0.juju-log Uncaught exception while in charm code:
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-postgresql-k8s-aws-0/charm/./src/charm.py", line 2052, in <module>
    main(PostgresqlOperatorCharm, use_juju_for_storage=True)
  File "/var/lib/juju/agents/unit-postgresql-k8s-aws-0/charm/venv/ops/main.py", line 551, in main
    manager.run()
  File "/var/lib/juju/agents/unit-postgresql-k8s-aws-0/charm/venv/ops/main.py", line 530, in run
    self._emit()
  File "/var/lib/juju/agents/unit-postgresql-k8s-aws-0/charm/venv/ops/main.py", line 519, in _emit
    _emit_charm_event(self.charm, self.dispatcher.event_name)
  File "/var/lib/juju/agents/unit-postgresql-k8s-aws-0/charm/venv/ops/main.py", line 147, in _emit_charm_event
    event_to_emit.emit(*args, **kwargs)
  File "/var/lib/juju/agents/unit-postgresql-k8s-aws-0/charm/venv/ops/framework.py", line 348, in emit
    framework._emit(event)
  File "/var/lib/juju/agents/unit-postgresql-k8s-aws-0/charm/venv/ops/framework.py", line 860, in _emit
    self._reemit(event_path)
  File "/var/lib/juju/agents/unit-postgresql-k8s-aws-0/charm/venv/ops/framework.py", line 950, in _reemit
    custom_handler(event)
  File "/var/lib/juju/agents/unit-postgresql-k8s-aws-0/charm/lib/charms/tempo_k8s/v1/charm_tracing.py", line 647, in wrapped_function
    return callable(*args, **kwargs)  # type: ignore
  File "/var/lib/juju/agents/unit-postgresql-k8s-aws-0/charm/./src/charm.py", line 1328, in _on_update_status
    ) and not self._was_restore_successful(container, services[0]):
  File "/var/lib/juju/agents/unit-postgresql-k8s-aws-0/charm/lib/charms/tempo_k8s/v1/charm_tracing.py", line 647, in wrapped_function
    return callable(*args, **kwargs)  # type: ignore
  File "/var/lib/juju/agents/unit-postgresql-k8s-aws-0/charm/./src/charm.py", line 1342, in _was_restore_successful
    if "restore-to-time" in self.app_peer_data and all(self.is_pitr_failed(container)):
  File "/var/lib/juju/agents/unit-postgresql-k8s-aws-0/charm/lib/charms/tempo_k8s/v1/charm_tracing.py", line 647, in wrapped_function
    return callable(*args, **kwargs)  # type: ignore
  File "/var/lib/juju/agents/unit-postgresql-k8s-aws-0/charm/./src/charm.py", line 2025, in is_pitr_failed
    patroni_logs = log_exec.wait_output()[0]
  File "/var/lib/juju/agents/unit-postgresql-k8s-aws-0/charm/venv/ops/pebble.py", line 1771, in wait_output
    raise ExecError[AnyStr](self._command, exit_code, out_value, err_value)
ops.pebble.ExecError: non-zero exit code 1 executing ['pebble', 'logs', 'postgresql'], stdout='error: cannot communicate with server: Get "http://localhost/v1/logs?n=30&services=postgresql": socket "/var/lib/pebble/default/.pebble.socket" not found\n'
unit-postgresql-k8s-aws-0: 12:51:45 ERROR juju.worker.uniter.operation hook "update-status" (via hook dispatching script: dispatch) failed: exit status 1
```

## Solution
Get the logs from the Patroni log file on Juju 2.9.

Unit test coverage will be increased through [DPE-4991](https://warthogs.atlassian.net/browse/DPE-4991).

[DPE-4991]: https://warthogs.atlassian.net/browse/DPE-4991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ