### PR TITLE
[DPE-3887] Avoid replication slot deletion

### DIFF
--- a/tests/integration/ha_tests/test_restart.py
+++ b/tests/integration/ha_tests/test_restart.py
@@ -9,18 +9,19 @@ from kubernetes import config, dynamic
 from kubernetes.client import api_client
 from pytest_operator.plugin import OpsTest
 
-from .helpers import (
-    are_writes_increasing,
-    check_writes,
-    start_continuous_writes,
-)
 from ..helpers import (
     APPLICATION_NAME,
     DATABASE_APP_NAME,
     build_and_deploy,
+    get_application_units,
+    get_cluster_members,
     get_primary,
     get_unit_address,
-    get_application_units, get_cluster_members,
+)
+from .helpers import (
+    are_writes_increasing,
+    check_writes,
+    start_continuous_writes,
 )
 
 logger = logging.getLogger(__name__)
@@ -31,27 +32,23 @@ CLUSTER_SIZE = 3
 
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
-async def test_deploy(
-    ops_test: OpsTest
-) -> None:
+async def test_deploy(ops_test: OpsTest) -> None:
     """Build and deploy a PostgreSQL cluster and a test application."""
     await build_and_deploy(ops_test, CLUSTER_SIZE, wait_for_idle=False)
     await ops_test.model.deploy(APPLICATION_NAME, num_units=1)
 
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(
-                apps=[DATABASE_APP_NAME, APPLICATION_NAME],
-                status="active",
-                timeout=1000,
-                raise_on_error=False
-            )
+            apps=[DATABASE_APP_NAME, APPLICATION_NAME],
+            status="active",
+            timeout=1000,
+            raise_on_error=False,
+        )
 
 
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
-async def test_restart(
-    ops_test: OpsTest, continuous_writes
-) -> None:
+async def test_restart(ops_test: OpsTest, continuous_writes) -> None:
     """Test restart of all the units simultaneously."""
     logger.info("starting continuous writes to the database")
     await start_continuous_writes(ops_test, DATABASE_APP_NAME)
@@ -60,17 +57,16 @@ async def test_restart(
     await are_writes_increasing(ops_test)
 
     logger.info("restarting all the units by deleting their pods")
-    client = dynamic.DynamicClient(
-        api_client.ApiClient(configuration=config.load_kube_config())
-    )
+    client = dynamic.DynamicClient(api_client.ApiClient(configuration=config.load_kube_config()))
     api = client.resources.get(api_version="v1", kind="Pod")
-    api.delete(namespace=ops_test.model.info.name, label_selector=f"app.kubernetes.io/name={DATABASE_APP_NAME}")
+    api.delete(
+        namespace=ops_test.model.info.name,
+        label_selector=f"app.kubernetes.io/name={DATABASE_APP_NAME}",
+    )
 
     async with ops_test.fast_forward():
         await gather(
-            ops_test.model.wait_for_idle(
-                apps=[DATABASE_APP_NAME], status="active", timeout=1000
-            )
+            ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME], status="active", timeout=1000)
         )
 
     # Check that all replication slots are present in the primary

