### PR TITLE
[DPE-4469] Polish COS dashboard

### DIFF
--- a/src/grafana_dashboards/postgresql-metrics.json
+++ b/src/grafana_dashboards/postgresql-metrics.json
@@ -216,7 +216,8 @@
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
-          "refId": "A"
+          "refId": "A",
+          "type": "instant"
         }
       ],
       "thresholds": "",
@@ -558,7 +559,8 @@
           "expr": "pg_settings_max_connections{release=\"$release\", instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
-          "refId": "A"
+          "refId": "A",
+          "type": "instant"
         }
       ],
       "thresholds": "",
@@ -620,7 +622,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(process_cpu_seconds_total{release=\"$release\", instance=\"$instance\"}[5m]) * 1000)",
+          "expr": "avg(irate(process_cpu_seconds_total{release=\"$release\", instance=\"$instance\"}[5m]) * 1000)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "CPU Time",
@@ -714,14 +716,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(process_resident_memory_bytes{release=\"$release\", instance=\"$instance\"}[5m]))",
+          "expr": "avg(irate(process_resident_memory_bytes{release=\"$release\", instance=\"$instance\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Resident Mem",
           "refId": "A"
         },
         {
-          "expr": "avg(rate(process_virtual_memory_bytes{release=\"$release\", instance=\"$instance\"}[5m]))",
+          "expr": "avg(irate(process_virtual_memory_bytes{release=\"$release\", instance=\"$instance\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Virtual Mem",
@@ -946,7 +948,8 @@
           "expr": "pg_settings_shared_buffers_bytes{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
-          "refId": "A"
+          "refId": "A",
+          "type": "instant"
         }
       ],
       "thresholds": "",
@@ -1030,7 +1033,8 @@
           "expr": "pg_settings_effective_cache_size_bytes{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
-          "refId": "A"
+          "refId": "A",
+          "type": "instant"
         }
       ],
       "thresholds": "",
@@ -1114,7 +1118,8 @@
           "expr": "pg_settings_maintenance_work_mem_bytes{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
-          "refId": "A"
+          "refId": "A",
+          "type": "instant"
         }
       ],
       "thresholds": "",
@@ -1199,7 +1204,8 @@
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "",
-          "refId": "A"
+          "refId": "A",
+          "type": "instant"
         }
       ],
       "thresholds": "",
@@ -1284,7 +1290,8 @@
           "expr": "pg_settings_max_wal_size_bytes{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
-          "refId": "A"
+          "refId": "A",
+          "type": "instant"
         }
       ],
       "thresholds": "",
@@ -1368,7 +1375,8 @@
           "expr": "pg_settings_random_page_cost{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
-          "refId": "A"
+          "refId": "A",
+          "type": "instant"
         }
       ],
       "thresholds": "",
@@ -1452,7 +1460,8 @@
           "expr": "pg_settings_seq_page_cost",
           "format": "time_series",
           "intervalFactor": 1,
-          "refId": "A"
+          "refId": "A",
+          "type": "instant"
         }
       ],
       "thresholds": "",
@@ -1536,7 +1545,8 @@
           "expr": "pg_settings_max_worker_processes{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
-          "refId": "A"
+          "refId": "A",
+          "type": "instant"
         }
       ],
       "thresholds": "",
@@ -1620,7 +1630,8 @@
           "expr": "pg_settings_max_parallel_workers{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
-          "refId": "A"
+          "refId": "A",
+          "type": "instant"
         }
       ],
       "thresholds": "",
