### PR TITLE
tests: remove patching of private ops class

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,28 +3,8 @@
 # See LICENSE file for licensing details.
 
 from pathlib import Path
-from typing import Callable
-from unittest.mock import patch
 
 import yaml
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 STORAGE_PATH = METADATA["storage"]["pgdata"]["location"]
-
-
-def patch_network_get(private_address="10.1.157.116") -> Callable:
-    def network_get(*args, **kwargs) -> dict:
-        """Patch for the not-yet-implemented testing backend needed for `bind_address`.
-
-        This patch decorator can be used for cases such as:
-        self.model.get_binding(event.relation).network.bind_address
-        """
-        return {
-            "bind-addresses": [
-                {
-                    "addresses": [{"value": private_address}],
-                }
-            ]
-        }
-
-    return patch("ops.testing._TestingModelBackend.network_get", network_get)

--- a/tests/unit/test_postgresql_provider.py
+++ b/tests/unit/test_postgresql_provider.py
@@ -16,7 +16,6 @@ from ops.testing import Harness
 
 from charm import PostgresqlOperatorCharm
 from constants import PEER
-from tests.helpers import patch_network_get
 
 DATABASE = "test_database"
 EXTRA_USER_ROLES = "CREATEDB,CREATEROLE"
@@ -74,7 +73,6 @@ def request_database(_harness):
     )
 
 
-@patch_network_get(private_address="1.1.1.1")
 def test_on_database_requested(harness):
     with (
         patch.object(PostgresqlOperatorCharm, "postgresql", Mock()) as postgresql_mock,
@@ -161,7 +159,6 @@ def test_on_database_requested(harness):
         assert isinstance(harness.model.unit.status, BlockedStatus)
 
 
-@patch_network_get(private_address="1.1.1.1")
 def test_on_relation_departed(harness):
     with patch("charm.Patroni.member_started", new_callable=PropertyMock(return_value=True)):
         peer_rel_id = harness.model.get_relation(PEER).id
@@ -183,7 +180,6 @@ def test_on_relation_departed(harness):
         assert "departing" not in relation_data
 
 
-@patch_network_get(private_address="1.1.1.1")
 def test_on_relation_broken(harness):
     with harness.hooks_disabled():
         harness.set_leader()

--- a/tests/unit/test_postgresql_tls.py
+++ b/tests/unit/test_postgresql_tls.py
@@ -10,7 +10,6 @@ from ops.testing import Harness
 
 from charm import PostgresqlOperatorCharm
 from constants import PEER
-from tests.helpers import patch_network_get
 
 RELATION_NAME = "certificates"
 SCOPE = "unit"
@@ -88,7 +87,6 @@ def test_on_set_tls_private_key(harness):
         _request_certificate.assert_called_once_with("test-key")
 
 
-@patch_network_get(private_address="1.1.1.1")
 def test_request_certificate(harness):
     with (
         patch(
@@ -109,12 +107,12 @@ def test_request_certificate(harness):
         generate_csr_call = call(
             private_key=b"fake private key",
             subject="postgresql-k8s-0.postgresql-k8s-endpoints",
-            sans_ip=["1.1.1.1"],
+            sans_ip=["192.0.2.0"],
             sans_dns=[
                 "postgresql-k8s-0",
                 "postgresql-k8s-0.postgresql-k8s-endpoints",
                 socket.getfqdn(),
-                "1.1.1.1",
+                "192.0.2.0",
                 f"postgresql-k8s-primary.{harness.charm.model.name}.svc.cluster.local",
                 f"postgresql-k8s-replicas.{harness.charm.model.name}.svc.cluster.local",
             ],
@@ -142,12 +140,12 @@ def test_request_certificate(harness):
         custom_key_generate_csr_call = call(
             private_key=key.encode("utf-8"),
             subject="postgresql-k8s-0.postgresql-k8s-endpoints",
-            sans_ip=["1.1.1.1"],
+            sans_ip=["192.0.2.0"],
             sans_dns=[
                 "postgresql-k8s-0",
                 "postgresql-k8s-0.postgresql-k8s-endpoints",
                 socket.getfqdn(),
-                "1.1.1.1",
+                "192.0.2.0",
                 f"postgresql-k8s-primary.{harness.charm.model.name}.svc.cluster.local",
                 f"postgresql-k8s-replicas.{harness.charm.model.name}.svc.cluster.local",
             ],
@@ -180,7 +178,6 @@ def test_on_tls_relation_joined(harness):
         _request_certificate.assert_called_once_with(None)
 
 
-@patch_network_get(private_address="1.1.1.1")
 def test_on_tls_relation_broken(harness):
     with patch("charm.PostgresqlOperatorCharm.update_config") as _update_config:
         _update_config.reset_mock()
@@ -219,7 +216,6 @@ def test_on_certificate_available(harness):
         _defer.assert_called_once()
 
 
-@patch_network_get(private_address="1.1.1.1")
 def test_on_certificate_expiring(harness):
     with (
         patch(
@@ -241,16 +237,15 @@ def test_on_certificate_expiring(harness):
         _request_certificate_renewal.assert_called_once()
 
 
-@patch_network_get(private_address="1.1.1.1")
 def test_get_sans(harness):
     sans = harness.charm.tls._get_sans()
     assert sans == {
-        "sans_ip": ["1.1.1.1"],
+        "sans_ip": ["192.0.2.0"],
         "sans_dns": [
             "postgresql-k8s-0",
             "postgresql-k8s-0.postgresql-k8s-endpoints",
             socket.getfqdn(),
-            "1.1.1.1",
+            "192.0.2.0",
             "postgresql-k8s-primary.None.svc.cluster.local",
             "postgresql-k8s-replicas.None.svc.cluster.local",
         ],


### PR DESCRIPTION
## Issue

The tests currently patch a private ops class. No compatibility guarantees are provided for private names, and this will stop working in an upcoming ops release.

## Solution

Remove the patching - it's no longer required with modern versions of ops anyway. Also adjust the expected default IP (from Cloudflare's DNS server, which we shouldn't be using anyway).