### PR TITLE
[DPE-5712] Add warning logs to Patroni reinitialisation

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -592,7 +592,6 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             self.unit.status = MaintenanceStatus("reinitialising replica")
             self._patroni.reinitialize_postgresql()
             logger.debug("Deferring on_peer_relation_changed: reinitialising replica")
-            self.unit.status = MaintenanceStatus("reinitialising replica")
             event.defer()
             return
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -588,6 +588,8 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
                 or int(self._patroni.member_replication_lag) > 1000
             )
         ):
+            logger.warning("Workload failure detected. Reinitialising unit.")
+            self.unit.status = MaintenanceStatus("reinitialising replica")
             self._patroni.reinitialize_postgresql()
             logger.debug("Deferring on_peer_relation_changed: reinitialising replica")
             self.unit.status = MaintenanceStatus("reinitialising replica")
@@ -1543,9 +1545,9 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             and not self._patroni.member_streaming
         ):
             try:
-                self._patroni.reinitialize_postgresql()
-                logger.info("restarted the replica because it was not streaming from primary")
+                logger.warning("Degraded member detected: reinitialising unit")
                 self.unit.status = MaintenanceStatus("reinitialising replica")
+                self._patroni.reinitialize_postgresql()
             except RetryError:
                 logger.error(
                     "failed to reinitialise replica after checking that it was not streaming from primary"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1578,9 +1578,7 @@ def test_handle_processes_failures(harness):
             harness.charm.unit.status = ActiveStatus()
             result = harness.charm._handle_processes_failures()
             assert result == (values[0] is None)
-            assert isinstance(
-                harness.charm.unit.status, MaintenanceStatus if values[0] is None else ActiveStatus
-            )
+            assert isinstance(harness.charm.unit.status, MaintenanceStatus)
             _restart.assert_not_called()
             _reinitialize_postgresql.assert_called_once()
 


### PR DESCRIPTION
Adds warning and status change before re-initialising to make it more visible in logs