@@ -1664,7 +1675,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 15
+        "y": 22
       },
       "id": 1,
       "legend": {
@@ -1762,7 +1773,7 @@
       "gridPos": {
         "h": 7,
         "w": 8,
-        "x": 0,
+        "x": 16,
         "y": 15
       },
       "id": 60,
@@ -1926,8 +1937,105 @@
       },
       "yaxes": [
         {
-          "format": "bytes",
+          "format": "short",
+          "label": "Rows",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
           "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "datasource",
+        "uid": "${prometheusds}"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 15
+      },
+      "id": 509,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": true,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "irate(pg_stat_database_tup_fetched{datname=~\"$datname\", instance=~\"$instance\"}[5m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{datname}}",
+          "refId": "A",
+          "step": 2
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Read rate (fetched)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": "Rows/sec",
           "logBase": 1,
           "max": null,
           "min": null,
@@ -2023,8 +2131,8 @@
       },
       "yaxes": [
         {
-          "format": "bytes",
-          "label": null,
+          "format": "ops",
+          "label": "Rows/sec",
           "logBase": 1,
           "max": null,
           "min": null,
@@ -2120,8 +2228,8 @@
       },
       "yaxes": [
         {
-          "format": "bytes",
-          "label": null,
+          "format": "ops",
+          "label": "Rows/sec",
           "logBase": 1,
           "max": null,
           "min": null,
@@ -2217,8 +2325,8 @@
       },
       "yaxes": [
         {
-          "format": "bytes",
-          "label": null,
+          "format": "ops",
+          "label": "Rows/sec",
           "logBase": 1,
           "max": null,
           "min": null,
@@ -2314,8 +2422,8 @@
       },
       "yaxes": [
         {
-          "format": "bytes",
-          "label": null,
+          "format": "ops",
+          "label": "Rows/sec",
           "logBase": 1,
           "max": null,
           "min": null,
@@ -2411,8 +2519,8 @@
       },
       "yaxes": [
         {
-          "format": "bytes",
-          "label": null,
+          "format": "short",
+          "label": "Rows",
           "logBase": 1,
           "max": null,
           "min": null,
@@ -2448,7 +2556,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 29
+        "y": 36
       },
       "id": 3,
       "legend": {
@@ -2547,6 +2655,103 @@
         "h": 7,
         "w": 8,
         "x": 8,
+        "y": 15
+      },
+      "id": 141,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sort": "total",
+        "sortDesc": true,
+        "total": true,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "pg_stat_database_tup_fetched{datname=~\"$datname\", instance=~\"$instance\"}",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{datname}}",
+          "refId": "A",
+          "step": 2
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Read count (fetched)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "Rows",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "datasource",
+        "uid": "${prometheusds}"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
         "y": 22
       },
       "id": 14,
@@ -2608,8 +2813,8 @@
       },
       "yaxes": [
         {
-          "format": "bytes",
-          "label": null,
+          "format": "short",
+          "label": "Rows",
           "logBase": 1,
           "max": null,
           "min": null,
@@ -2644,7 +2849,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 22
+        "y": 29
       },
       "id": 4,
       "legend": {
@@ -2802,8 +3007,8 @@
       },
       "yaxes": [
         {
-          "format": "bytes",
-          "label": null,
+          "format": "short",
+          "label": "Rows",
           "logBase": 1,
           "max": null,
           "min": null,
@@ -2929,7 +3134,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 36
+        "y": 43
       },
       "id": 64,
       "legend": {
@@ -3048,7 +3253,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 43
+        "y": 50
       },
       "id": 66,
       "legend": {
@@ -3146,7 +3351,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 50
+        "y": 57
       },
       "id": 68,
       "legend": {

--- a/src/grafana_dashboards/postgresql-metrics.json
+++ b/src/grafana_dashboards/postgresql-metrics.json
@@ -1663,7 +1663,7 @@
       "gridPos": {
         "h": 7,
         "w": 8,
-        "x": 0,
+        "x": 16,
         "y": 15
       },
       "id": 1,
@@ -1680,7 +1680,7 @@
         "total": false,
         "values": true
       },
-      "lines": false,
+      "lines": true,
       "linewidth": 1,
       "links": [],
       "nullPointMode": "connected",
@@ -1689,7 +1689,7 @@
       },
       "percentage": false,
       "pointradius": 3,
-      "points": true,
+      "points": false,
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
@@ -1762,7 +1762,7 @@
       "gridPos": {
         "h": 7,
         "w": 8,
-        "x": 8,
+        "x": 0,
         "y": 15
       },
       "id": 60,
@@ -1863,8 +1863,8 @@
       "gridPos": {
         "h": 7,
         "w": 8,
-        "x": 16,
-        "y": 15
+        "x": 8,
+        "y": 29
       },
       "id": 8,
       "legend": {
@@ -1898,7 +1898,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "pg_stat_database_tup_updated{datname=~\"$datname\", instance=~\"$instance\"} != 0",
+          "expr": "pg_stat_database_tup_updated{datname=~\"$datname\", instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}}",
@@ -1910,7 +1910,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Update data",
+      "title": "Write count (UPDATE)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1995,7 +1995,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "pg_stat_database_tup_fetched{datname=~\"$datname\", instance=~\"$instance\"} != 0",
+          "expr": "irate(pg_stat_database_tup_returned{datname=~\"$datname\", instance=~\"$instance\"}[5m])",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}}",
@@ -2007,7 +2007,298 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Fetch data (SELECT)",
+      "title": "Read rate (SELECT)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "datasource",
+        "uid": "${prometheusds}"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 29
+      },
+      "id": 500,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": true,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "irate(pg_stat_database_tup_updated{datname=~\"$datname\", instance=~\"$instance\"}[5m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{datname}}",
+          "refId": "A",
+          "step": 2
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Write rate (UPDATE)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "datasource",
+        "uid": "${prometheusds}"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 36
+      },
+      "id": 501,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": true,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "irate(pg_stat_database_tup_inserted{datname=~\"$datname\", instance=~\"$instance\"}[5m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{datname}}",
+          "refId": "B",
+          "step": 2
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Write rate (INSERT)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "datasource",
+        "uid": "${prometheusds}"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 43
+      },
+      "id": 502,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": true,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "irate(pg_stat_database_tup_deleted{datname=~\"$datname\", instance=~\"$instance\"}[5m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{datname}}",
+          "refId": "C",
+          "step": 2
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Write rate (DELETE)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2059,7 +2350,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 22
+        "y": 36
       },
       "id": 6,
       "legend": {
@@ -2092,7 +2383,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "pg_stat_database_tup_inserted{datname=~\"$datname\", instance=~\"$instance\"} != 0",
+          "expr": "pg_stat_database_tup_inserted{datname=~\"$datname\", instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}}",
@@ -2104,7 +2395,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Insert data",
+      "title": "Write count (INSERT)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2157,7 +2448,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 22
+        "y": 29
       },
       "id": 3,
       "legend": {
@@ -2255,8 +2546,8 @@
       "gridPos": {
         "h": 7,
         "w": 8,
-        "x": 0,
-        "y": 29
+        "x": 8,
+        "y": 22
       },
       "id": 14,
       "legend": {
@@ -2289,7 +2580,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "pg_stat_database_tup_returned{datname=~\"$datname\", instance=~\"$instance\"} != 0",
+          "expr": "pg_stat_database_tup_returned{datname=~\"$datname\", instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}}",
@@ -2301,7 +2592,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Return data",
+      "title": "Read count (SELECT)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2352,8 +2643,8 @@
       "gridPos": {
         "h": 7,
         "w": 8,
-        "x": 8,
-        "y": 29
+        "x": 16,
+        "y": 22
       },
       "id": 4,
       "legend": {
@@ -2449,8 +2740,8 @@
       "gridPos": {
         "h": 7,
         "w": 8,
-        "x": 16,
-        "y": 29
+        "x": 8,
+        "y": 43
       },
       "id": 7,
       "legend": {
@@ -2483,7 +2774,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "pg_stat_database_tup_deleted{datname=~\"$datname\", instance=~\"$instance\"} != 0",
+          "expr": "pg_stat_database_tup_deleted{datname=~\"$datname\", instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}}",
@@ -2495,7 +2786,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Delete data",
+      "title": "Write count (DELETE)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2546,8 +2837,8 @@
       "gridPos": {
         "h": 7,
         "w": 8,
-        "x": 0,
-        "y": 36
+        "x": 8,
+        "y": 50
       },
       "id": 62,
       "legend": {
@@ -2637,7 +2928,7 @@
       "gridPos": {
         "h": 7,
         "w": 8,
-        "x": 8,
+        "x": 16,
         "y": 36
       },
       "id": 64,
@@ -2757,7 +3048,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 36
+        "y": 43
       },
       "id": 66,
       "legend": {
@@ -2854,8 +3145,8 @@
       "gridPos": {
         "h": 7,
         "w": 8,
-        "x": 0,
-        "y": 43
+        "x": 16,
+        "y": 50
       },
       "id": 68,
       "legend": {
@@ -2943,9 +3234,9 @@
       "fill": 1,
       "gridPos": {
         "h": 7,
-        "w": 16,
-        "x": 8,
-        "y": 43
+        "w": 8,
+        "x": 0,
+        "y": 50
       },
       "id": 70,
       "legend": {

--- a/src/grafana_dashboards/postgresql-metrics.json
+++ b/src/grafana_dashboards/postgresql-metrics.json
@@ -217,7 +217,7 @@
           "intervalFactor": 2,
           "legendFormat": "",
           "refId": "A",
-          "type": "instant"
+          "instant": true
         }
       ],
       "thresholds": "",
@@ -560,7 +560,7 @@
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A",
-          "type": "instant"
+          "instant": true
         }
       ],
       "thresholds": "",
@@ -949,7 +949,7 @@
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A",
-          "type": "instant"
+          "instant": true
         }
       ],
       "thresholds": "",
@@ -1034,7 +1034,7 @@
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A",
-          "type": "instant"
+          "instant": true
         }
       ],
       "thresholds": "",
@@ -1119,7 +1119,7 @@
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A",
-          "type": "instant"
+          "instant": true
         }
       ],
       "thresholds": "",
@@ -1205,7 +1205,7 @@
           "intervalFactor": 1,
           "legendFormat": "",
           "refId": "A",
-          "type": "instant"
+          "instant": true
         }
       ],
       "thresholds": "",
@@ -1291,7 +1291,7 @@
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A",
-          "type": "instant"
+          "instant": true
         }
       ],
       "thresholds": "",
