### PR TITLE
[DPE-5915] Reduce pgdate permissions

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -903,7 +903,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         """Create the PostgreSQL data directory."""
         if not container.exists(self.pgdata_path):
             container.make_dir(
-                self.pgdata_path, permissions=0o770, user=WORKLOAD_OS_USER, group=WORKLOAD_OS_GROUP
+                self.pgdata_path, permissions=0o750, user=WORKLOAD_OS_USER, group=WORKLOAD_OS_GROUP
             )
         # Also, fix the permissions from the parent directory.
         container.exec([

--- a/tests/integration/new_relations/test_new_relations.py
+++ b/tests/integration/new_relations/test_new_relations.py
@@ -668,6 +668,7 @@ async def test_discourse(ops_test: OpsTest):
 
 
 @pytest.mark.group(1)
+@pytest.mark.unstable
 @markers.amd64_only  # indico charm not available for arm64
 async def test_indico_datatabase(ops_test: OpsTest) -> None:
     """Tests deploying and relating to the Indico charm."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1773,7 +1773,7 @@ def test_create_pgdata(harness):
     container.exists.return_value = False
     harness.charm._create_pgdata(container)
     container.make_dir.assert_called_once_with(
-        "/var/lib/postgresql/data/pgdata", permissions=504, user="postgres", group="postgres"
+        "/var/lib/postgresql/data/pgdata", permissions=488, user="postgres", group="postgres"
     )
     container.exec.assert_called_once_with([
         "chown",


### PR DESCRIPTION
Replica units fail to initialize on Juju 3.6 due to too restrictive permissions rejected by initdb.

> ... FATAL:  data directory "/var/lib/postgresql/data/pgdata" has invalid permissions                                                            
> ... DETAIL:  Permissions should be u=rwx (0700) or u=rwx,g=rx (0750). 

Reducing permissions to the maximum accepted by initdb.

Tech details:
Previously in Juju 3.5, the old Pebble 1.10 [ignored our 0770](https://github.com/canonical/postgresql-k8s-operator/blob/6f10bb97b7d5c591fc4536c9d67afe6cbc27da09/src/charm.py#L906) and set 0750 => everything worked well. 

In Juju 3.6-rc1, the new Pebble 1.16 shipped.
Meanwhile, the Pebble 1.12 [has fixed mkdir](https://github.com/canonical/pebble/releases/tag/v1.12.0).
As a result our 0770 is how set properly causing regression as PG/initdb accept 0750 maximum.

Fixes: https://github.com/canonical/postgresql-k8s-operator/issues/760 
 and https://warthogs.atlassian.net/browse/DPE-5915