### PR TITLE
[DPE-5658] Update COS alert rules

### DIFF
--- a/src/prometheus_alert_rules/patroni_rules.yaml
+++ b/src/prometheus_alert_rules/patroni_rules.yaml
@@ -14,7 +14,7 @@ groups:
       annotations:
         summary: Patroni PostgreSQL is down (instance {{ $labels.instance }})
         description: |
-        Patroni Postgresql instance is down.
+        Patroni Postgresql instance is down. Please check for errors on Loki logs.
         VALUE = {{ $value }}
         LABELS = {{ $labels }}
 
@@ -27,6 +27,6 @@ groups:
       annotations:
         summary: Patroni has no Leader (instance {{ $labels.instance }})
         description: |
-        A leader node (neither primary nor standby) cannot be found inside the cluster {{ $labels.scope }}.
+        A leader node (neither primary nor standby) cannot be found inside the cluster {{ $labels.scope }}. Please check for errors on Loki logs.
         VALUE = {{ $value }}
         LABELS = {{ $labels }}

--- a/src/prometheus_alert_rules/patroni_rules.yaml
+++ b/src/prometheus_alert_rules/patroni_rules.yaml
@@ -14,9 +14,10 @@ groups:
       annotations:
         summary: Patroni PostgreSQL is down (instance {{ $labels.instance }})
         description: |
-        Patroni Postgresql instance is down. Please check for errors on Loki logs.
+        `A Patroni PostgreSQL instance is down.
+        Check for errors in the Loki logs.
         VALUE = {{ $value }}
-        LABELS = {{ $labels }}
+        LABELS = {{ $labels }}`
 
     # 2.4.1
     - alert: PatroniHasNoLeader
@@ -27,6 +28,7 @@ groups:
       annotations:
         summary: Patroni has no Leader (instance {{ $labels.instance }})
         description: |
-        A leader node (neither primary nor standby) cannot be found inside the cluster {{ $labels.scope }}. Please check for errors on Loki logs.
+        `A leader node (neither primary nor standby) cannot be found inside the cluster {{ $labels.scope }}.
+        Check for errors in the Loki logs.
         VALUE = {{ $value }}
-        LABELS = {{ $labels }}
+        LABELS = {{ $labels }}`

--- a/src/prometheus_alert_rules/patroni_rules.yaml
+++ b/src/prometheus_alert_rules/patroni_rules.yaml
@@ -12,11 +12,9 @@ groups:
       labels:
         severity: critical
       annotations:
-        summary: Patroni PostgreSQL is down (instance {{ $labels.instance }})
+        summary: Patroni PostgreSQL instance {{ $labels.instance }} is down.
         description: |
-          A Patroni PostgreSQL instance is down.
           Check for errors in the Loki logs.
-          VALUE = {{ $value }}
           LABELS = {{ $labels }}
 
     # 2.4.1
@@ -26,9 +24,8 @@ groups:
       labels:
         severity: critical
       annotations:
-        summary: Patroni has no Leader (instance {{ $labels.instance }})
+        summary: Patroni instance {{ $labels.instance }} has no leader node. 
         description: |
           A leader node (neither primary nor standby) cannot be found inside the cluster {{ $labels.scope }}.
           Check for errors in the Loki logs.
-          VALUE = {{ $value }}
           LABELS = {{ $labels }}

--- a/src/prometheus_alert_rules/patroni_rules.yaml
+++ b/src/prometheus_alert_rules/patroni_rules.yaml
@@ -7,13 +7,16 @@ groups:
   rules:
 
     - alert: PatroniPostgresqlDown
-      expr: "patroni_postgres_running == 0"
+      expr: 'patroni_postgres_running == 0'
       for: 0m
       labels:
         severity: critical
       annotations:
-        summary: Patroni Posrgresql Down (instance {{ $labels.instance }})
-        description: "Patroni Postgresql instance is down\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        summary: Patroni PostgreSQL is down (instance {{ $labels.instance }})
+        description: |
+        Patroni Postgresql instance is down.
+        VALUE = {{ $value }}
+        LABELS = {{ $labels }}
 
     # 2.4.1
     - alert: PatroniHasNoLeader
@@ -23,4 +26,7 @@ groups:
         severity: critical
       annotations:
         summary: Patroni has no Leader (instance {{ $labels.instance }})
-        description: "A leader node (neither primary nor standby) cannot be found inside the cluster {{ $labels.scope }}\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        description: |
+        A leader node (neither primary nor standby) cannot be found inside the cluster {{ $labels.scope }}.
+        VALUE = {{ $value }}
+        LABELS = {{ $labels }}

--- a/src/prometheus_alert_rules/patroni_rules.yaml
+++ b/src/prometheus_alert_rules/patroni_rules.yaml
@@ -14,10 +14,10 @@ groups:
       annotations:
         summary: Patroni PostgreSQL is down (instance {{ $labels.instance }})
         description: |
-        `A Patroni PostgreSQL instance is down.
-        Check for errors in the Loki logs.
-        VALUE = {{ $value }}
-        LABELS = {{ $labels }}`
+          A Patroni PostgreSQL instance is down.
+          Check for errors in the Loki logs.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
 
     # 2.4.1
     - alert: PatroniHasNoLeader
@@ -28,7 +28,7 @@ groups:
       annotations:
         summary: Patroni has no Leader (instance {{ $labels.instance }})
         description: |
-        `A leader node (neither primary nor standby) cannot be found inside the cluster {{ $labels.scope }}.
-        Check for errors in the Loki logs.
-        VALUE = {{ $value }}
-        LABELS = {{ $labels }}`
+          A leader node (neither primary nor standby) cannot be found inside the cluster {{ $labels.scope }}.
+          Check for errors in the Loki logs.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}

--- a/src/prometheus_alert_rules/pgbouncer_rules.yaml
+++ b/src/prometheus_alert_rules/pgbouncer_rules.yaml
@@ -43,6 +43,6 @@ groups:
       annotations:
         summary: PgBouncer max connections (instance {{ $labels.instance }})
         description: |
-        The number of PgBouncer client connections has reached `max_client_conn`.
+        The number of PgBouncer client connections has reached `max_client_conn`. Consider double-checking how many connections the client application is opening.
         VALUE = {{ $value }}
         LABELS = {{ $labels }}

--- a/src/prometheus_alert_rules/pgbouncer_rules.yaml
+++ b/src/prometheus_alert_rules/pgbouncer_rules.yaml
@@ -15,9 +15,9 @@ groups:
       annotations:
         summary: PgBouncer active connections (instance {{ $labels.instance }})
         description: |
-        `PgBouncer pools are filling up.
-        VALUE = {{ $value }}
-        LABELS = {{ $labels }}`
+          PgBouncer pools are filling up.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
 
     # 2.5.2
     # 10 -> 3
@@ -29,10 +29,10 @@ groups:
       annotations:
         summary: PgBouncer errors (instance {{ $labels.instance }})
         description: |
-        `PgBouncer is logging errors.
-        This may be due to a a server restart or an admin typing commands at the PgBouncer console.
-        VALUE = {{ $value }}
-        LABELS = {{ $labels }}`
+          PgBouncer is logging errors.
+          This may be due to a a server restart or an admin typing commands at the PgBouncer console.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
 
     # 2.5.3
     - alert: PgbouncerMaxConnections
@@ -43,7 +43,7 @@ groups:
       annotations:
         summary: PgBouncer max connections (instance {{ $labels.instance }})
         description: |
