### PR TITLE
[DPE-6033] Preload shared libs on normal PG start

### DIFF
--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -115,6 +115,7 @@ postgresql:
   bin_dir: /usr/lib/postgresql/{{ version }}/bin
   listen: 0.0.0.0:5432
   parameters:
+    shared_preload_libraries: 'timescaledb,pgaudit'
     {%- if enable_pgbackrest_archiving %}
     archive_command: 'pgbackrest --stanza={{ stanza }} archive-push %p'
     {% else %}

--- a/tests/integration/ha_tests/test_rollback_to_master_label.py
+++ b/tests/integration/ha_tests/test_rollback_to_master_label.py
@@ -17,6 +17,7 @@ from ..helpers import (
     APPLICATION_NAME,
     CHARM_BASE,
     DATABASE_APP_NAME,
+    METADATA,
     get_leader_unit,
     get_primary,
     get_unit_by_index,
@@ -108,8 +109,11 @@ async def test_fail_and_rollback(ops_test, continuous_writes) -> None:
 
     application = ops_test.model.applications[DATABASE_APP_NAME]
 
+    resources = {"postgresql-image": METADATA["resources"]["postgresql-image"]["upstream-source"]}
+    application = ops_test.model.applications[DATABASE_APP_NAME]
+
     logger.info("Refresh the charm")
-    await application.refresh(path=fault_charm)
+    await application.refresh(path=fault_charm, resources=resources)
 
     logger.info("Get first upgrading unit")
     # Highest ordinal unit always the first to upgrade.

--- a/tests/integration/ha_tests/test_upgrade_to_primary_label.py
+++ b/tests/integration/ha_tests/test_upgrade_to_primary_label.py
@@ -16,6 +16,7 @@ from ..helpers import (
     CHARM_BASE,
     CHARM_SERIES,
     DATABASE_APP_NAME,
+    METADATA,
     get_leader_unit,
     get_primary,
     get_unit_by_index,
@@ -100,8 +101,11 @@ async def test_upgrade(ops_test, continuous_writes) -> None:
     local_charm = await ops_test.build_charm(".")
     application = ops_test.model.applications[DATABASE_APP_NAME]
 
+    resources = {"postgresql-image": METADATA["resources"]["postgresql-image"]["upstream-source"]}
+    application = ops_test.model.applications[DATABASE_APP_NAME]
+
     logger.info("Refresh the charm")
-    await application.refresh(path=local_charm)
+    await application.refresh(path=local_charm, resources=resources)
 
     logger.info("Get first upgrading unit")
     # Highest ordinal unit always the first to upgrade.


### PR DESCRIPTION
## Issue
psycopg errors out after upgrade due to `shared_preload_libraries` directive missing in Patroni's `postgresql.parameters` config

## Solution
* Add shared_preload_libraries` to `postgresql.parameters` config
* Add resources to primary label upgrade tests