### PR TITLE
[MISC] Only update tls flags on the Juju leader unit

### DIFF
--- a/src/relations/postgresql_provider.py
+++ b/src/relations/postgresql_provider.py
@@ -211,6 +211,9 @@ class PostgreSQLProvider(Object):
 
     def update_tls_flag(self, tls: str) -> None:
         """Update TLS flag and CA in relation databag."""
+        if not self.charm.unit.is_leader():
+            return
+
         relations = self.model.relations[self.relation_name]
         if tls == "True":
             _, ca, _ = self.charm.tls.get_tls_files()


### PR DESCRIPTION
## Issue

Trying to update tls flags in the client relation data from follower unit causes warnings:
```
2024-11-14T03:01:16.3917364Z unit-postgresql-k8s-2: 03:00:51 ERROR unit.postgresql-k8s/2.juju-log This operation (update_relation_data()) can only be performed by the leader unit
2024-11-14T03:01:16.3935892Z unit-postgresql-k8s-2: 03:00:51 ERROR unit.postgresql-k8s/2.juju-log This operation (update_relation_data()) can only be performed by the leader unit
```

## Solution
Check leadership before setting the relation data