-        The number of PgBouncer client connections has reached `max_client_conn`.
-        Consider double-checking how many connections the client application is opening.
-        VALUE = {{ $value }}
-        LABELS = {{ $labels }}`
+          The number of PgBouncer client connections has reached `max_client_conn`.
+          Consider double-checking how many connections the client application is opening.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}

--- a/src/prometheus_alert_rules/pgbouncer_rules.yaml
+++ b/src/prometheus_alert_rules/pgbouncer_rules.yaml
@@ -13,10 +13,9 @@ groups:
       labels:
         severity: warning
       annotations:
-        summary: PgBouncer active connections (instance {{ $labels.instance }})
+        summary: PgBouncer instance {{ $labels.instance }} has > 200 active connections
         description: |
-          PgBouncer pools are filling up.
-          VALUE = {{ $value }}
+          Consider checking the client application responsible for generating those additional connections.
           LABELS = {{ $labels }}
 
     # 2.5.2
@@ -27,9 +26,8 @@ groups:
       labels:
         severity: warning
       annotations:
-        summary: PgBouncer errors (instance {{ $labels.instance }})
+        summary: PgBouncer instance {{ $labels.instance }} is logging errors. 
         description: |
-          PgBouncer is logging errors.
           This may be due to a a server restart or an admin typing commands at the PgBouncer console.
           VALUE = {{ $value }}
           LABELS = {{ $labels }}
@@ -41,9 +39,8 @@ groups:
       labels:
         severity: critical
       annotations:
-        summary: PgBouncer max connections (instance {{ $labels.instance }})
+        summary: PgBouncer instance {{ $labels.instance }} has reached `max_client_conn`.
         description: |
-          The number of PgBouncer client connections has reached `max_client_conn`.
-          Consider double-checking how many connections the client application is opening.
+          Consider checking how many connections the client application is opening.
           VALUE = {{ $value }}
           LABELS = {{ $labels }}

--- a/src/prometheus_alert_rules/pgbouncer_rules.yaml
+++ b/src/prometheus_alert_rules/pgbouncer_rules.yaml
@@ -15,9 +15,9 @@ groups:
       annotations:
         summary: PgBouncer active connections (instance {{ $labels.instance }})
         description: |
-        PgBouncer pools are filling up.
+        `PgBouncer pools are filling up.
         VALUE = {{ $value }}
-        LABELS = {{ $labels }}
+        LABELS = {{ $labels }}`
 
     # 2.5.2
     # 10 -> 3
@@ -29,10 +29,10 @@ groups:
       annotations:
         summary: PgBouncer errors (instance {{ $labels.instance }})
         description: |
-        PgBouncer is logging errors.
+        `PgBouncer is logging errors.
         This may be due to a a server restart or an admin typing commands at the PgBouncer console.
         VALUE = {{ $value }}
-        LABELS = {{ $labels }}
+        LABELS = {{ $labels }}`
 
     # 2.5.3
     - alert: PgbouncerMaxConnections
@@ -43,6 +43,7 @@ groups:
       annotations:
         summary: PgBouncer max connections (instance {{ $labels.instance }})
         description: |
-        The number of PgBouncer client connections has reached `max_client_conn`. Consider double-checking how many connections the client application is opening.
+        The number of PgBouncer client connections has reached `max_client_conn`.
+        Consider double-checking how many connections the client application is opening.
         VALUE = {{ $value }}
-        LABELS = {{ $labels }}
+        LABELS = {{ $labels }}`

--- a/src/prometheus_alert_rules/pgbouncer_rules.yaml
+++ b/src/prometheus_alert_rules/pgbouncer_rules.yaml
@@ -13,8 +13,11 @@ groups:
       labels:
         severity: warning
       annotations:
-        summary: PGBouncer active connections (instance {{ $labels.instance }})
-        description: "PGBouncer pools are filling up\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        summary: PgBouncer active connections (instance {{ $labels.instance }})
+        description: |
+        PgBouncer pools are filling up.
+        VALUE = {{ $value }}
+        LABELS = {{ $labels }}
 
     # 2.5.2
     # 10 -> 3
@@ -24,8 +27,12 @@ groups:
       labels:
         severity: warning
       annotations:
-        summary: PGBouncer errors (instance {{ $labels.instance }})
-        description: "PGBouncer is logging errors. This may be due to a a server restart or an admin typing commands at the pgbouncer console.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        summary: PgBouncer errors (instance {{ $labels.instance }})
+        description: |
+        PgBouncer is logging errors.
+        This may be due to a a server restart or an admin typing commands at the PgBouncer console.
+        VALUE = {{ $value }}
+        LABELS = {{ $labels }}
 
     # 2.5.3
     - alert: PgbouncerMaxConnections
@@ -34,5 +41,8 @@ groups:
       labels:
         severity: critical
       annotations:
-        summary: PGBouncer max connections (instance {{ $labels.instance }})
-        description: "The number of PGBouncer client connections has reached max_client_conn.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        summary: PgBouncer max connections (instance {{ $labels.instance }})
+        description: |
+        The number of PgBouncer client connections has reached `max_client_conn`.
+        VALUE = {{ $value }}
+        LABELS = {{ $labels }}

--- a/src/prometheus_alert_rules/postgresql_rules.yaml
+++ b/src/prometheus_alert_rules/postgresql_rules.yaml
@@ -13,8 +13,11 @@ groups:
       labels:
         severity: critical
       annotations:
-        summary: Postgresql down (instance {{ $labels.instance }})
-        description: "Postgresql instance is down\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        summary: PostgresSQL down (instance {{ $labels.instance }})
+        description: |
+        PostgresSQL instance is down
+        VALUE = {{ $value }}
+        LABELS = {{ $labels }}
 
     # 2.2.2
     # critical -> info
@@ -24,8 +27,11 @@ groups:
       labels:
         severity: info
       annotations:
-        summary: Postgresql restarted (instance {{ $labels.instance }})
-        description: "Postgresql restarted\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        summary: PostgresSQL restarted (instance {{ $labels.instance }})
+        description: |
+        PostgresSQL restarted
+        VALUE = {{ $value }}
+        LABELS = {{ $labels }}
 
     # 2.2.3
     - alert: PostgresqlExporterError
@@ -34,8 +40,12 @@ groups:
       labels:
         severity: critical
       annotations:
-        summary: Postgresql exporter error (instance {{ $labels.instance }})
-        description: "Postgresql exporter is showing errors. A query may be buggy in query.yaml\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        summary: PostgresSQL exporter error (instance {{ $labels.instance }})
+        description: |
+        PostgresSQL exporter is showing errors.
+        A query may be buggy in query.yaml
+        VALUE = {{ $value }}
+        LABELS = {{ $labels }}
 
     # 2.2.4
     # 10 days -> 7 days
@@ -45,8 +55,11 @@ groups:
       labels:
         severity: warning
       annotations:
-        summary: Postgresql table not auto vacuumed (instance {{ $labels.instance }})
-        description: "Table {{ $labels.relname }} has not been auto vacuumed for 7 days\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        summary: PostgresSQL table not auto vacuumed (instance {{ $labels.instance }})
+        description: |
+        Table {{ $labels.relname }} has not been auto vacuumed for 7 days
+        VALUE = {{ $value }}
+        LABELS = {{ $labels }}
 
     # 2.2.5
     # 10 days -> 7 days
@@ -56,8 +69,11 @@ groups:
       labels:
         severity: warning
       annotations:
-        summary: Postgresql table not auto analyzed (instance {{ $labels.instance }})
-        description: "Table {{ $labels.relname }} has not been auto analyzed for 7 days\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        summary: PostgresSQL table not auto analyzed (instance {{ $labels.instance }})
+        description: |
+        Table {{ $labels.relname }} has not been auto analyzed for 7 days
+        VALUE = {{ $value }}
+        LABELS = {{ $labels }}
 
     # 2.2.6
     - alert: PostgresqlTooManyConnections
@@ -66,8 +82,11 @@ groups:
       labels:
         severity: warning
       annotations:
-        summary: Postgresql too many connections (instance {{ $labels.instance }})
-        description: "PostgreSQL instance has too many connections (> 80%).\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        summary: PostgresSQL too many connections (instance {{ $labels.instance }})
+        description: |
+        PostgreSQL instance has too many connections (> 80%).
+        VALUE = {{ $value }}
+        LABELS = {{ $labels }}
 
     # 2.2.7
     # warning -> info
