### PR TITLE
[MISC] Reenable labelling tests

### DIFF
--- a/tests/integration/ha_tests/test_rollback_to_master_label.py
+++ b/tests/integration/ha_tests/test_rollback_to_master_label.py
@@ -35,7 +35,6 @@ TIMEOUT = 600
 
 
 @pytest.mark.group(1)
-@pytest.mark.unstable
 @markers.amd64_only  # TODO: remove after arm64 stable release
 @pytest.mark.abort_on_fail
 async def test_deploy_stable(ops_test: OpsTest) -> None:
@@ -44,7 +43,6 @@ async def test_deploy_stable(ops_test: OpsTest) -> None:
         ops_test.model.deploy(
             DATABASE_APP_NAME,
             num_units=3,
-            channel="14/stable",
             revision=(280 if architecture == "arm64" else 281),
             series=CHARM_SERIES,
             trust=True,
@@ -68,7 +66,6 @@ async def test_deploy_stable(ops_test: OpsTest) -> None:
 
 
 @pytest.mark.group(1)
-@pytest.mark.unstable
 @markers.amd64_only  # TODO: remove after arm64 stable release
 async def test_fail_and_rollback(ops_test, continuous_writes) -> None:
     # Start an application that continuously writes data to the database.

--- a/tests/integration/ha_tests/test_rollback_to_master_label.py
+++ b/tests/integration/ha_tests/test_rollback_to_master_label.py
@@ -43,6 +43,7 @@ async def test_deploy_stable(ops_test: OpsTest) -> None:
         ops_test.model.deploy(
             DATABASE_APP_NAME,
             num_units=3,
+            channel="14/stable",
             revision=(280 if architecture == "arm64" else 281),
             series=CHARM_SERIES,
             trust=True,

--- a/tests/integration/ha_tests/test_rollback_to_master_label.py
+++ b/tests/integration/ha_tests/test_rollback_to_master_label.py
@@ -33,6 +33,8 @@ logger = logging.getLogger(__name__)
 
 TIMEOUT = 600
 
+label_revision = 280 if architecture == "arm64" else 281
+
 
 @pytest.mark.group(1)
 @markers.amd64_only  # TODO: remove after arm64 stable release
@@ -44,7 +46,7 @@ async def test_deploy_stable(ops_test: OpsTest) -> None:
             DATABASE_APP_NAME,
             num_units=3,
             channel="14/stable",
-            revision=(280 if architecture == "arm64" else 281),
+            revision=label_revision,
             series=CHARM_SERIES,
             trust=True,
         ),
@@ -131,7 +133,14 @@ async def test_fail_and_rollback(ops_test, continuous_writes) -> None:
 
     logger.info("Re-refresh the charm")
     await ops_test.juju(
-        "refresh", DATABASE_APP_NAME, "--switch", "postgresql-k8s", "--channel", "14/stable"
+        "refresh",
+        DATABASE_APP_NAME,
+        "--switch",
+        "postgresql-k8s",
+        "--channel",
+        "14/stable",
+        "--revision",
+        label_revision,
     )
 
     async with ops_test.fast_forward("60s"):

--- a/tests/integration/ha_tests/test_rollback_to_master_label.py
+++ b/tests/integration/ha_tests/test_rollback_to_master_label.py
@@ -141,6 +141,8 @@ async def test_fail_and_rollback(ops_test, continuous_writes) -> None:
         "14/stable",
         "--revision",
         label_revision,
+        "--resource",
+        "postgresql-image=ghcr.io/canonical/charmed-postgresql@sha256:76ef26c7d11a524bcac206d5cb042ebc3c8c8ead73fa0cd69d21921552db03b6",
     )
 
     async with ops_test.fast_forward("60s"):

--- a/tests/integration/ha_tests/test_rollback_to_master_label.py
+++ b/tests/integration/ha_tests/test_rollback_to_master_label.py
@@ -33,10 +33,9 @@ logger = logging.getLogger(__name__)
 
 TIMEOUT = 600
 
-label_revision = 280 if architecture == "arm64" else 281
-
 
 @pytest.mark.group(1)
+@pytest.mark.unstable
 @markers.amd64_only  # TODO: remove after arm64 stable release
 @pytest.mark.abort_on_fail
 async def test_deploy_stable(ops_test: OpsTest) -> None:
@@ -46,7 +45,7 @@ async def test_deploy_stable(ops_test: OpsTest) -> None:
             DATABASE_APP_NAME,
             num_units=3,
             channel="14/stable",
-            revision=label_revision,
+            revision=(280 if architecture == "arm64" else 281),
             series=CHARM_SERIES,
             trust=True,
         ),
