### PR TITLE
[MISC] Adds missing `await` to `invalid_extra_user_roles` integration test + fix check loop

### DIFF
--- a/src/relations/postgresql_provider.py
+++ b/src/relations/postgresql_provider.py
@@ -252,7 +252,7 @@ class PostgreSQLProvider(Object):
             for data in relation.data.values():
                 extra_user_roles = data.get("extra-user-roles")
                 if extra_user_roles is None:
-                    break
+                    continue
                 extra_user_roles = extra_user_roles.lower().split(",")
                 for extra_user_role in extra_user_roles:
                     if (

--- a/tests/integration/new_relations/test_new_relations.py
+++ b/tests/integration/new_relations/test_new_relations.py
@@ -552,7 +552,7 @@ async def test_invalid_extra_user_roles(ops_test: OpsTest):
         for app in data_integrator_apps_names:
             await ops_test.model.add_relation(f"{app}:postgresql", f"{DATABASE_APP_NAME}:database")
         await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME])
-        ops_test.model.block_until(
+        await ops_test.model.block_until(
             lambda: any(
                 unit.workload_status_message == INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE
                 for unit in ops_test.model.applications[DATABASE_APP_NAME].units
@@ -566,7 +566,7 @@ async def test_invalid_extra_user_roles(ops_test: OpsTest):
             f"{DATABASE_APP_NAME}:database", f"{DATA_INTEGRATOR_APP_NAME}:postgresql"
         )
         await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME])
-        ops_test.model.block_until(
+        await ops_test.model.block_until(
             lambda: any(
                 unit.workload_status_message == INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE
                 for unit in ops_test.model.applications[DATABASE_APP_NAME].units


### PR DESCRIPTION
## Issue

New relations integration test had a typo in `test_invalid_extra_user_roles` where two `block_until` calls were not being properly awaited. Once those were added, the test started failing due to blocked status resolving when it shouldn't have.

## Solution

- Add the necessary `await`s
- Use `continue` instead of `break` inside check loop to resolve the blocked status for invalid extra user roles.

This was previously done on VM inside https://github.com/canonical/postgresql-operator/pull/546