@@ -77,8 +96,11 @@ groups:
       labels:
         severity: info
       annotations:
-        summary: Postgresql not enough connections (instance {{ $labels.instance }})
-        description: "PostgreSQL instance should have more connections (> 5)\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        summary: PostgresSQL not enough connections (instance {{ $labels.instance }})
+        description: |
+        PostgreSQL instance should have more connections (> 5)
+        VALUE = {{ $value }}
+        LABELS = {{ $labels }}
 
     # 2.2.8
     - alert: PostgresqlDeadLocks
@@ -87,8 +109,11 @@ groups:
       labels:
         severity: warning
       annotations:
-        summary: Postgresql dead locks (instance {{ $labels.instance }})
-        description: "PostgreSQL has dead-locks\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        summary: PostgresSQL dead locks (instance {{ $labels.instance }})
+        description: |
+        PostgreSQL has dead-locks
+        VALUE = {{ $value }}
+        LABELS = {{ $labels }}
 
     # 2.2.9
     - alert: PostgresqlHighRollbackRate
@@ -97,8 +122,11 @@ groups:
       labels:
         severity: warning
       annotations:
-        summary: Postgresql high rollback rate (instance {{ $labels.instance }})
-        description: "Ratio of transactions being aborted compared to committed is > 2 %\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        summary: PostgresSQL high rollback rate (instance {{ $labels.instance }})
+        description: |
+        Ratio of transactions being aborted compared to committed is > 2 %
+        VALUE = {{ $value }}
+        LABELS = {{ $labels }}
 
     # 2.2.10
     # critical -> info
@@ -108,8 +136,11 @@ groups:
       labels:
         severity: info
       annotations:
-        summary: Postgresql commit rate low (instance {{ $labels.instance }})
-        description: "Postgresql seems to be processing very few transactions\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        summary: PostgresSQL commit rate low (instance {{ $labels.instance }})
+        description: |
+        PostgresSQL seems to be processing very few transactions.
+        VALUE = {{ $value }}
+        LABELS = {{ $labels }}
 
     # 2.2.11
     # warning -> info
@@ -119,8 +150,11 @@ groups:
       labels:
         severity: info
       annotations:
-        summary: Postgresql low XID consumption (instance {{ $labels.instance }})
-        description: "Postgresql seems to be consuming transaction IDs very slowly\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        summary: PostgresSQL low XID consumption (instance {{ $labels.instance }})
+        description: |
+        PostgresSQL seems to be consuming transaction IDs very slowly
+        VALUE = {{ $value }}
+        LABELS = {{ $labels }}
 
     # 2.2.12
     - alert: PostgresqlHighRateStatementTimeout
@@ -129,8 +163,11 @@ groups:
       labels:
         severity: critical
       annotations:
-        summary: Postgresql high rate statement timeout (instance {{ $labels.instance }})
-        description: "Postgres transactions showing high rate of statement timeouts\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        summary: PostgresSQL high rate statement timeout (instance {{ $labels.instance }})
+        description: |
+        PostgresSQL transactions showing high rate of statement timeouts
+        VALUE = {{ $value }}
+        LABELS = {{ $labels }}
 
     # 2.2.13
     # critical -> warning
@@ -140,8 +177,11 @@ groups:
       labels:
         severity: warning
       annotations:
-        summary: Postgresql high rate deadlock (instance {{ $labels.instance }})
-        description: "Postgres detected deadlocks\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        summary: PostgresSQL high rate deadlock (instance {{ $labels.instance }})
+        description: |
+        PostgresSQL detected deadlocks
+        VALUE = {{ $value }}
+        LABELS = {{ $labels }}
 
     # 2.2.14
     # warning -> info
@@ -151,8 +191,11 @@ groups:
       labels:
         severity: info
       annotations:
-        summary: Postgresql unused replication slot (instance {{ $labels.instance }})
-        description: "Unused Replication Slots\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        summary: PostgresSQL unused replication slot (instance {{ $labels.instance }})
+        description: |
+        Unused Replication Slots
+        VALUE = {{ $value }}
+        LABELS = {{ $labels }}
 
     # 2.2.15
     - alert: PostgresqlTooManyDeadTuples
@@ -161,8 +204,11 @@ groups:
       labels:
         severity: warning
       annotations:
-        summary: Postgresql too many dead tuples (instance {{ $labels.instance }})
-        description: "PostgreSQL dead tuples is too large\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        summary: PostgresSQL too many dead tuples (instance {{ $labels.instance }})
+        description: |
+        PostgreSQL dead tuples is too large
+        VALUE = {{ $value }}
+        LABELS = {{ $labels }}
 
     # 2.2.16
     - alert: PostgresqlConfigurationChanged
@@ -171,8 +217,11 @@ groups:
       labels:
         severity: info
       annotations:
-        summary: Postgresql configuration changed (instance {{ $labels.instance }})
-        description: "Postgres Database configuration change has occurred\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        summary: PostgresSQL configuration changed (instance {{ $labels.instance }})
+        description: |
+        PostgresSQL Database configuration change has occurred
+        VALUE = {{ $value }}
+        LABELS = {{ $labels }}
 
     # 2.2.17
     # critical -> warning
@@ -182,8 +231,12 @@ groups:
       labels:
         severity: warning
       annotations:
-        summary: Postgresql SSL compression active (instance {{ $labels.instance }})
-        description: "Database connections with SSL compression enabled. This may add significant jitter in replication delay. Replicas should turn off SSL compression via `sslcompression=0` in `recovery.conf`.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        summary: PostgresSQL SSL compression active (instance {{ $labels.instance }})
+        description: |
+        Database connections with SSL compression enabled. This may add significant jitter in replication delay.
+        Replicas should turn off SSL compression via `sslcompression=0` in `recovery.conf`.
+        VALUE = {{ $value }}
+        LABELS = {{ $labels }}
 
     # 2.2.18
     # critical -> warning
@@ -194,7 +247,11 @@ groups:
         severity: warning
       annotations:
         summary: Postgresql too many locks acquired (instance {{ $labels.instance }})
-        description: "Too many locks acquired on the database. If this alert happens frequently, we may need to increase the postgres setting max_locks_per_transaction.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        description: |
+        Too many locks acquired on the database.
+        If this alert happens frequently, you may need to increase the PostgresSQL setting `max_locks_per_transaction`.
+        VALUE = {{ $value }}
+        LABELS = {{ $labels }}
 
     # 2.2.19
     - alert: PostgresqlBloatIndexHigh(>80%)
@@ -204,7 +261,11 @@ groups:
         severity: warning
       annotations:
         summary: Postgresql bloat index high (> 80%) (instance {{ $labels.instance }})
-        description: "The index {{ $labels.idxname }} is bloated. You should execute `REINDEX INDEX CONCURRENTLY {{ $labels.idxname }};`\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        description: |
+        The index {{ $labels.idxname }} is bloated.
+        You should execute `REINDEX INDEX CONCURRENTLY {{ $labels.idxname }};`
+        VALUE = {{ $value }}
+        LABELS = {{ $labels }}
 
     # 2.2.20
     - alert: PostgresqlBloatTableHigh(>80%)
@@ -213,8 +274,12 @@ groups:
       labels:
         severity: warning
       annotations:
-        summary: Postgresql bloat table high (> 80%) (instance {{ $labels.instance }})
-        description: "The table {{ $labels.relname }} is bloated. You should execute `VACUUM {{ $labels.relname }};`\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        summary: PostgresSQL bloat table high (> 80%) (instance {{ $labels.instance }})
+        description: |
+        The table {{ $labels.relname }} is bloated.
+        You should execute `VACUUM {{ $labels.relname }};`
+        VALUE = {{ $value }}
+        LABELS = {{ $labels }}
 
     # 2.2.21
     # warning -> critical