@@ -69,6 +68,7 @@ async def test_deploy_stable(ops_test: OpsTest) -> None:
 
 
 @pytest.mark.group(1)
+@pytest.mark.unstable
 @markers.amd64_only  # TODO: remove after arm64 stable release
 async def test_fail_and_rollback(ops_test, continuous_writes) -> None:
     # Start an application that continuously writes data to the database.
@@ -133,16 +133,7 @@ async def test_fail_and_rollback(ops_test, continuous_writes) -> None:
 
     logger.info("Re-refresh the charm")
     await ops_test.juju(
-        "refresh",
-        DATABASE_APP_NAME,
-        "--switch",
-        "postgresql-k8s",
-        "--channel",
-        "14/stable",
-        "--revision",
-        label_revision,
-        "--resource",
-        "postgresql-image=ghcr.io/canonical/charmed-postgresql@sha256:76ef26c7d11a524bcac206d5cb042ebc3c8c8ead73fa0cd69d21921552db03b6",
+        "refresh", DATABASE_APP_NAME, "--switch", "postgresql-k8s", "--channel", "14/stable"
     )
 
     async with ops_test.fast_forward("60s"):

--- a/tests/integration/ha_tests/test_upgrade_to_primary_label.py
+++ b/tests/integration/ha_tests/test_upgrade_to_primary_label.py
@@ -38,6 +38,7 @@ async def test_deploy_stable(ops_test: OpsTest) -> None:
         ops_test.model.deploy(
             DATABASE_APP_NAME,
             num_units=3,
+            channel="14/stable",
             revision=(280 if architecture == "arm64" else 281),
             trust=True,
         ),

--- a/tests/integration/ha_tests/test_upgrade_to_primary_label.py
+++ b/tests/integration/ha_tests/test_upgrade_to_primary_label.py
@@ -9,7 +9,7 @@ import pytest
 from pytest_operator.plugin import OpsTest
 from tenacity import Retrying, stop_after_attempt, wait_fixed
 
-from .. import markers
+from .. import architecture, markers
 from ..helpers import (
     APPLICATION_NAME,
     DATABASE_APP_NAME,
@@ -30,7 +30,6 @@ TIMEOUT = 600
 
 
 @pytest.mark.group(1)
-@pytest.mark.unstable
 @markers.amd64_only  # TODO: remove after arm64 stable release
 @pytest.mark.abort_on_fail
 async def test_deploy_stable(ops_test: OpsTest) -> None:
@@ -39,7 +38,7 @@ async def test_deploy_stable(ops_test: OpsTest) -> None:
         ops_test.model.deploy(
             DATABASE_APP_NAME,
             num_units=3,
-            channel="14/stable",
+            revision=(280 if architecture == "arm64" else 281),
             trust=True,
         ),
         ops_test.model.deploy(
@@ -61,7 +60,6 @@ async def test_deploy_stable(ops_test: OpsTest) -> None:
 
 
 @pytest.mark.group(1)
-@pytest.mark.unstable
 @markers.amd64_only  # TODO: remove after arm64 stable release
 async def test_upgrade(ops_test, continuous_writes) -> None:
     # Start an application that continuously writes data to the database.

--- a/tests/integration/ha_tests/test_upgrade_to_primary_label.py
+++ b/tests/integration/ha_tests/test_upgrade_to_primary_label.py
@@ -9,7 +9,8 @@ import pytest
 from pytest_operator.plugin import OpsTest
 from tenacity import Retrying, stop_after_attempt, wait_fixed
 
-from .. import architecture, markers
+from .. import markers
+from ..architecture import architecture
 from ..helpers import (
     APPLICATION_NAME,
     DATABASE_APP_NAME,

--- a/tests/integration/ha_tests/test_upgrade_to_primary_label.py
+++ b/tests/integration/ha_tests/test_upgrade_to_primary_label.py
@@ -13,6 +13,7 @@ from .. import markers
 from ..architecture import architecture
 from ..helpers import (
     APPLICATION_NAME,
+    CHARM_SERIES,
     DATABASE_APP_NAME,
     get_leader_unit,
     get_primary,
@@ -41,6 +42,7 @@ async def test_deploy_stable(ops_test: OpsTest) -> None:
             num_units=3,
             channel="14/stable",
             revision=(280 if architecture == "arm64" else 281),
+            series=CHARM_SERIES,
             trust=True,
         ),
         ops_test.model.deploy(


### PR DESCRIPTION
Re-enable the label upgrade test from `master` to `primary`

Cannot re-enable the roll back test, since the dependency fault charm is local and cannot be upgraded to the specific revision (281)