### PR TITLE
[DPE-5019] Fix get-password action description

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -21,8 +21,9 @@ create-replication:
 get-primary:
   description: Get the unit with is the primary/leader in the replication.
 get-password:
-  description: Get the system user's password, which is used by charm.
-    It is for internal charm users and SHOULD NOT be used by applications.
+  description: Get a charm system user's password.
+    Useful for manual troubleshooting and for backing up cluster credentials.
+    It cannot be used for application integration relations.
   params:
     username:
       type: string

--- a/actions.yaml
+++ b/actions.yaml
@@ -21,7 +21,7 @@ create-replication:
 get-primary:
   description: Get the unit with is the primary/leader in the replication.
 get-password:
-  description: Change the system user's password, which is used by charm.
+  description: Get the system user's password, which is used by charm.
     It is for internal charm users and SHOULD NOT be used by applications.
   params:
     username:


### PR DESCRIPTION
## Issue
The `get-password` action has the wrong description (it was copied from the `set-password` action).

## Solution
Update to use the correct description for the action (the same we have in the VM charm).

Fixes https://github.com/canonical/postgresql-k8s-operator/issues/603.