### PR TITLE
[DPE-3887] Add log for fix_leader_annotation method

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -849,6 +849,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
                     Endpoints, name=self.cluster_name, namespace=self._namespace, obj=patch
                 )
                 self.app_peer_data.pop("cluster_initialised", None)
+                logger.info("Fixed missing leader annotation")
         except ApiError as e:
             if e.status.code == 403:
                 self.on_deployed_without_trust()


### PR DESCRIPTION
## Issue
We don't know all the moments when the `leader` annotation is fixed (we know that one situation - expected - is after a scale down to 0 units and then a scale up to 1 unit), which causes the `cluster_initialised` flag to be removed from the peer relation data.

## Solution
Add a log for the `fix_leader_annotation` method.