### PR TITLE
[DPE-4889] Remove deprecated config option profile-limit-memory

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -311,20 +311,12 @@ options:
       minimal running performance.
    type: string
    default: "production"
-  profile-limit-memory:
-    type: int
-    description: |
-      [DEPRECTATED] Use profile_limit_memory instead. Amount of memory in Megabytes to limit PostgreSQL
-      and associated process to. If unset, this will be decided according to the default memory limit
-      in the selected profile. Only comes into effect when the `production` profile is selected. This
-      config option cannot be set at the same time as profile_limit_memory.
   profile_limit_memory:
     type: int
     description: |
       Amount of memory in Megabytes to limit PostgreSQL and associated process to.
       If unset, this will be decided according to the default memory limit in the selected profile.
-      Only comes into effect when the `production` profile is selected. This config option cannot be
-      set at the same time as profile-limit-memory.
+      Only comes into effect when the `production` profile is selected.
   request_date_style:
     description: |
       Sets the display format for date and time values. Allowed formats are explained

--- a/src/charm.py
+++ b/src/charm.py
@@ -1701,13 +1701,6 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
     def update_config(self, is_creating_backup: bool = False) -> bool:
         """Updates Patroni config file based on the existence of the TLS files."""
         # Retrieve PostgreSQL parameters.
-        if (
-            self.model.config.get("profile-limit-memory") is not None
-            and self.model.config.get("profile_limit_memory") is not None
-        ):
-            raise ValueError(
-                "Both profile-limit-memory and profile_limit_memory are set. Please use only one of them."
-            )
         if self.config.profile_limit_memory:
             limit_memory = self.config.profile_limit_memory * 10**6
         else:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1599,26 +1599,11 @@ def test_update_config(harness):
         harness.set_can_connect(POSTGRESQL_CONTAINER, True)
         harness.add_relation("upgrade", harness.charm.app.name)
         postgresql_mock.is_tls_enabled = PropertyMock(side_effect=[False, False, False, False])
-        _is_workload_running.side_effect = [False, False, True, True, False, True]
+        _is_workload_running.side_effect = [True, True, False, True]
         _member_started.side_effect = [True, True, False]
         postgresql_mock.build_postgresql_parameters.return_value = {"test": "test"}
 
-        # Test when only one of the two config options for profile limit memory is set.
-        harness.update_config({"profile-limit-memory": 1000})
-        harness.charm.update_config()
-
-        # Test when only one of the two config options for profile limit memory is set.
-        harness.update_config({"profile_limit_memory": 1000}, unset={"profile-limit-memory"})
-        harness.charm.update_config()
-
-        # Test when the two config options for profile limit memory are set at the same time.
-        _render_patroni_yml_file.reset_mock()
-        harness.update_config({"profile-limit-memory": 1000})
-        with tc.assertRaises(ValueError):
-            harness.charm.update_config()
-
         # Test without TLS files available.
-        harness.update_config(unset={"profile-limit-memory", "profile_limit_memory"})
         with harness.hooks_disabled():
             harness.update_relation_data(rel_id, harness.charm.unit.name, {"tls": ""})
         _is_tls_enabled.return_value = False


### PR DESCRIPTION
## Issue

See ticket, related to https://github.com/canonical/postgresql-operator/pull/564

## Solution
