### PR TITLE
bugfix: import JujuVersion from ops.jujuversion instead of ops.model

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -55,12 +55,12 @@ from ops.charm import (
     RelationDepartedEvent,
     WorkloadEvent,
 )
+from ops.jujuversion import JujuVersion
 from ops.main import main
 from ops.model import (
     ActiveStatus,
     BlockedStatus,
     Container,
-    JujuVersion,
     MaintenanceStatus,
     ModelError,
     Relation,


### PR DESCRIPTION
## Issue

https://github.com/canonical/postgresql-k8s-operator/issues/638

## Solution

Import `JujuVersion` from `ops.jujuversion` instead of `ops.model`.

Current, importing `JujuVersion` from `ops.model` works but only because `ops.model` happens to import `JujuVersion from `ops.jujuversion`. This will be changed soon, so we should import `JujuVersion` from `ops.jujuversion`.
