### PR TITLE
[DPE-5689] Fix connection rejection rule in `pg_hba.conf`

### DIFF
--- a/src/backups.py
+++ b/src/backups.py
@@ -806,10 +806,12 @@ Juju Version: {str(juju_version)}
             event.fail(error_message)
             return
 
+        disabled_connectivity = False
         if not self.charm.is_primary:
             # Create a rule to mark the cluster as in a creating backup state and update
             # the Patroni configuration.
             self._change_connectivity_to_database(connectivity=False)
+            disabled_connectivity = True
 
         self.charm.unit.status = MaintenanceStatus("creating backup")
         # Set flag due to missing in progress backups on JSON output
@@ -879,8 +881,8 @@ Stderr:
                 logger.info(f"Backup succeeded: with backup-id {datetime_backup_requested}")
                 event.set_results({"backup-status": "backup created"})
 
-        if not self.charm.is_primary:
-            # Remove the rule the marks the cluster as in a creating backup state
+        if disabled_connectivity:
+            # Remove the rule that marks the cluster as in a creating backup state
             # and update the Patroni configuration.
             self._change_connectivity_to_database(connectivity=True)
 

--- a/tests/unit/test_backups.py
+++ b/tests/unit/test_backups.py
@@ -1351,6 +1351,10 @@ Juju Version: test-juju-version
             ),
         ])
         assert _change_connectivity_to_database.call_count == 2
+        _change_connectivity_to_database.assert_has_calls([
+            call(connectivity=False),
+            call(connectivity=True),
+        ])
         mock_event.fail.assert_not_called()
         mock_event.set_results.assert_called_once_with({"backup-status": "backup created"})
 


### PR DESCRIPTION
## Issue

See #747. When the `create-backup` action is run on a non-primary unit (the case when TLS is being used), the unit disables the connectivity to the cluster in order to prevent client operations mid-backup. Afterwards, this same unit should re-establish the connectivity. 

Problem: if a switchover happens mid-operation and the replica unit creating the backup becomes the new primary, it will not re-enable connectivity to the cluster due to not being a replica anymore.

## Solution

Do not check if the unit is the primary or not before re-enabling connectivity (there's no need), but instead checks if it disabled it before -- If so, then enables it back.