@@ -1376,7 +1376,7 @@
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A",
-          "type": "instant"
+          "instant": true
         }
       ],
       "thresholds": "",
@@ -1461,7 +1461,7 @@
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A",
-          "type": "instant"
+          "instant": true
         }
       ],
       "thresholds": "",
@@ -1546,7 +1546,7 @@
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A",
-          "type": "instant"
+          "instant": true
         }
       ],
       "thresholds": "",
@@ -1631,7 +1631,7 @@
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A",
-          "type": "instant"
+          "instant": true
         }
       ],
       "thresholds": "",


### PR DESCRIPTION
## Issue
The previous state of our COS dashboard (the pg one, didn't look at patroni one yet) has some inconsistencies and weirdnesses. This PR aims to fix most of them + renaming of the graphs, so it's clearer what metric they're showcasing.

The diff is very confusing - I'll put comments on the most important changes. Please try it out if you can, LMK your thoughts. Feel free to suggest any more metrics/graphs you would like to see.

## Screenshot Before
![Screenshot from 2024-05-29 09-37-43](https://github.com/user-attachments/assets/cbe10900-e486-48cd-a1fc-6c23a7ce6d80)

## Screenshot After
![Screenshot 2024-10-10 at 15-29-37 PostgreSQL K8s - Dashboards - Grafana](https://github.com/user-attachments/assets/c028b3cd-f456-423f-ad9a-0242cbf7ed9d)