@@ -224,5 +289,9 @@ groups:
       labels:
         severity: critical
       annotations:
-        summary: Postgresql invalid index (instance {{ $labels.instance }})
-        description: "The table {{ $labels.relname }} has an invalid index: {{ $labels.indexrelname }}. You should execute `DROP INDEX {{ $labels.indexrelname }};`\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        summary: PostgresSQL invalid index (instance {{ $labels.instance }})
+        description: |
+        The table {{ $labels.relname }} has an invalid index: {{ $labels.indexrelname }}.
+        You should execute `DROP INDEX {{ $labels.indexrelname }};`
+        VALUE = {{ $value }}
+        LABELS = {{ $labels }}

--- a/src/prometheus_alert_rules/postgresql_rules.yaml
+++ b/src/prometheus_alert_rules/postgresql_rules.yaml
@@ -15,7 +15,7 @@ groups:
       annotations:
         summary: PostgresSQL down (instance {{ $labels.instance }})
         description: |
-        PostgresSQL instance is down
+        PostgresSQL instance is down. If you are not upgrading or configuring cross-region async replication clusters, please check for errors on Loki logs.
         VALUE = {{ $value }}
         LABELS = {{ $labels }}
 
@@ -29,7 +29,7 @@ groups:
       annotations:
         summary: PostgresSQL restarted (instance {{ $labels.instance }})
         description: |
-        PostgresSQL restarted
+        PostgresSQL restarted. If you are not enabling/disabling TLS or upgrading or configuring cross-region async replication clusters, please check for errors on Loki logs.
         VALUE = {{ $value }}
         LABELS = {{ $labels }}
 
@@ -57,7 +57,7 @@ groups:
       annotations:
         summary: PostgresSQL table not auto vacuumed (instance {{ $labels.instance }})
         description: |
-        Table {{ $labels.relname }} has not been auto vacuumed for 7 days
+        Table {{ $labels.relname }} has not been auto vacuumed for 7 days. Please double-check your VACUUM settings.
         VALUE = {{ $value }}
         LABELS = {{ $labels }}
 
@@ -71,7 +71,7 @@ groups:
       annotations:
         summary: PostgresSQL table not auto analyzed (instance {{ $labels.instance }})
         description: |
-        Table {{ $labels.relname }} has not been auto analyzed for 7 days
+        Table {{ $labels.relname }} has not been auto analyzed for 7 days. Please double-check your AUTOVACUUM ANALYZE settings.
         VALUE = {{ $value }}
         LABELS = {{ $labels }}
 
@@ -84,7 +84,7 @@ groups:
       annotations:
         summary: PostgresSQL too many connections (instance {{ $labels.instance }})
         description: |
-        PostgreSQL instance has too many connections (> 80%).
+        PostgreSQL instance has too many connections (> 80%). Consider double-checking how many connections the client application is opening and/or using PgBouncer in front of the database.
         VALUE = {{ $value }}
         LABELS = {{ $labels }}
 
@@ -98,7 +98,7 @@ groups:
       annotations:
         summary: PostgresSQL not enough connections (instance {{ $labels.instance }})
         description: |
-        PostgreSQL instance should have more connections (> 5)
+        PostgreSQL instance should have more connections (> 5). Consider double-checking how many connections the client application is opening and/or using PgBouncer in front of the database.
         VALUE = {{ $value }}
         LABELS = {{ $labels }}
 
@@ -111,7 +111,7 @@ groups:
       annotations:
         summary: PostgresSQL dead locks (instance {{ $labels.instance }})
         description: |
-        PostgreSQL has dead-locks
+        PostgreSQL has dead-locks. More details can be obtained through the pg_locks view.
         VALUE = {{ $value }}
         LABELS = {{ $labels }}
 
@@ -124,7 +124,7 @@ groups:
       annotations:
         summary: PostgresSQL high rollback rate (instance {{ $labels.instance }})
         description: |
-        Ratio of transactions being aborted compared to committed is > 2 %
+        Ratio of transactions being aborted compared to committed is > 2 %. This issue is probably happening due to unoptimized configurations related to commit delay, connections, memory and WAL files.
         VALUE = {{ $value }}
         LABELS = {{ $labels }}
 
@@ -138,7 +138,7 @@ groups:
       annotations:
         summary: PostgresSQL commit rate low (instance {{ $labels.instance }})
         description: |
-        PostgresSQL seems to be processing very few transactions.
+        PostgresSQL seems to be processing very few transactions. Please check for long-running queries and configuration issues, like not enough cache size.
         VALUE = {{ $value }}
         LABELS = {{ $labels }}
 
@@ -152,7 +152,7 @@ groups:
       annotations:
         summary: PostgresSQL low XID consumption (instance {{ $labels.instance }})
         description: |
-        PostgresSQL seems to be consuming transaction IDs very slowly
+        PostgresSQL seems to be consuming transaction IDs very slowly. Please run ANALYZE to update the optimizer statistics, ensuring that query plans are correct, and double-check your VACUUM settings.
         VALUE = {{ $value }}
         LABELS = {{ $labels }}
 
@@ -165,7 +165,7 @@ groups:
       annotations:
         summary: PostgresSQL high rate statement timeout (instance {{ $labels.instance }})
         description: |
-        PostgresSQL transactions showing high rate of statement timeouts
+        PostgresSQL transactions showing high rate of statement timeouts. Please, either tune statement_timeout when sending queries or use EXPLAIN ANALYZE to understand how the queries can be improved.
         VALUE = {{ $value }}
         LABELS = {{ $labels }}
 
@@ -179,7 +179,7 @@ groups:
       annotations:
         summary: PostgresSQL high rate deadlock (instance {{ $labels.instance }})
         description: |
-        PostgresSQL detected deadlocks
+        PostgresSQL detected deadlocks. More details can be obtained through the pg_locks view.
         VALUE = {{ $value }}
         LABELS = {{ $labels }}
 
@@ -193,7 +193,7 @@ groups:
       annotations:
         summary: PostgresSQL unused replication slot (instance {{ $labels.instance }})
         description: |
-        Unused Replication Slots
+        Unused Replication Slots. Please check if a replica is not using any of them before deleting it.
         VALUE = {{ $value }}
         LABELS = {{ $labels }}
 
@@ -206,7 +206,7 @@ groups:
       annotations:
         summary: PostgresSQL too many dead tuples (instance {{ $labels.instance }})
         description: |
-        PostgreSQL dead tuples is too large
+        PostgreSQL dead tuples is too large. Please double-check your VACUUM settings.
         VALUE = {{ $value }}
         LABELS = {{ $labels }}
 

--- a/src/prometheus_alert_rules/postgresql_rules.yaml
+++ b/src/prometheus_alert_rules/postgresql_rules.yaml
@@ -13,11 +13,9 @@ groups:
       labels:
         severity: critical
       annotations:
-        summary: PostgresSQL down (instance {{ $labels.instance }})
+        summary: PostgresSQL instance {{ $labels.instance }} is down.
         description: |
-          PostgresSQL instance is down.
           If you are not upgrading or configuring cross-region async replication clusters, check for errors in the Loki logs.
-          VALUE = {{ $value }}
           LABELS = {{ $labels }}
 
     # 2.2.2
@@ -28,11 +26,9 @@ groups:
       labels:
         severity: info
       annotations:
-        summary: PostgresSQL restarted (instance {{ $labels.instance }})
+        summary: PostgresSQL instance {{ $labels.instance }} has restarted.
         description: |
-          PostgresSQL restarted. 
           If you are not enabling/disabling TLS or upgrading or configuring cross-region async replication clusters, check for errors in the Loki logs.
-          VALUE = {{ $value }}
           LABELS = {{ $labels }}
 
     # 2.2.3
@@ -42,11 +38,9 @@ groups:
       labels:
         severity: critical
       annotations:
-        summary: PostgresSQL exporter error (instance {{ $labels.instance }})
+        summary: PostgresSQL instance {{ $labels.instance }} is showing an exporter error.
         description: |
