### PR TITLE
[DPE-5301] Add check for low storage space on pgdata volume

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -941,6 +941,9 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         self._set_active_status()
 
     def _set_active_status(self):
+        # The charm should not override this status outside of the function checking disk space.
+        if self.unit.status.message == INSUFFICIENT_SIZE_WARNING:
+            return
         if "require-change-bucket-after-restore" in self.app_peer_data:
             if self.unit.is_leader():
                 self.app_peer_data.update({
@@ -1346,6 +1349,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         if free_size / total_size < 0.1:
             self.unit.status = BlockedStatus(INSUFFICIENT_SIZE_WARNING)
         elif self.unit.status.message == INSUFFICIENT_SIZE_WARNING:
+            self.unit.status = ActiveStatus()
             self._set_active_status()
 
     def _on_update_status(self, _) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -125,7 +125,7 @@ logger = logging.getLogger(__name__)
 
 EXTENSIONS_DEPENDENCY_MESSAGE = "Unsatisfied plugin dependencies. Please check the logs"
 EXTENSION_OBJECT_MESSAGE = "Cannot disable plugins: Existing objects depend on it. See logs"
-INSUFFICIENT_SIZE_WARNING = "<10%% free space on pgdata volume."
+INSUFFICIENT_SIZE_WARNING = "<10% free space on pgdata volume."
 
 ORIGINAL_PATRONI_ON_FAILURE_CONDITION = "restart"
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -1337,7 +1337,12 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             logger.error("pgdata folder not found in %s", self.pgdata_path)
             return
 
-        logger.debug("pgdata free disk space: %s out of %s", free_size, total_size)
+        logger.debug(
+            "pgdata free disk space: %s out of %s, ratio of %s",
+            free_size,
+            total_size,
+            free_size / total_size,
+        )
         if free_size / total_size < 0.1:
             self.unit.status = BlockedStatus(INSUFFICIENT_SIZE_WARNING)
         elif self.unit.status.message == INSUFFICIENT_SIZE_WARNING:

--- a/src/charm.py
+++ b/src/charm.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import sys
 from pathlib import Path
 from typing import Dict, List, Literal, Optional, Tuple, get_args
@@ -124,6 +125,7 @@ logger = logging.getLogger(__name__)
 
 EXTENSIONS_DEPENDENCY_MESSAGE = "Unsatisfied plugin dependencies. Please check the logs"
 EXTENSION_OBJECT_MESSAGE = "Cannot disable plugins: Existing objects depend on it. See logs"
+INSUFFICIENT_SIZE_WARNING = "<10%% free space on pgdata volume."
 
 ORIGINAL_PATRONI_ON_FAILURE_CONDITION = "restart"
 
@@ -205,6 +207,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         self.framework.observe(self.on.get_primary_action, self._on_get_primary)
         self.framework.observe(self.on.update_status, self._on_update_status)
         self._storage_path = self.meta.storages["pgdata"].location
+        self.pgdata_path = f"{self._storage_path}/pgdata"
 
         self.upgrade = PostgreSQLUpgrade(
             self,
@@ -860,10 +863,9 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
 
     def _create_pgdata(self, container: Container):
         """Create the PostgreSQL data directory."""
-        path = f"{self._storage_path}/pgdata"
-        if not container.exists(path):
+        if not container.exists(self.pgdata_path):
             container.make_dir(
-                path, permissions=0o770, user=WORKLOAD_OS_USER, group=WORKLOAD_OS_GROUP
+                self.pgdata_path, permissions=0o770, user=WORKLOAD_OS_USER, group=WORKLOAD_OS_GROUP
             )
         # Also, fix the permissions from the parent directory.
         container.exec([
@@ -1327,11 +1329,27 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             return False
         return True
 
+    def _check_pgdata_storage_size(self) -> None:
+        """Asserts that pgdata volume has at least 10% free space and blocks charm if not."""
+        try:
+            total_size, _, free_size = shutil.disk_usage(self.pgdata_path)
+        except FileNotFoundError:
+            logger.error("pgdata folder not found in %s", self.pgdata_path)
+            return
+
+        logger.debug("pgdata free disk space: %s out of %s", free_size, total_size)
+        if free_size / total_size < 0.1:
+            self.unit.status = BlockedStatus(INSUFFICIENT_SIZE_WARNING)
+        elif self.unit.status.message == INSUFFICIENT_SIZE_WARNING:
+            self._set_active_status()
+
     def _on_update_status(self, _) -> None:
         """Update the unit status message."""
         container = self.unit.get_container("postgresql")
         if not self._on_update_status_early_exit_checks(container):
             return
+
+        self._check_pgdata_storage_size()
 
         if self._has_blocked_status or self._has_non_restore_waiting_status:
             # If charm was failing to disable plugin, try again (user may have removed the objects)

--- a/tests/integration/test_storage.py
+++ b/tests/integration/test_storage.py
@@ -42,13 +42,11 @@ async def test_filling_and_emptying_pgdata_storage(ops_test: OpsTest):
         await ops_test.model.block_until(
             lambda: any(
                 unit.workload_status == "blocked"
+                and unit.workload_status_message == INSUFFICIENT_SIZE_WARNING
                 for unit in ops_test.model.applications[DATABASE_APP_NAME].units
             ),
             timeout=500,
         )
-
-    assert primary.workload_status == "blocked"
-    assert primary.workload_status_message == INSUFFICIENT_SIZE_WARNING
 
     # Delete big file to release storage space
     await run_command_on_unit(ops_test, primary, f"rm {STORAGE_PATH}/pgdata/tmp")

--- a/tests/integration/test_storage.py
+++ b/tests/integration/test_storage.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+
+import pytest
+from pytest_operator.plugin import OpsTest
+
+from .helpers import (
+    DATABASE_APP_NAME,
+    build_and_deploy,
+    db_connect,
+    get_leader_unit,
+    get_password,
+    get_primary,
+    get_unit_address,
+)
+
+logger = logging.getLogger(__name__)
+
+APP_NAME = "untrusted-postgresql-k8s"
+MAX_RETRIES = 20
+INSUFFICIENT_SIZE_WARNING = "<10%% free space on pgdata volume."
+
+
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_filling_and_emptying_pgdata_storage(ops_test: OpsTest):
+    """Build and deploy the charm and saturate its pgdata volume."""
+    # Build and deploy the PostgreSQL charm.
+    async with ops_test.fast_forward():
+        await build_and_deploy(ops_test, 1)
+
+    # Write some data to the initial primary (this causes a divergence
+    # in the instances' timelines).
+    primary = await get_primary(ops_test)
+    host = await get_unit_address(ops_test, primary)
+    password = await get_password(ops_test)
+    with db_connect(host, password) as connection:
+        connection.autocommit = True
+        with connection.cursor() as cursor:
+            cursor.execute("CREATE TABLE big_table (testcol INT);")
+            cursor.execute("INSERT INTO big_table SELECT generate_series(1,237500000);")
+    connection.close()
+
+    async with ops_test.fast_forward():
+        await ops_test.model.block_until(
+            lambda: any(
+                unit.workload_status == "blocked"
+                for unit in ops_test.model.applications[DATABASE_APP_NAME].units
+            ),
+            timeout=500,
+        )
+
+    leader_unit = await get_leader_unit(ops_test, APP_NAME)
+    assert leader_unit.workload_status == "blocked"
+    assert leader_unit.workload_status_message == INSUFFICIENT_SIZE_WARNING

--- a/tests/integration/test_storage.py
+++ b/tests/integration/test_storage.py
@@ -41,7 +41,7 @@ async def test_filling_and_emptying_pgdata_storage(ops_test: OpsTest):
         connection.autocommit = True
         with connection.cursor() as cursor:
             cursor.execute("CREATE TABLE big_table (testcol INT);")
-            cursor.execute("INSERT INTO big_table SELECT generate_series(1,237500000);")
+            cursor.execute("INSERT INTO big_table SELECT generate_series(1,290000000);")
     connection.close()
 
     async with ops_test.fast_forward():

--- a/tests/integration/test_storage.py
+++ b/tests/integration/test_storage.py
@@ -36,7 +36,6 @@ async def test_filling_and_emptying_pgdata_storage(ops_test: OpsTest, database_c
         application_name=DATABASE_APP_NAME,
         num_units=1,
         trust=True,
-        storage={"pgdata": "rootfs,1G"},
     )
 
     # Saturate storage with some data
@@ -47,7 +46,7 @@ async def test_filling_and_emptying_pgdata_storage(ops_test: OpsTest, database_c
         connection.autocommit = True
         with connection.cursor() as cursor:
             cursor.execute("CREATE TABLE big_table (testcol INT);")
-            cursor.execute("INSERT INTO big_table SELECT generate_series(1,100000000);")
+            cursor.execute("INSERT INTO big_table SELECT generate_series(1,10000000000);")
     connection.close()
 
     # wait for charm to get blocked

--- a/tests/integration/test_storage.py
+++ b/tests/integration/test_storage.py
@@ -9,7 +9,7 @@ from pytest_operator.plugin import OpsTest
 
 from .helpers import (
     DATABASE_APP_NAME,
-    build_and_deploy,
+    METADATA,
     db_connect,
     get_leader_unit,
     get_password,
@@ -25,11 +25,19 @@ INSUFFICIENT_SIZE_WARNING = "<10% free space on pgdata volume."
 
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
-async def test_filling_and_emptying_pgdata_storage(ops_test: OpsTest):
+async def test_filling_and_emptying_pgdata_storage(ops_test: OpsTest, database_charm):
     """Build and deploy the charm and saturate its pgdata volume."""
     # Build and deploy the PostgreSQL charm.
-    async with ops_test.fast_forward():
-        await build_and_deploy(ops_test, 1)
+    await ops_test.model.deploy(
+        database_charm,
+        resources={
+            "postgresql-image": METADATA["resources"]["postgresql-image"]["upstream-source"]
+        },
+        application_name=DATABASE_APP_NAME,
+        num_units=1,
+        trust=True,
+        storage={"pgdata": "1G"},
+    )
 
     # Saturate storage with some data
     primary = await get_primary(ops_test)
@@ -39,7 +47,7 @@ async def test_filling_and_emptying_pgdata_storage(ops_test: OpsTest):
         connection.autocommit = True
         with connection.cursor() as cursor:
             cursor.execute("CREATE TABLE big_table (testcol INT);")
-            cursor.execute("INSERT INTO big_table SELECT generate_series(1,600000000);")
+            cursor.execute("INSERT INTO big_table SELECT generate_series(1,100000000);")
     connection.close()
 
     # wait for charm to get blocked
@@ -49,7 +57,7 @@ async def test_filling_and_emptying_pgdata_storage(ops_test: OpsTest):
                 unit.workload_status == "blocked"
                 for unit in ops_test.model.applications[DATABASE_APP_NAME].units
             ),
-            timeout=500,
+            timeout=300,
         )
 
     leader_unit = await get_leader_unit(ops_test, DATABASE_APP_NAME)

--- a/tests/integration/test_storage.py
+++ b/tests/integration/test_storage.py
@@ -41,7 +41,7 @@ async def test_filling_and_emptying_pgdata_storage(ops_test: OpsTest):
         connection.autocommit = True
         with connection.cursor() as cursor:
             cursor.execute("CREATE TABLE big_table (testcol INT);")
-            cursor.execute("INSERT INTO big_table SELECT generate_series(1,290000000);")
+            cursor.execute("INSERT INTO big_table SELECT generate_series(1,400000000);")
     connection.close()
 
     async with ops_test.fast_forward():

--- a/tests/integration/test_storage.py
+++ b/tests/integration/test_storage.py
@@ -36,7 +36,7 @@ async def test_filling_and_emptying_pgdata_storage(ops_test: OpsTest, database_c
         application_name=DATABASE_APP_NAME,
         num_units=1,
         trust=True,
-        storage={"pgdata": "1G"},
+        storage={"pgdata": {"size": 2048}},
     )
 
     # Saturate storage with some data

--- a/tests/integration/test_storage.py
+++ b/tests/integration/test_storage.py
@@ -39,7 +39,7 @@ async def test_filling_and_emptying_pgdata_storage(ops_test: OpsTest):
         connection.autocommit = True
         with connection.cursor() as cursor:
             cursor.execute("CREATE TABLE big_table (testcol INT);")
-            cursor.execute("INSERT INTO big_table SELECT generate_series(1,10000000000);")
+            cursor.execute("INSERT INTO big_table SELECT generate_series(1,1000000000);")
     connection.close()
 
     # wait for charm to get blocked
@@ -49,7 +49,7 @@ async def test_filling_and_emptying_pgdata_storage(ops_test: OpsTest):
                 unit.workload_status == "blocked"
                 for unit in ops_test.model.applications[DATABASE_APP_NAME].units
             ),
-            timeout=300,
+            timeout=500,
         )
 
     leader_unit = await get_leader_unit(ops_test, DATABASE_APP_NAME)

--- a/tests/integration/test_storage.py
+++ b/tests/integration/test_storage.py
@@ -20,7 +20,7 @@ from .helpers import (
 logger = logging.getLogger(__name__)
 
 MAX_RETRIES = 20
-INSUFFICIENT_SIZE_WARNING = "<10%% free space on pgdata volume."
+INSUFFICIENT_SIZE_WARNING = "<10% free space on pgdata volume."
 
 
 @pytest.mark.group(1)

--- a/tests/integration/test_storage.py
+++ b/tests/integration/test_storage.py
@@ -39,7 +39,7 @@ async def test_filling_and_emptying_pgdata_storage(ops_test: OpsTest):
         connection.autocommit = True
         with connection.cursor() as cursor:
             cursor.execute("CREATE TABLE big_table (testcol INT);")
-            cursor.execute("INSERT INTO big_table SELECT generate_series(1,1000000000);")
+            cursor.execute("INSERT INTO big_table SELECT generate_series(1,600000000);")
     connection.close()
 
     # wait for charm to get blocked

--- a/tests/integration/test_storage.py
+++ b/tests/integration/test_storage.py
@@ -9,7 +9,7 @@ from pytest_operator.plugin import OpsTest
 
 from .helpers import (
     DATABASE_APP_NAME,
-    METADATA,
+    build_and_deploy,
     db_connect,
     get_leader_unit,
     get_password,
@@ -25,18 +25,11 @@ INSUFFICIENT_SIZE_WARNING = "<10% free space on pgdata volume."
 
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
-async def test_filling_and_emptying_pgdata_storage(ops_test: OpsTest, database_charm):
+async def test_filling_and_emptying_pgdata_storage(ops_test: OpsTest):
     """Build and deploy the charm and saturate its pgdata volume."""
     # Build and deploy the PostgreSQL charm.
-    await ops_test.model.deploy(
-        database_charm,
-        resources={
-            "postgresql-image": METADATA["resources"]["postgresql-image"]["upstream-source"]
-        },
-        application_name=DATABASE_APP_NAME,
-        num_units=1,
-        trust=True,
-    )
+    async with ops_test.fast_forward():
+        await build_and_deploy(ops_test, 1)
 
     # Saturate storage with some data
     primary = await get_primary(ops_test)

--- a/tests/integration/test_storage.py
+++ b/tests/integration/test_storage.py
@@ -36,7 +36,7 @@ async def test_filling_and_emptying_pgdata_storage(ops_test: OpsTest, database_c
         application_name=DATABASE_APP_NAME,
         num_units=1,
         trust=True,
-        storage={"pgdata": {"size": 2048}},
+        storage={"pgdata": "rootfs,1G"},
     )
 
     # Saturate storage with some data

--- a/tests/integration/test_storage.py
+++ b/tests/integration/test_storage.py
@@ -41,7 +41,7 @@ async def test_filling_and_emptying_pgdata_storage(ops_test: OpsTest):
         connection.autocommit = True
         with connection.cursor() as cursor:
             cursor.execute("CREATE TABLE big_table (testcol INT);")
-            cursor.execute("INSERT INTO big_table SELECT generate_series(1,400000000);")
+            cursor.execute("INSERT INTO big_table SELECT generate_series(1,600000000);")
     connection.close()
 
     async with ops_test.fast_forward():


### PR DESCRIPTION
## Issue

The charm gives no indication of low storage space on `pgdata` folder, which can cause unexpected failures

## Solution

Added check on `update_status` hook + integration test.