--- a/tests/integration/ha_tests/test_restart.py
+++ b/tests/integration/ha_tests/test_restart.py
@@ -21,7 +21,7 @@ from ..helpers import (
 from .helpers import (
     are_writes_increasing,
     check_writes,
-    inject_stop_hook_fault,
+    remove_charm_code,
     start_continuous_writes,
 )
 
@@ -59,7 +59,7 @@ async def test_restart(ops_test: OpsTest, continuous_writes) -> None:
     await are_writes_increasing(ops_test)
 
     logger.info(
-        "patch the stop hook of one non-primary unit to simulate a crash and prevent firing the update-charm hook"
+        "removing charm code from one non-primary unit to simulate a crash and prevent firing the update-charm hook"
     )
     primary = await get_primary(ops_test)
     status = await ops_test.model.get_status()
@@ -67,8 +67,8 @@ async def test_restart(ops_test: OpsTest, continuous_writes) -> None:
         if unit != primary:
             non_primary = unit
             break
-    await inject_stop_hook_fault(ops_test, non_primary)
-    logger.info(f"{non_primary} patched")
+    await remove_charm_code(ops_test, non_primary)
+    logger.info(f"removed charm code from {non_primary}")
 
     logger.info("restarting all the units by deleting their pods")
     client = dynamic.DynamicClient(api_client.ApiClient(configuration=config.load_kube_config()))

--- a/tests/integration/ha_tests/test_restart.py
+++ b/tests/integration/ha_tests/test_restart.py
@@ -67,6 +67,7 @@ async def test_restart(ops_test: OpsTest, continuous_writes) -> None:
             non_primary = unit
             break
     await inject_stop_hook_fault(ops_test, non_primary)
+    logger.info(f"{non_primary} patched")
 
     # Disable the automatic retry of hooks to avoid the stop hook being retried.
     await ops_test.model.set_config({"automatically-retry-hooks": "false"})

--- a/tests/integration/ha_tests/test_restart.py
+++ b/tests/integration/ha_tests/test_restart.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+import logging
+from asyncio import gather
+
+import pytest as pytest
+from kubernetes import config, dynamic
+from kubernetes.client import api_client
+from pytest_operator.plugin import OpsTest
+
+from .helpers import (
+    are_writes_increasing,
+    check_writes,
+    start_continuous_writes,
+)
+from ..helpers import (
+    APPLICATION_NAME,
+    DATABASE_APP_NAME,
+    build_and_deploy,
+    get_primary,
+    get_unit_address,
+    get_application_units, get_cluster_members,
+)
+
+logger = logging.getLogger(__name__)
+
+
+CLUSTER_SIZE = 3
+
+
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_deploy(
+    ops_test: OpsTest
+) -> None:
+    """Build and deploy a PostgreSQL cluster and a test application."""
+    await build_and_deploy(ops_test, CLUSTER_SIZE, wait_for_idle=False)
+    await ops_test.model.deploy(APPLICATION_NAME, num_units=1)
+
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(
+                apps=[DATABASE_APP_NAME, APPLICATION_NAME],
+                status="active",
+                timeout=1000,
+                raise_on_error=False
+            )
+
+
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_restart(
+    ops_test: OpsTest, continuous_writes
+) -> None:
+    """Test restart of all the units simultaneously."""
+    logger.info("starting continuous writes to the database")
+    await start_continuous_writes(ops_test, DATABASE_APP_NAME)
+
+    logger.info("checking whether writes are increasing")
+    await are_writes_increasing(ops_test)
+
+    logger.info("restarting all the units by deleting their pods")
+    client = dynamic.DynamicClient(
+        api_client.ApiClient(configuration=config.load_kube_config())
+    )
+    api = client.resources.get(api_version="v1", kind="Pod")
+    api.delete(namespace=ops_test.model.info.name, label_selector=f"app.kubernetes.io/name={DATABASE_APP_NAME}")
+
+    async with ops_test.fast_forward():
+        await gather(
+            ops_test.model.wait_for_idle(
+                apps=[DATABASE_APP_NAME], status="active", timeout=1000
+            )
+        )
+
+    # Check that all replication slots are present in the primary
+    # (by checking the list of cluster members).
+    primary = await get_primary(ops_test)
+    address = await get_unit_address(ops_test, primary)
+    assert get_cluster_members(address) == get_application_units(ops_test, DATABASE_APP_NAME)
+
+    logger.info("Ensure continuous_writes after the crashed unit")
+    await are_writes_increasing(ops_test)
+
+    # Verify that no writes to the database were missed after stopping the writes
+    # (check that all the units have all the writes).
+    logger.info("checking whether no writes were lost")
+    await check_writes(ops_test)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -666,18 +666,21 @@ def resource_exists(client: Client, resource: GenericNamespacedResource) -> bool
         return False
 
 
-async def run_command_on_unit(ops_test: OpsTest, unit_name: str, command: str) -> str:
+async def run_command_on_unit(
+    ops_test: OpsTest, unit_name: str, command: str, container: str = "postgresql"
+) -> str:
     """Run a command on a specific unit.
 
     Args:
         ops_test: The ops test framework instance
         unit_name: The name of the unit to run the command on
         command: The command to run
+        container: The container to run the command in (default: postgresql)
 
     Returns:
         the command output if it succeeds, otherwise raises an exception.
     """
-    complete_command = f"ssh --container postgresql {unit_name} {command}"
+    complete_command = f"ssh --container {container} {unit_name} {command}"
     return_code, stdout, stderr = await ops_test.juju(*complete_command.split())
     if return_code != 0:
         raise Exception(


### PR DESCRIPTION
## Issue
After restarting the pods of a PostgreSQL K8s charm deployment (we can use `kubectl -n dev delete pod -l app.kubernetes.io/name=postgresql-k8s` for testing), if the `stop` hook fails for some reason, the `upgrade-charm` hook won't fire when the pod is rescheduled, and no Patroni labels will be added to the pod. This makes Patroni understand that the unit is not part of the cluster, so it deletes that unit replication slot from the primary.

In the past (before https://github.com/canonical/postgresql-k8s-operator/pull/448, which added a check for `container.can_connect()`), this could happen due to a re-emitted deferred pebble-ready event:
```sh
unit-postgresql-k8s-2: 17:36:20 ERROR unit.postgresql-k8s/2.juju-log Uncaught exception while in charm code:
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-postgresql-k8s-2/charm/./src/charm.py", line 1574, in <module>
    main(PostgresqlOperatorCharm, use_juju_for_storage=True)
  File "/var/lib/juju/agents/unit-postgresql-k8s-2/charm/venv/ops/main.py", line 434, in main
    framework.reemit()
  File "/var/lib/juju/agents/unit-postgresql-k8s-2/charm/venv/ops/framework.py", line 863, in reemit
    self._reemit()
  File "/var/lib/juju/agents/unit-postgresql-k8s-2/charm/venv/ops/framework.py", line 942, in _reemit
    custom_handler(event)
  File "/var/lib/juju/agents/unit-postgresql-k8s-2/charm/./src/charm.py", line 660, in _on_postgresql_pebble_ready
    self._create_pgdata(container)
  File "/var/lib/juju/agents/unit-postgresql-k8s-2/charm/./src/charm.py", line 646, in _create_pgdata
    if not container.exists(path):
  File "/var/lib/juju/agents/unit-postgresql-k8s-2/charm/venv/ops/model.py", line 2547, in exists
    self._pebble.list_files(str(path), itself=True)
  File "/var/lib/juju/agents/unit-postgresql-k8s-2/charm/venv/ops/pebble.py", line 2219, in list_files
    resp = self._request('GET', '/v1/files', query)
  File "/var/lib/juju/agents/unit-postgresql-k8s-2/charm/venv/ops/pebble.py", line 1655, in _request
    response = self._request_raw(method, path, query, headers, data)
  File "/var/lib/juju/agents/unit-postgresql-k8s-2/charm/venv/ops/pebble.py", line 1704, in _request_raw
    raise ConnectionError(
ops.pebble.ConnectionError: Could not connect to Pebble: socket not found at '/charm/containers/postgresql/pebble.socket' (container restarted?)
unit-postgresql-k8s-1: 17:36:20 INFO unit.postgresql-k8s/1.juju-log Updating Patroni config file
unit-postgresql-k8s-0: 17:36:20 INFO juju.worker.uniter.operation ran "stop" hook (via hook dispatching script: dispatch)
unit-postgresql-k8s-0: 17:36:20 INFO juju.worker.uniter unit "postgresql-k8s/0" shutting down: agent should be terminated
unit-postgresql-k8s-1: 17:36:20 INFO unit.postgresql-k8s/1.juju-log Updated health checks
unit-postgresql-k8s-2: 17:36:20 ERROR juju.worker.uniter.operation hook "stop" (via hook dispatching script: dispatch) failed: exit status 1
```

## Solution
Patch the pods in the `postgresql-pebble-ready` hook (only when the unit is already a member of the Patroni/PostgreSQL cluster), which is fired after the charm starts again. An integration test (forcing a failure in the `stop` hook) was added to avoid regressions.

Some safeguards still need to be added to the stop hook as a different situation may cause it to fail.

Fixes https://github.com/canonical/postgresql-k8s-operator/issues/433.