-          PostgresSQL exporter is showing errors.
           There may be a buggy query in query.yaml
-          VALUE = {{ $value }}
           LABELS = {{ $labels }}
 
     # 2.2.4
@@ -57,11 +51,10 @@ groups:
       labels:
         severity: warning
       annotations:
-        summary: PostgresSQL table not auto vacuumed (instance {{ $labels.instance }})
+        summary: A PostgresSQL table in instance {{ $labels.instance }} is not auto vacuumed.
         description: |
           Table {{ $labels.relname }} has not been auto vacuumed for 7 days.
           Double-check your VACUUM settings.
-          VALUE = {{ $value }}
           LABELS = {{ $labels }}
 
     # 2.2.5
@@ -72,11 +65,10 @@ groups:
       labels:
         severity: warning
       annotations:
-        summary: PostgresSQL table not auto analyzed (instance {{ $labels.instance }})
+        summary: A PostgresSQL table in instance {{ $labels.instance }} is not auto analyzed.
         description: |
           Table {{ $labels.relname }} has not been auto analyzed for 7 days.
           Double-check your AUTOVACUUM ANALYZE settings.
-          VALUE = {{ $value }}
           LABELS = {{ $labels }}
 
     # 2.2.6
@@ -86,11 +78,9 @@ groups:
       labels:
         severity: warning
       annotations:
-        summary: PostgresSQL too many connections (instance {{ $labels.instance }})
+        summary: PostgresSQL instance {{ $labels.instance }} is using > 80% of the maximum connections.
         description: |
-          PostgreSQL instance has too many connections (> 80%).
-          Consider double-checking how many connections the client application is opening, or using PgBouncer in front of the database.
-          VALUE = {{ $value }}
+          Consider checking how many connections the client application is opening, or using PgBouncer in front of the database.
           LABELS = {{ $labels }}
 
     # 2.2.7
@@ -101,11 +91,10 @@ groups:
       labels:
         severity: info
       annotations:
-        summary: PostgresSQL not enough connections (instance {{ $labels.instance }})
+        summary: PostgresSQL instance {{ $labels.instance }} does not have enough connections.
         description: |
-          PostgreSQL instance should have more connections (> 5).
+          PostgreSQL instance {{ $labels.instance }} should have more connections (> 5).
           Consider double-checking how many connections the client application is opening and/or using PgBouncer in front of the database.
-          VALUE = {{ $value }}
           LABELS = {{ $labels }}
 
     # 2.2.8
@@ -115,11 +104,9 @@ groups:
       labels:
         severity: warning
       annotations:
-        summary: PostgresSQL dead locks (instance {{ $labels.instance }})
+        summary: PostgresSQL instance {{ $labels.instance }} has dead locks.
         description: |
-          PostgreSQL has dead-locks.
           See more details with the pg_locks view.
-          VALUE = {{ $value }}
           LABELS = {{ $labels }}
 
     # 2.2.9
@@ -129,11 +116,10 @@ groups:
       labels:
         severity: warning
       annotations:
-        summary: PostgresSQL high rollback rate (instance {{ $labels.instance }})
+        summary: PostgresSQL instance {{ $labels.instance }} has a high rollback rate instance.
         description: |
-          Ratio of transactions being aborted compared to committed is > 2 %.
+          The ratio of transactions being aborted compared to committed is > 2 %.
           This is probably happening due to unoptimized configurations related to commit delay, connections, memory, and WAL files.
-          VALUE = {{ $value }}
           LABELS = {{ $labels }}
 
     # 2.2.10
@@ -144,11 +130,10 @@ groups:
       labels:
         severity: info
       annotations:
-        summary: PostgresSQL commit rate low (instance {{ $labels.instance }})
+        summary: PostgresSQL instance {{ $labels.instance }} has a low commit rate. 
         description: |
           PostgresSQL seems to be processing very few transactions.
           Please check for long-running queries and configuration issues, like insufficient cache size.
-          VALUE = {{ $value }}
           LABELS = {{ $labels }}
 
     # 2.2.11
@@ -159,11 +144,10 @@ groups:
       labels:
         severity: info
       annotations:
-        summary: PostgresSQL low XID consumption (instance {{ $labels.instance }})
+        summary: PostgresSQL instance {{ $labels.instance }} shows low XID consumption.
         description: |
           PostgresSQL seems to be consuming transaction IDs very slowly.
           Run ANALYZE to update the optimizer statistics, ensure that query plans are correct, and double-check your VACUUM settings.
-          VALUE = {{ $value }}
           LABELS = {{ $labels }}
 
     # 2.2.12
@@ -173,12 +157,11 @@ groups:
       labels:
         severity: critical
       annotations:
-        summary: PostgresSQL high rate statement timeout (instance {{ $labels.instance }})
+        summary: PostgresSQL instance {{ $labels.instance }} shows a high rate of statement timeout.
         description: |
-        `PostgresSQL transactions are showing a high rate of statement timeouts.
-        Either tune `statement_timeou`t when sending queries or use EXPLAIN ANALYZE to understand how the queries can be improved.
-        VALUE = {{ $value }}
-        LABELS = {{ $labels }}`
+          Either tune `statement_timeout` when sending queries or use EXPLAIN ANALYZE to understand how the queries can be improved.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
 
     # 2.2.13
     # critical -> warning
@@ -188,11 +171,9 @@ groups:
       labels:
         severity: warning
       annotations:
-        summary: PostgresSQL high rate deadlock (instance {{ $labels.instance }})
+        summary: PostgresSQL instance {{ $labels.instance }} shows a high deadlock rate.
         description: |
-          PostgresSQL detected deadlocks.
           More details can be obtained through the pg_locks view.
-          VALUE = {{ $value }}
           LABELS = {{ $labels }}
 
     # 2.2.14
@@ -203,11 +184,9 @@ groups:
       labels:
         severity: info
       annotations:
-        summary: PostgresSQL unused replication slot (instance {{ $labels.instance }})
+        summary: PostgresSQL instance {{ $labels.instance }} has unused replication slots.
         description: |
-          Unused replication slots.
           Check if a replica is not using any of them before deleting it.
-          VALUE = {{ $value }}
           LABELS = {{ $labels }}
 
     # 2.2.15
@@ -217,11 +196,9 @@ groups:
       labels:
         severity: warning
       annotations:
-        summary: PostgresSQL too many dead tuples (instance {{ $labels.instance }})
+        summary: PostgresSQL instance {{ $labels.instance }} has too many dead tuples.
         description: |
-          PostgreSQL dead tuples is too large.
           Double-check your VACUUM settings.
-          VALUE = {{ $value }}
           LABELS = {{ $labels }}
 
     # 2.2.16
@@ -231,10 +208,9 @@ groups:
       labels:
         severity: info
       annotations:
-        summary: PostgresSQL configuration changed (instance {{ $labels.instance }})
+        summary: PostgresSQL instance {{ $labels.instance }} configuration has changed.
         description: |
           PostgresSQL database configuration has changed.
-          VALUE = {{ $value }}
           LABELS = {{ $labels }}
 
     # 2.2.17
@@ -245,11 +221,10 @@ groups:
       labels:
         severity: warning
       annotations:
-        summary: PostgresSQL SSL compression active (instance {{ $labels.instance }})
+        summary: PostgresSQL instance {{ $labels.instance }} SSL compression is active.
         description: |
-          Database connections with SSL compression enabled. This may add significant jitter in replication delay.
+          Database connections with SSL compression are enabled. This may add significant jitter in replication delay.
           Replicas should turn off SSL compression via `sslcompression=0` in `recovery.conf`.
-          VALUE = {{ $value }}
           LABELS = {{ $labels }}
 
     # 2.2.18
@@ -260,11 +235,9 @@ groups:
       labels:
         severity: warning
       annotations:
-        summary: Postgresql too many locks acquired (instance {{ $labels.instance }})
+        summary: PostgreSQL instance {{ $labels.instance }} has acquired too many locks.
         description: |
-          Too many locks acquired on the database.
           If this alert happens frequently, you may need to increase the PostgresSQL setting max_locks_per_transaction.
-          VALUE = {{ $value }}
           LABELS = {{ $labels }}
 
     # 2.2.19
@@ -274,11 +247,10 @@ groups:
       labels:
         severity: warning
       annotations:
-        summary: Postgresql bloat index high (> 80%) (instance {{ $labels.instance }})
+        summary: PostgreSQL instance {{ $labels.instance }} has a high bloat index (> 80%).
         description: |
           The index {{ $labels.idxname }} is bloated.
-          You should execute `REINDEX INDEX CONCURRENTLY {{ $labels.idxname }};`
-          VALUE = {{ $value }}
+          Consider running `REINDEX INDEX CONCURRENTLY {{ $labels.idxname }};`
           LABELS = {{ $labels }}
 
     # 2.2.20
@@ -288,11 +260,10 @@ groups:
       labels:
         severity: warning
       annotations:
-        summary: PostgresSQL bloat table high (> 80%) (instance {{ $labels.instance }})
+        summary: PostgreSQL instance {{ $labels.instance }} has a high bloat table (> 80%).
         description: |
           The table {{ $labels.relname }} is bloated.
-          You should execute `VACUUM {{ $labels.relname }};`
-          VALUE = {{ $value }}
+          Consider running `VACUUM {{ $labels.relname }};`
           LABELS = {{ $labels }}
 
     # 2.2.21
@@ -303,9 +274,8 @@ groups:
       labels:
         severity: critical
       annotations:
-        summary: PostgresSQL invalid index (instance {{ $labels.instance }})
+        summary: PostgresSQL instance {{ $labels.instance }})= has an invalid index. 
         description: |
           The table {{ $labels.relname }} has an invalid index: {{ $labels.indexrelname }}.
-          You should execute `DROP INDEX {{ $labels.indexrelname }};`
-          VALUE = {{ $value }}
+          Consider running `DROP INDEX {{ $labels.indexrelname }};`
           LABELS = {{ $labels }}

--- a/src/prometheus_alert_rules/postgresql_rules.yaml
+++ b/src/prometheus_alert_rules/postgresql_rules.yaml
@@ -15,9 +15,10 @@ groups:
       annotations:
         summary: PostgresSQL down (instance {{ $labels.instance }})
         description: |
-        PostgresSQL instance is down. If you are not upgrading or configuring cross-region async replication clusters, please check for errors on Loki logs.
-        VALUE = {{ $value }}
-        LABELS = {{ $labels }}
+          PostgresSQL instance is down.
+          If you are not upgrading or configuring cross-region async replication clusters, check for errors in the Loki logs.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
 
     # 2.2.2
     # critical -> info
@@ -29,9 +30,10 @@ groups:
       annotations:
         summary: PostgresSQL restarted (instance {{ $labels.instance }})
         description: |
-        PostgresSQL restarted. If you are not enabling/disabling TLS or upgrading or configuring cross-region async replication clusters, please check for errors on Loki logs.
-        VALUE = {{ $value }}
-        LABELS = {{ $labels }}
+          PostgresSQL restarted. 
+          If you are not enabling/disabling TLS or upgrading or configuring cross-region async replication clusters, check for errors in the Loki logs.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
 
     # 2.2.3
     - alert: PostgresqlExporterError
@@ -42,10 +44,10 @@ groups:
       annotations:
         summary: PostgresSQL exporter error (instance {{ $labels.instance }})
         description: |
-        PostgresSQL exporter is showing errors.
-        A query may be buggy in query.yaml
-        VALUE = {{ $value }}
-        LABELS = {{ $labels }}
+          PostgresSQL exporter is showing errors.
+          There may be a buggy query in query.yaml
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
 
     # 2.2.4
     # 10 days -> 7 days
@@ -57,9 +59,10 @@ groups:
       annotations:
         summary: PostgresSQL table not auto vacuumed (instance {{ $labels.instance }})
         description: |
-        Table {{ $labels.relname }} has not been auto vacuumed for 7 days. Please double-check your VACUUM settings.
-        VALUE = {{ $value }}
-        LABELS = {{ $labels }}
+          Table {{ $labels.relname }} has not been auto vacuumed for 7 days.
+          Double-check your VACUUM settings.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
 
     # 2.2.5
     # 10 days -> 7 days
@@ -71,9 +74,10 @@ groups:
       annotations:
         summary: PostgresSQL table not auto analyzed (instance {{ $labels.instance }})
         description: |
-        Table {{ $labels.relname }} has not been auto analyzed for 7 days. Please double-check your AUTOVACUUM ANALYZE settings.
-        VALUE = {{ $value }}
-        LABELS = {{ $labels }}
+          Table {{ $labels.relname }} has not been auto analyzed for 7 days.
+          Double-check your AUTOVACUUM ANALYZE settings.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
 
     # 2.2.6
     - alert: PostgresqlTooManyConnections
@@ -84,9 +88,10 @@ groups:
       annotations:
         summary: PostgresSQL too many connections (instance {{ $labels.instance }})
         description: |
-        PostgreSQL instance has too many connections (> 80%). Consider double-checking how many connections the client application is opening and/or using PgBouncer in front of the database.
-        VALUE = {{ $value }}
-        LABELS = {{ $labels }}
+          PostgreSQL instance has too many connections (> 80%).
+          Consider double-checking how many connections the client application is opening, or using PgBouncer in front of the database.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
 
     # 2.2.7
     # warning -> info
@@ -98,9 +103,10 @@ groups:
       annotations:
         summary: PostgresSQL not enough connections (instance {{ $labels.instance }})
         description: |
-        PostgreSQL instance should have more connections (> 5). Consider double-checking how many connections the client application is opening and/or using PgBouncer in front of the database.
-        VALUE = {{ $value }}
-        LABELS = {{ $labels }}
+          PostgreSQL instance should have more connections (> 5).
+          Consider double-checking how many connections the client application is opening and/or using PgBouncer in front of the database.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
 
     # 2.2.8
     - alert: PostgresqlDeadLocks
@@ -111,9 +117,10 @@ groups:
       annotations:
         summary: PostgresSQL dead locks (instance {{ $labels.instance }})
         description: |
-        PostgreSQL has dead-locks. More details can be obtained through the pg_locks view.
-        VALUE = {{ $value }}
-        LABELS = {{ $labels }}
+          PostgreSQL has dead-locks.
+          See more details with the pg_locks view.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
 
     # 2.2.9
     - alert: PostgresqlHighRollbackRate
@@ -124,9 +131,10 @@ groups:
       annotations:
         summary: PostgresSQL high rollback rate (instance {{ $labels.instance }})
         description: |
-        Ratio of transactions being aborted compared to committed is > 2 %. This issue is probably happening due to unoptimized configurations related to commit delay, connections, memory and WAL files.
-        VALUE = {{ $value }}
-        LABELS = {{ $labels }}
+          Ratio of transactions being aborted compared to committed is > 2 %.
+          This is probably happening due to unoptimized configurations related to commit delay, connections, memory, and WAL files.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
 
     # 2.2.10
     # critical -> info
@@ -138,9 +146,10 @@ groups:
       annotations:
         summary: PostgresSQL commit rate low (instance {{ $labels.instance }})
         description: |
-        PostgresSQL seems to be processing very few transactions. Please check for long-running queries and configuration issues, like not enough cache size.
-        VALUE = {{ $value }}
-        LABELS = {{ $labels }}
+          PostgresSQL seems to be processing very few transactions.
+          Please check for long-running queries and configuration issues, like insufficient cache size.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
 
     # 2.2.11
     # warning -> info
@@ -152,9 +161,10 @@ groups:
       annotations:
         summary: PostgresSQL low XID consumption (instance {{ $labels.instance }})
         description: |
