### PR TITLE
chore: update jujuversion import

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -55,7 +55,7 @@ from ops.charm import (
     RelationDepartedEvent,
     WorkloadEvent,
 )
-from ops.jujuversion import JujuVersion
+from ops import JujuVersion
 from ops.main import main
 from ops.model import (
     ActiveStatus,


### PR DESCRIPTION
## Issue

https://github.com/canonical/postgresql-k8s-operator/pull/640

## Solution

See more detail in the issue, but sorry to bother you again, because after discussion, we will change `ops.jujuversion` as well, so [my previous PR](https://github.com/canonical/postgresql-k8s-operator/pull/640) won't work in the future, and now I'm creating a new PR to fix it once and for all.