### PR TITLE
[DPE-4239] Use manifest file to check for charm architecture

### DIFF
--- a/src/arch_utils.py
+++ b/src/arch_utils.py
@@ -26,7 +26,7 @@ class WrongArchitectureWarningCharm(CharmBase):
 
 def is_wrong_architecture() -> bool:
     """Checks if charm was deployed on wrong architecture."""
-    juju_charm_file = f"/var/lib/juju/agents/{os.environ.get('HOSTNAME')}/charm/.juju-charm"
+    juju_charm_file = f"/var/lib/juju/agents/unit-{os.environ.get('HOSTNAME')}/charm/.juju-charm"
     if not os.path.exists(juju_charm_file):
         logger.error("Cannot check architecture: .juju-charm file not found")
         return False

--- a/src/arch_utils.py
+++ b/src/arch_utils.py
@@ -26,19 +26,21 @@ class WrongArchitectureWarningCharm(CharmBase):
 
 def is_wrong_architecture() -> bool:
     """Checks if charm was deployed on wrong architecture."""
-    juju_charm_file = f"{os.environ.get('CHARM_DIR')}/manifest.yaml"
-    if not os.path.exists(juju_charm_file):
-        logger.error("Cannot check architecture: manifest file not found in %s", juju_charm_file)
+    manifest_file_path = f"{os.environ.get('CHARM_DIR')}/manifest.yaml"
+    if not os.path.exists(manifest_file_path):
+        logger.error(
+            "Cannot check architecture: manifest file not found in %s", manifest_file_path
+        )
         return False
 
-    with open(juju_charm_file, "r") as file:
-        ch_platform = file.read()
+    with open(manifest_file_path, "r") as file:
+        manifest = file.read()
     hw_arch = os.uname().machine
-    if ("amd64" in ch_platform and hw_arch == "x86_64") or (
-        "arm64" in ch_platform and hw_arch == "aarch64"
+    if ("amd64" in manifest and hw_arch == "x86_64") or (
+        "arm64" in manifest and hw_arch == "aarch64"
     ):
-        logger.info("Architecture matches: %s charm for %s machine", ch_platform, hw_arch)
+        logger.info("Charm architecture matches")
         return False
 
-    logger.error("Architecture does not match: %s charm for %s machine", ch_platform, hw_arch)
+    logger.error("Charm architecture does not match")
     return True

--- a/src/arch_utils.py
+++ b/src/arch_utils.py
@@ -26,9 +26,9 @@ class WrongArchitectureWarningCharm(CharmBase):
 
 def is_wrong_architecture() -> bool:
     """Checks if charm was deployed on wrong architecture."""
-    juju_charm_file = f"/var/lib/juju/agents/unit-{os.environ.get('HOSTNAME')}/charm/.juju-charm"
+    juju_charm_file = f"/var/lib/juju/agents/unit-{os.environ.get('HOSTNAME')}/charm/manifest.yaml"
     if not os.path.exists(juju_charm_file):
-        logger.error("Cannot check architecture: .juju-charm file not found")
+        logger.error("Cannot check architecture: manifest file not found in %s", juju_charm_file)
         return False
 
     with open(juju_charm_file, "r") as file:

--- a/src/arch_utils.py
+++ b/src/arch_utils.py
@@ -12,9 +12,6 @@ from ops.model import BlockedStatus
 
 logger = logging.getLogger(__name__)
 
-logging.getLogger("httpcore").setLevel(logging.ERROR)
-logging.getLogger("httpx").setLevel(logging.ERROR)
-
 
 class WrongArchitectureWarningCharm(CharmBase):
     """A fake charm class that only signals a wrong architecture deploy."""

--- a/src/arch_utils.py
+++ b/src/arch_utils.py
@@ -26,7 +26,7 @@ class WrongArchitectureWarningCharm(CharmBase):
 
 def is_wrong_architecture() -> bool:
     """Checks if charm was deployed on wrong architecture."""
-    juju_charm_file = f"/var/lib/juju/agents/unit-{os.environ.get('HOSTNAME')}/charm/manifest.yaml"
+    juju_charm_file = f"{os.environ.get('CHARM_DIR')}/manifest.yaml"
     if not os.path.exists(juju_charm_file):
         logger.error("Cannot check architecture: manifest file not found in %s", juju_charm_file)
         return False

--- a/src/arch_utils.py
+++ b/src/arch_utils.py
@@ -29,7 +29,7 @@ class WrongArchitectureWarningCharm(CharmBase):
 
 def is_wrong_architecture() -> bool:
     """Checks if charm was deployed on wrong architecture."""
-    juju_charm_file = f"{os.environ.get('CHARM_DIR')}/.juju-charm"
+    juju_charm_file = f"/var/lib/juju/agents/{os.environ.get("HOSTNAME")}/charm/.juju-charm"
     if not os.path.exists(juju_charm_file):
         logger.error("Cannot check architecture: .juju-charm file not found")
         return False

--- a/src/arch_utils.py
+++ b/src/arch_utils.py
@@ -26,7 +26,7 @@ class WrongArchitectureWarningCharm(CharmBase):
 
 def is_wrong_architecture() -> bool:
     """Checks if charm was deployed on wrong architecture."""
-    juju_charm_file = f"/var/lib/juju/agents/{os.environ.get("HOSTNAME")}/charm/.juju-charm"
+    juju_charm_file = f"/var/lib/juju/agents/{os.environ.get('HOSTNAME')}/charm/.juju-charm"
     if not os.path.exists(juju_charm_file):
         logger.error("Cannot check architecture: .juju-charm file not found")
         return False


### PR DESCRIPTION
## Issue
Fixes a bug reported on https://github.com/canonical/postgresql-k8s-operator/pull/613#issuecomment-2294369041 where the import error would get re-raised because the architecture check was not working properly (returning `False` due to not finding the `.juju-charm` file). 

## Solution

Use `manifest.yaml` instead of `.juju-charm`, it is a more reliable check for some reason.

## Test

CI pass (always have been, apparently jujus 2.9 and 3.4 never had the problem?) + local tests on AMD and juju 3.5 work + @marceloneppel tested on ARM + juju 3.5 and also worked. Should be fine now!