-        PostgresSQL seems to be consuming transaction IDs very slowly. Please run ANALYZE to update the optimizer statistics, ensuring that query plans are correct, and double-check your VACUUM settings.
-        VALUE = {{ $value }}
-        LABELS = {{ $labels }}
+          PostgresSQL seems to be consuming transaction IDs very slowly.
+          Run ANALYZE to update the optimizer statistics, ensure that query plans are correct, and double-check your VACUUM settings.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
 
     # 2.2.12
     - alert: PostgresqlHighRateStatementTimeout
@@ -165,9 +175,10 @@ groups:
       annotations:
         summary: PostgresSQL high rate statement timeout (instance {{ $labels.instance }})
         description: |
-        PostgresSQL transactions showing high rate of statement timeouts. Please, either tune statement_timeout when sending queries or use EXPLAIN ANALYZE to understand how the queries can be improved.
+        `PostgresSQL transactions are showing a high rate of statement timeouts.
+        Either tune `statement_timeou`t when sending queries or use EXPLAIN ANALYZE to understand how the queries can be improved.
         VALUE = {{ $value }}
-        LABELS = {{ $labels }}
+        LABELS = {{ $labels }}`
 
     # 2.2.13
     # critical -> warning
@@ -179,9 +190,10 @@ groups:
       annotations:
         summary: PostgresSQL high rate deadlock (instance {{ $labels.instance }})
         description: |
-        PostgresSQL detected deadlocks. More details can be obtained through the pg_locks view.
-        VALUE = {{ $value }}
-        LABELS = {{ $labels }}
+          PostgresSQL detected deadlocks.
+          More details can be obtained through the pg_locks view.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
 
     # 2.2.14
     # warning -> info
@@ -193,9 +205,10 @@ groups:
       annotations:
         summary: PostgresSQL unused replication slot (instance {{ $labels.instance }})
         description: |
-        Unused Replication Slots. Please check if a replica is not using any of them before deleting it.
-        VALUE = {{ $value }}
-        LABELS = {{ $labels }}
+          Unused replication slots.
+          Check if a replica is not using any of them before deleting it.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
 
     # 2.2.15
     - alert: PostgresqlTooManyDeadTuples
@@ -206,9 +219,10 @@ groups:
       annotations:
         summary: PostgresSQL too many dead tuples (instance {{ $labels.instance }})
         description: |
-        PostgreSQL dead tuples is too large. Please double-check your VACUUM settings.
-        VALUE = {{ $value }}
-        LABELS = {{ $labels }}
+          PostgreSQL dead tuples is too large.
+          Double-check your VACUUM settings.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
 
     # 2.2.16
     - alert: PostgresqlConfigurationChanged
@@ -219,9 +233,9 @@ groups:
       annotations:
         summary: PostgresSQL configuration changed (instance {{ $labels.instance }})
         description: |
-        PostgresSQL Database configuration change has occurred
-        VALUE = {{ $value }}
-        LABELS = {{ $labels }}
+          PostgresSQL database configuration has changed.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
 
     # 2.2.17
     # critical -> warning
@@ -233,10 +247,10 @@ groups:
       annotations:
         summary: PostgresSQL SSL compression active (instance {{ $labels.instance }})
         description: |
-        Database connections with SSL compression enabled. This may add significant jitter in replication delay.
-        Replicas should turn off SSL compression via `sslcompression=0` in `recovery.conf`.
-        VALUE = {{ $value }}
-        LABELS = {{ $labels }}
+          Database connections with SSL compression enabled. This may add significant jitter in replication delay.
+          Replicas should turn off SSL compression via `sslcompression=0` in `recovery.conf`.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
 
     # 2.2.18
     # critical -> warning
@@ -248,10 +262,10 @@ groups:
       annotations:
         summary: Postgresql too many locks acquired (instance {{ $labels.instance }})
         description: |
-        Too many locks acquired on the database.
-        If this alert happens frequently, you may need to increase the PostgresSQL setting `max_locks_per_transaction`.
-        VALUE = {{ $value }}
-        LABELS = {{ $labels }}
+          Too many locks acquired on the database.
+          If this alert happens frequently, you may need to increase the PostgresSQL setting max_locks_per_transaction.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
 
     # 2.2.19
     - alert: PostgresqlBloatIndexHigh(>80%)
@@ -262,10 +276,10 @@ groups:
       annotations:
         summary: Postgresql bloat index high (> 80%) (instance {{ $labels.instance }})
         description: |
-        The index {{ $labels.idxname }} is bloated.
-        You should execute `REINDEX INDEX CONCURRENTLY {{ $labels.idxname }};`
-        VALUE = {{ $value }}
-        LABELS = {{ $labels }}
+          The index {{ $labels.idxname }} is bloated.
+          You should execute `REINDEX INDEX CONCURRENTLY {{ $labels.idxname }};`
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
 
     # 2.2.20
     - alert: PostgresqlBloatTableHigh(>80%)
@@ -276,10 +290,10 @@ groups:
       annotations:
         summary: PostgresSQL bloat table high (> 80%) (instance {{ $labels.instance }})
         description: |
-        The table {{ $labels.relname }} is bloated.
-        You should execute `VACUUM {{ $labels.relname }};`
-        VALUE = {{ $value }}
-        LABELS = {{ $labels }}
+          The table {{ $labels.relname }} is bloated.
+          You should execute `VACUUM {{ $labels.relname }};`
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
 
     # 2.2.21
     # warning -> critical
@@ -291,7 +305,7 @@ groups:
       annotations:
         summary: PostgresSQL invalid index (instance {{ $labels.instance }})
         description: |
-        The table {{ $labels.relname }} has an invalid index: {{ $labels.indexrelname }}.
-        You should execute `DROP INDEX {{ $labels.indexrelname }};`
-        VALUE = {{ $value }}
-        LABELS = {{ $labels }}
+          The table {{ $labels.relname }} has an invalid index: {{ $labels.indexrelname }}.
+          You should execute `DROP INDEX {{ $labels.indexrelname }};`
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}

--- a/src/prometheus_alert_rules/postgresql_rules.yaml
+++ b/src/prometheus_alert_rules/postgresql_rules.yaml
@@ -13,7 +13,7 @@ groups:
       labels:
         severity: critical
       annotations:
-        summary: PostgresSQL instance {{ $labels.instance }} is down.
+        summary: PostgreSQL instance {{ $labels.instance }} is down.
         description: |
           If you are not upgrading or configuring cross-region async replication clusters, check for errors in the Loki logs.
           LABELS = {{ $labels }}
@@ -26,7 +26,7 @@ groups:
       labels:
         severity: info
       annotations:
-        summary: PostgresSQL instance {{ $labels.instance }} has restarted.
+        summary: PostgreSQL instance {{ $labels.instance }} has restarted.
         description: |
           If you are not enabling/disabling TLS or upgrading or configuring cross-region async replication clusters, check for errors in the Loki logs.
           LABELS = {{ $labels }}
@@ -38,7 +38,7 @@ groups:
       labels:
         severity: critical
       annotations:
-        summary: PostgresSQL instance {{ $labels.instance }} is showing an exporter error.
+        summary: PostgreSQL instance {{ $labels.instance }} is showing an exporter error.
         description: |
           There may be a buggy query in query.yaml
           LABELS = {{ $labels }}
@@ -51,7 +51,7 @@ groups:
       labels:
         severity: warning
       annotations:
-        summary: A PostgresSQL table in instance {{ $labels.instance }} is not auto vacuumed.
+        summary: A PostgreSQL table in instance {{ $labels.instance }} is not auto vacuumed.
         description: |
           Table {{ $labels.relname }} has not been auto vacuumed for 7 days.
           Double-check your VACUUM settings.
@@ -65,7 +65,7 @@ groups:
       labels:
         severity: warning
       annotations:
