### PR TITLE
[DPE-5311] Enable DCS failsafe mode

### DIFF
--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -1,6 +1,7 @@
 bootstrap:
   dcs:
     synchronous_mode: true
+    failsafe_mode: true
     synchronous_node_count: {{ minority_count }}
     postgresql:
       use_pg_rewind: true


### PR DESCRIPTION
## Issue
Patroni depends on the K8s API and resources to maintain the leader lock. Primary will step down during a temporary K8s API outage

## Solution
Enable DCS failsafe mode. If the K8s API (DCS) is not available, Patroni will try to maintain the current primary if it can connect to all cluster members

Documentation: https://patroni.readthedocs.io/en/latest/dcs_failsafe_mode.html#dcs-failsafe-mode

Related #669 and #616