-        summary: A PostgresSQL table in instance {{ $labels.instance }} is not auto analyzed.
+        summary: A PostgreSQL table in instance {{ $labels.instance }} is not auto analyzed.
         description: |
           Table {{ $labels.relname }} has not been auto analyzed for 7 days.
           Double-check your AUTOVACUUM ANALYZE settings.
@@ -78,7 +78,7 @@ groups:
       labels:
         severity: warning
       annotations:
-        summary: PostgresSQL instance {{ $labels.instance }} is using > 80% of the maximum connections.
+        summary: PostgreSQL instance {{ $labels.instance }} is using > 80% of the maximum connections.
         description: |
           Consider checking how many connections the client application is opening, or using PgBouncer in front of the database.
           LABELS = {{ $labels }}
@@ -91,7 +91,7 @@ groups:
       labels:
         severity: info
       annotations:
-        summary: PostgresSQL instance {{ $labels.instance }} does not have enough connections.
+        summary: PostgreSQL instance {{ $labels.instance }} does not have enough connections.
         description: |
           PostgreSQL instance {{ $labels.instance }} should have more connections (> 5).
           Consider double-checking how many connections the client application is opening and/or using PgBouncer in front of the database.
@@ -104,7 +104,7 @@ groups:
       labels:
         severity: warning
       annotations:
-        summary: PostgresSQL instance {{ $labels.instance }} has dead locks.
+        summary: PostgreSQL instance {{ $labels.instance }} has dead locks.
         description: |
           See more details with the pg_locks view.
           LABELS = {{ $labels }}
@@ -116,7 +116,7 @@ groups:
       labels:
         severity: warning
       annotations:
-        summary: PostgresSQL instance {{ $labels.instance }} has a high rollback rate instance.
+        summary: PostgreSQL instance {{ $labels.instance }} has a high rollback rate instance.
         description: |
           The ratio of transactions being aborted compared to committed is > 2 %.
           This is probably happening due to unoptimized configurations related to commit delay, connections, memory, and WAL files.
@@ -130,9 +130,9 @@ groups:
       labels:
         severity: info
       annotations:
-        summary: PostgresSQL instance {{ $labels.instance }} has a low commit rate. 
+        summary: PostgreSQL instance {{ $labels.instance }} has a low commit rate. 
         description: |
-          PostgresSQL seems to be processing very few transactions.
+          PostgreSQL seems to be processing very few transactions.
           Please check for long-running queries and configuration issues, like insufficient cache size.
           LABELS = {{ $labels }}
 
@@ -144,9 +144,9 @@ groups:
       labels:
         severity: info
       annotations:
-        summary: PostgresSQL instance {{ $labels.instance }} shows low XID consumption.
+        summary: PostgreSQL instance {{ $labels.instance }} shows low XID consumption.
         description: |
-          PostgresSQL seems to be consuming transaction IDs very slowly.
+          PostgreSQL seems to be consuming transaction IDs very slowly.
           Run ANALYZE to update the optimizer statistics, ensure that query plans are correct, and double-check your VACUUM settings.
           LABELS = {{ $labels }}
 
@@ -157,7 +157,7 @@ groups:
       labels:
         severity: critical
       annotations:
-        summary: PostgresSQL instance {{ $labels.instance }} shows a high rate of statement timeout.
+        summary: PostgreSQL instance {{ $labels.instance }} shows a high rate of statement timeout.
         description: |
           Either tune `statement_timeout` when sending queries or use EXPLAIN ANALYZE to understand how the queries can be improved.
           VALUE = {{ $value }}
@@ -171,7 +171,7 @@ groups:
       labels:
         severity: warning
       annotations:
-        summary: PostgresSQL instance {{ $labels.instance }} shows a high deadlock rate.
+        summary: PostgreSQL instance {{ $labels.instance }} shows a high deadlock rate.
         description: |
           More details can be obtained through the pg_locks view.
           LABELS = {{ $labels }}
@@ -184,7 +184,7 @@ groups:
       labels:
         severity: info
       annotations:
-        summary: PostgresSQL instance {{ $labels.instance }} has unused replication slots.
+        summary: PostgreSQL instance {{ $labels.instance }} has unused replication slots.
         description: |
           Check if a replica is not using any of them before deleting it.
           LABELS = {{ $labels }}
@@ -196,7 +196,7 @@ groups:
       labels:
         severity: warning
       annotations:
-        summary: PostgresSQL instance {{ $labels.instance }} has too many dead tuples.
+        summary: PostgreSQL instance {{ $labels.instance }} has too many dead tuples.
         description: |
           Double-check your VACUUM settings.
           LABELS = {{ $labels }}
@@ -208,9 +208,9 @@ groups:
       labels:
         severity: info
       annotations:
-        summary: PostgresSQL instance {{ $labels.instance }} configuration has changed.
+        summary: PostgreSQL instance {{ $labels.instance }} configuration has changed.
         description: |
-          PostgresSQL database configuration has changed.
+          PostgreSQL database configuration has changed.
           LABELS = {{ $labels }}
 
     # 2.2.17
@@ -221,7 +221,7 @@ groups:
       labels:
         severity: warning
       annotations:
-        summary: PostgresSQL instance {{ $labels.instance }} SSL compression is active.
+        summary: PostgreSQL instance {{ $labels.instance }} SSL compression is active.
         description: |
           Database connections with SSL compression are enabled. This may add significant jitter in replication delay.
           Replicas should turn off SSL compression via `sslcompression=0` in `recovery.conf`.
@@ -237,7 +237,7 @@ groups:
       annotations:
         summary: PostgreSQL instance {{ $labels.instance }} has acquired too many locks.
         description: |
-          If this alert happens frequently, you may need to increase the PostgresSQL setting max_locks_per_transaction.
+          If this alert happens frequently, you may need to increase the PostgreSQL setting max_locks_per_transaction.
           LABELS = {{ $labels }}
 
     # 2.2.19
@@ -274,7 +274,7 @@ groups:
       labels:
         severity: critical
       annotations:
-        summary: PostgresSQL instance {{ $labels.instance }})= has an invalid index. 
+        summary: PostgreSQL instance {{ $labels.instance }})= has an invalid index. 
         description: |
           The table {{ $labels.relname }} has an invalid index: {{ $labels.indexrelname }}.
           Consider running `DROP INDEX {{ $labels.indexrelname }};`

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ commands_pre =
     poetry install --only lint,format --no-root
 commands =
     poetry check --lock
-    poetry run codespell {[vars]all_path}
+    poetry run codespell {[vars]all_path} --skip {tox_root}/src/prometheus_alert_rules
     poetry run ruff check {[vars]all_path}
     poetry run ruff format --check --diff {[vars]all_path}
     find {[vars]all_path} -type f \( -name "*.sh" -o -name "*.bash" \) -exec poetry run shellcheck --color=always \{\} +

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ commands_pre =
     poetry install --only lint,format --no-root
 commands =
     poetry check --lock
-    poetry run codespell {[vars]all_path} --skip {tox_root}/src/prometheus_alert_rules
+    poetry run codespell {[vars]all_path}
     poetry run ruff check {[vars]all_path}
     poetry run ruff format --check --diff {[vars]all_path}
     find {[vars]all_path} -type f \( -name "*.sh" -o -name "*.bash" \) -exec poetry run shellcheck --color=always \{\} +


### PR DESCRIPTION
## Issue
Alert rule descriptions do not provide much guidance about what actions the user can take.

## Solution
Improve the descriptions of the COS alert rule expressions.

The format should be:
1. What happened, or what is the problem
2. What can the user do to recover, or investigate further _(this is the part that's usually missing)_

Here is a good example:
```yaml
summary: PostgresSQL SSL compression active (instance {{ $labels.instance }})
description: |
Database connections have SSL compression enabled. This may add significant jitter in replication delay.
Replicas can turn off SSL compression via `sslcompression=0` in `recovery.conf`.
```