### PR TITLE
[DPE-5827] Synchronous node count configuration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,7 +5,7 @@ options:
   synchronous_node_count:
     description: |
       Sets the number of synchronous nodes to be maintained in the cluster. Should be
-      either "all", "minority", "majority" or a positive value.
+      either "all", "majority" or a positive value.
     type: string
     default: "all"
   durability_synchronous_commit:

--- a/config.yaml
+++ b/config.yaml
@@ -2,11 +2,12 @@
 # See LICENSE file for licensing details.
 
 options:
-  durability_synchronous_node_count:
+  synchronous_node_count:
     description: |
       Sets the number of synchronous nodes to be maintained in the cluster. Should be
-      a positive value.
-    type: int
+      either "all", "minority", "majority" or a positive value.
+    type: string
+    default: "all"
   durability_synchronous_commit:
     description: |
       Sets the current transactions synchronization level. This charm allows only the

--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,11 @@
 # See LICENSE file for licensing details.
 
 options:
+  durability_synchronous_node_count:
+    description: |
+      Sets the number of synchronous nodes to be maintained in the cluster. Should be
+      a positive value.
+      type: integer
   durability_synchronous_commit:
     description: |
       Sets the current transactions synchronization level. This charm allows only the

--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -654,7 +654,7 @@ WHERE lomowner = (SELECT oid FROM pg_roles WHERE rolname = '{}');""".format(user
                 "request",
                 "response",
                 "vacuum",
-            )) or config in ("durability_synchronous_node_count"):
+            )) or config in ("durability_synchronous_node_count",):
                 continue
             parameter = "_".join(config.split("_")[1:])
             if parameter in ["date_style", "time_zone"]:

--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -36,7 +36,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 39
+LIBPATCH = 40
 
 INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE = "invalid role(s) for extra user roles"
 
@@ -654,7 +654,7 @@ WHERE lomowner = (SELECT oid FROM pg_roles WHERE rolname = '{}');""".format(user
                 "request",
                 "response",
                 "vacuum",
-            )):
+            )) or config in ("durability_synchronous_node_count"):
                 continue
             parameter = "_".join(config.split("_")[1:])
             if parameter in ["date_style", "time_zone"]:

--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -36,7 +36,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 40
+LIBPATCH = 39
 
 INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE = "invalid role(s) for extra user roles"
 
@@ -654,7 +654,7 @@ WHERE lomowner = (SELECT oid FROM pg_roles WHERE rolname = '{}');""".format(user
                 "request",
                 "response",
                 "vacuum",
-            )) or config in ("durability_synchronous_node_count",):
+            )):
                 continue
             parameter = "_".join(config.split("_")[1:])
             if parameter in ["date_style", "time_zone"]:

--- a/src/config.py
+++ b/src/config.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 class CharmConfig(BaseConfigModel):
     """Manager for the structured configuration."""
 
-    synchronous_node_count: Literal["all", "minority", "majority"] | PositiveInt
+    synchronous_node_count: Literal["all", "majority"] | PositiveInt
     durability_synchronous_commit: Optional[str]
     instance_default_text_search_config: Optional[str]
     instance_password_encryption: Optional[str]

--- a/src/config.py
+++ b/src/config.py
@@ -8,7 +8,7 @@ import logging
 from typing import Optional
 
 from charms.data_platform_libs.v0.data_models import BaseConfigModel
-from pydantic import validator
+from pydantic import PositiveInt, validator
 
 logger = logging.getLogger(__name__)
 
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 class CharmConfig(BaseConfigModel):
     """Manager for the structured configuration."""
 
+    durability_synchronous_node_count: Optional[PositiveInt]
     durability_synchronous_commit: Optional[str]
     instance_default_text_search_config: Optional[str]
     instance_password_encryption: Optional[str]

--- a/src/config.py
+++ b/src/config.py
@@ -5,7 +5,7 @@
 """Structured configuration for the PostgreSQL charm."""
 
 import logging
-from typing import Optional
+from typing import Literal, Optional
 
 from charms.data_platform_libs.v0.data_models import BaseConfigModel
 from pydantic import PositiveInt, validator
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 class CharmConfig(BaseConfigModel):
     """Manager for the structured configuration."""
 
-    durability_synchronous_node_count: Optional[PositiveInt]
+    synchronous_node_count: Literal["all", "minority", "majority"] | PositiveInt
     durability_synchronous_commit: Optional[str]
     instance_default_text_search_config: Optional[str]
     instance_password_encryption: Optional[str]

--- a/src/patroni.py
+++ b/src/patroni.py
@@ -131,14 +131,15 @@ class Patroni:
 
     @property
     def _synchronous_node_count(self) -> int:
+        planned_units = self._charm.app.planned_units()
         if self._charm.config.synchronous_node_count == "all":
-            return self._members_count - 1
+            return planned_units - 1
         elif self._charm.config.synchronous_node_count == "majority":
-            return self._members_count // 2
+            return planned_units // 2
         return (
             self._charm.config.synchronous_node_count
             if self._charm.config.synchronous_node_count < self._members_count - 1
-            else self._members_count - 1
+            else planned_units - 1
         )
 
     def update_synchronous_node_count(self) -> None:

--- a/src/patroni.py
+++ b/src/patroni.py
@@ -137,11 +137,8 @@ class Patroni:
             return self._members_count // 2
         elif self._charm.config.synchronous_node_count == "majority":
             return self._members_count // 2 + 1
-        return (
-            self._charm.config.synchronous_node_count
-            if self._charm.config.synchronous_node_count < self._members_count - 1
-            else self._members_count - 1
-        )
+        node_count = int(self._charm.config.synchronous_node_count)
+        return node_count if node_count < self._members_count - 1 else self._members_count - 1
 
     def update_synchronous_node_count(self) -> None:
         """Update synchronous_node_count."""

--- a/src/patroni.py
+++ b/src/patroni.py
@@ -133,10 +133,8 @@ class Patroni:
     def _synchronous_node_count(self) -> int:
         if self._charm.config.synchronous_node_count == "all":
             return self._members_count - 1
-        elif self._charm.config.synchronous_node_count == "minority":
-            return self._members_count // 2
         elif self._charm.config.synchronous_node_count == "majority":
-            return self._members_count // 2 + 1
+            return self._members_count // 2
         return (
             self._charm.config.synchronous_node_count
             if self._charm.config.synchronous_node_count < self._members_count - 1

--- a/src/patroni.py
+++ b/src/patroni.py
@@ -131,15 +131,17 @@ class Patroni:
 
     @property
     def _synchronous_node_count(self) -> int:
-        pass
-        units = (
-            self._charm.config.durability_synchronous_node_count
-            if self._charm.config.durability_synchronous_node_count
+        if self._charm.config.synchronous_node_count == "all":
+            return self._members_count - 1
+        elif self._charm.config.synchronous_node_count == "minorty":
+            return self._members_count // 2
+        elif self._charm.config.synchronous_node_count == "majority":
+            return self._members_count // 2 + 1
+        return (
+            self._charm.config.synchronous_node_count
+            if self._charm.config.synchronous_node_count < self._members_count - 1
             else self._members_count - 1
         )
-        if units > self._members_count - 1:
-            units = self._members_count - 1
-        return units
 
     def update_synchronous_node_count(self) -> None:
         """Update synchronous_node_count."""

--- a/src/patroni.py
+++ b/src/patroni.py
@@ -133,12 +133,15 @@ class Patroni:
     def _synchronous_node_count(self) -> int:
         if self._charm.config.synchronous_node_count == "all":
             return self._members_count - 1
-        elif self._charm.config.synchronous_node_count == "minorty":
+        elif self._charm.config.synchronous_node_count == "minority":
             return self._members_count // 2
         elif self._charm.config.synchronous_node_count == "majority":
             return self._members_count // 2 + 1
-        node_count = int(self._charm.config.synchronous_node_count)
-        return node_count if node_count < self._members_count - 1 else self._members_count - 1
+        return (
+            self._charm.config.synchronous_node_count
+            if self._charm.config.synchronous_node_count < self._members_count - 1
+            else self._members_count - 1
+        )
 
     def update_synchronous_node_count(self) -> None:
         """Update synchronous_node_count."""

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -1177,7 +1177,7 @@ async def remove_unit_force(ops_test: OpsTest, num_units: int):
 
 
 async def get_cluster_roles(
-    ops_test: OpsTest, unit_name: str, use_ip_from_inside: bool = False
+    ops_test: OpsTest, unit_name: str
 ) -> dict[str, str | list[str] | None]:
     """Returns whether the unit a replica in the cluster."""
     unit_ip = await get_unit_address(ops_test, unit_name)

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -1174,3 +1174,24 @@ async def remove_unit_force(ops_test: OpsTest, num_units: int):
             timeout=1000,
             wait_for_exact_units=scale,
         )
+
+
+async def get_cluster_roles(
+    ops_test: OpsTest, unit_name: str, use_ip_from_inside: bool = False
+) -> dict[str, str | list[str] | None]:
+    """Returns whether the unit a replica in the cluster."""
+    unit_ip = await get_unit_address(ops_test, unit_name)
+    members = {"replicas": [], "primaries": [], "sync_standbys": []}
+    member_list = get_patroni_cluster(unit_ip)["members"]
+    logger.info(f"Cluster members are: {member_list}")
+    for member in member_list:
+        role = member["role"]
+        name = "/".join(member["name"].rsplit("-", 1))
+        if role == "leader":
+            members["primaries"].append(name)
+        elif role == "sync_standby":
+            members["sync_standbys"].append(name)
+        else:
+            members["replicas"].append(name)
+
+    return members

--- a/tests/integration/ha_tests/test_synchronous_policy.py
+++ b/tests/integration/ha_tests/test_synchronous_policy.py
@@ -31,7 +31,7 @@ async def test_default_all(ops_test: OpsTest) -> None:
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(apps=[app], status="active")
 
-    roles = get_cluster_roles(ops_test.model.applications[app].units[0].name)
+    roles = get_cluster_roles(ops_test, ops_test.model.applications[app].units[0].name)
 
     assert len(roles["primaries"]) == 1
     assert len(roles["sync_standbys"]) == 2
@@ -48,7 +48,7 @@ async def test_minority(ops_test: OpsTest) -> None:
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(apps=[app], status="active")
 
-    roles = get_cluster_roles(ops_test.model.applications[app].units[0].name)
+    roles = get_cluster_roles(ops_test, ops_test.model.applications[app].units[0].name)
 
     assert len(roles["primaries"]) == 1
     assert len(roles["sync_standbys"]) == 1
@@ -65,7 +65,7 @@ async def test_majority(ops_test: OpsTest) -> None:
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(apps=[app], status="active")
 
-    roles = get_cluster_roles(ops_test.model.applications[app].units[0].name)
+    roles = get_cluster_roles(ops_test, ops_test.model.applications[app].units[0].name)
 
     assert len(roles["primaries"]) == 1
     assert len(roles["sync_standbys"]) == 2
@@ -82,7 +82,7 @@ async def test_constant(ops_test: OpsTest) -> None:
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(apps=[app], status="active")
 
-    roles = get_cluster_roles(ops_test.model.applications[app].units[0].name)
+    roles = get_cluster_roles(ops_test, ops_test.model.applications[app].units[0].name)
 
     assert len(roles["primaries"]) == 1
     assert len(roles["sync_standbys"]) == 1

--- a/tests/integration/ha_tests/test_synchronous_policy.py
+++ b/tests/integration/ha_tests/test_synchronous_policy.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+import pytest
+from pytest_operator.plugin import OpsTest
+
+from ..helpers import app_name, build_and_deploy
+from .helpers import get_cluster_roles
+
+
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest) -> None:
+    """Build and deploy three unit of PostgreSQL."""
+    wait_for_apps = False
+    # It is possible for users to provide their own cluster for HA testing. Hence, check if there
+    # is a pre-existing cluster.
+    if not await app_name(ops_test):
+        wait_for_apps = True
+        await build_and_deploy(ops_test, 3, wait_for_idle=False)
+
+    if wait_for_apps:
+        async with ops_test.fast_forward():
+            await ops_test.model.wait_for_idle(status="active", timeout=1000, raise_on_error=False)
+
+
+@pytest.mark.group(1)
+async def test_default_all(ops_test: OpsTest) -> None:
+    app = await app_name(ops_test)
+
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(apps=[app], status="active")
+
+    roles = get_cluster_roles(ops_test.model.applications[app].units[0].name)
+
+    assert len(roles["primaries"]) == 1
+    assert len(roles["sync_standbys"]) == 2
+    assert len(roles["replicas"]) == 0
+
+
+@pytest.mark.group(1)
+async def test_minority(ops_test: OpsTest) -> None:
+    """Kill primary unit, check reelection."""
+    app = await app_name(ops_test)
+
+    await ops_test.model.applications[app].set_config({"synchronous_node_count": "minority"})
+
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(apps=[app], status="active")
+
+    roles = get_cluster_roles(ops_test.model.applications[app].units[0].name)
+
+    assert len(roles["primaries"]) == 1
+    assert len(roles["sync_standbys"]) == 1
+    assert len(roles["replicas"]) == 1
+
+
+@pytest.mark.group(1)
+async def test_majority(ops_test: OpsTest) -> None:
+    """Kill primary unit, check reelection."""
+    app = await app_name(ops_test)
+
+    await ops_test.model.applications[app].set_config({"synchronous_node_count": "majority"})
+
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(apps=[app], status="active")
+
+    roles = get_cluster_roles(ops_test.model.applications[app].units[0].name)
+
+    assert len(roles["primaries"]) == 1
+    assert len(roles["sync_standbys"]) == 2
+    assert len(roles["replicas"]) == 0
+
+
+@pytest.mark.group(1)
+async def test_constant(ops_test: OpsTest) -> None:
+    """Kill primary unit, check reelection."""
+    app = await app_name(ops_test)
+
+    await ops_test.model.applications[app].set_config({"synchronous_node_count": "1"})
+
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(apps=[app], status="active")
+
+    roles = get_cluster_roles(ops_test.model.applications[app].units[0].name)
+
+    assert len(roles["primaries"]) == 1
+    assert len(roles["sync_standbys"]) == 1
+    assert len(roles["replicas"]) == 1

--- a/tests/integration/ha_tests/test_synchronous_policy.py
+++ b/tests/integration/ha_tests/test_synchronous_policy.py
@@ -32,7 +32,7 @@ async def test_default_all(ops_test: OpsTest) -> None:
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(apps=[app], status="active", timeout=300)
 
-    for attempt in Retrying(stop=stop_after_attempt(3), wait=wait_fixed(5), reraise=True):
+    for attempt in Retrying(stop=stop_after_attempt(3), wait=wait_fixed(10), reraise=True):
         with attempt:
             roles = await get_cluster_roles(
                 ops_test, ops_test.model.applications[app].units[0].name
@@ -52,7 +52,7 @@ async def test_majority(ops_test: OpsTest) -> None:
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(apps=[app], status="active")
 
-    for attempt in Retrying(stop=stop_after_attempt(3), wait=wait_fixed(5), reraise=True):
+    for attempt in Retrying(stop=stop_after_attempt(3), wait=wait_fixed(10), reraise=True):
         with attempt:
             roles = await get_cluster_roles(
                 ops_test, ops_test.model.applications[app].units[0].name
@@ -73,7 +73,7 @@ async def test_constant(ops_test: OpsTest) -> None:
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(apps=[app], status="active", timeout=300)
 
-    for attempt in Retrying(stop=stop_after_attempt(3), wait=wait_fixed(5), reraise=True):
+    for attempt in Retrying(stop=stop_after_attempt(3), wait=wait_fixed(10), reraise=True):
         with attempt:
             roles = await get_cluster_roles(
                 ops_test, ops_test.model.applications[app].units[0].name

--- a/tests/integration/ha_tests/test_synchronous_policy.py
+++ b/tests/integration/ha_tests/test_synchronous_policy.py
@@ -32,7 +32,7 @@ async def test_default_all(ops_test: OpsTest) -> None:
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(apps=[app], status="active", timeout=300)
 
-    for attempt in Retrying(stop=stop_after_attempt(3), wait=wait_fixed(10), reraise=True):
+    for attempt in Retrying(stop=stop_after_attempt(3), wait=wait_fixed(5), reraise=True):
         with attempt:
             roles = await get_cluster_roles(
                 ops_test, ops_test.model.applications[app].units[0].name
@@ -52,7 +52,7 @@ async def test_majority(ops_test: OpsTest) -> None:
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(apps=[app], status="active")
 
-    for attempt in Retrying(stop=stop_after_attempt(3), wait=wait_fixed(10), reraise=True):
+    for attempt in Retrying(stop=stop_after_attempt(3), wait=wait_fixed(5), reraise=True):
         with attempt:
             roles = await get_cluster_roles(
                 ops_test, ops_test.model.applications[app].units[0].name
@@ -73,7 +73,7 @@ async def test_constant(ops_test: OpsTest) -> None:
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(apps=[app], status="active", timeout=300)
 
-    for attempt in Retrying(stop=stop_after_attempt(3), wait=wait_fixed(10), reraise=True):
+    for attempt in Retrying(stop=stop_after_attempt(3), wait=wait_fixed(5), reraise=True):
         with attempt:
             roles = await get_cluster_roles(
                 ops_test, ops_test.model.applications[app].units[0].name

--- a/tests/integration/ha_tests/test_synchronous_policy.py
+++ b/tests/integration/ha_tests/test_synchronous_policy.py
@@ -29,9 +29,9 @@ async def test_default_all(ops_test: OpsTest) -> None:
     app = await app_name(ops_test)
 
     async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(apps=[app], status="active")
+        await ops_test.model.wait_for_idle(apps=[app], status="active", timeout=300)
 
-    roles = get_cluster_roles(ops_test, ops_test.model.applications[app].units[0].name)
+    roles = await get_cluster_roles(ops_test, ops_test.model.applications[app].units[0].name)
 
     assert len(roles["primaries"]) == 1
     assert len(roles["sync_standbys"]) == 2
@@ -46,9 +46,9 @@ async def test_minority(ops_test: OpsTest) -> None:
     await ops_test.model.applications[app].set_config({"synchronous_node_count": "minority"})
 
     async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(apps=[app], status="active")
+        await ops_test.model.wait_for_idle(apps=[app], status="active", timeout=300)
 
-    roles = get_cluster_roles(ops_test, ops_test.model.applications[app].units[0].name)
+    roles = await get_cluster_roles(ops_test, ops_test.model.applications[app].units[0].name)
 
     assert len(roles["primaries"]) == 1
     assert len(roles["sync_standbys"]) == 1
@@ -65,7 +65,7 @@ async def test_majority(ops_test: OpsTest) -> None:
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(apps=[app], status="active")
 
-    roles = get_cluster_roles(ops_test, ops_test.model.applications[app].units[0].name)
+    roles = await get_cluster_roles(ops_test, ops_test.model.applications[app].units[0].name)
 
     assert len(roles["primaries"]) == 1
     assert len(roles["sync_standbys"]) == 2
@@ -80,9 +80,9 @@ async def test_constant(ops_test: OpsTest) -> None:
     await ops_test.model.applications[app].set_config({"synchronous_node_count": "1"})
 
     async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(apps=[app], status="active")
+        await ops_test.model.wait_for_idle(apps=[app], status="active", timeout=300)
 
-    roles = get_cluster_roles(ops_test, ops_test.model.applications[app].units[0].name)
+    roles = await get_cluster_roles(ops_test, ops_test.model.applications[app].units[0].name)
 
     assert len(roles["primaries"]) == 1
     assert len(roles["sync_standbys"]) == 1

--- a/tests/integration/ha_tests/test_synchronous_policy.py
+++ b/tests/integration/ha_tests/test_synchronous_policy.py
@@ -3,6 +3,7 @@
 # See LICENSE file for licensing details.
 import pytest
 from pytest_operator.plugin import OpsTest
+from tenacity import Retrying, stop_after_attempt, wait_fixed
 
 from ..helpers import app_name, build_and_deploy
 from .helpers import get_cluster_roles
@@ -31,33 +32,19 @@ async def test_default_all(ops_test: OpsTest) -> None:
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(apps=[app], status="active", timeout=300)
 
-    roles = await get_cluster_roles(ops_test, ops_test.model.applications[app].units[0].name)
+    for attempt in Retrying(stop=stop_after_attempt(3), wait=wait_fixed(5), reraise=True):
+        with attempt:
+            roles = await get_cluster_roles(
+                ops_test, ops_test.model.applications[app].units[0].name
+            )
 
-    assert len(roles["primaries"]) == 1
-    assert len(roles["sync_standbys"]) == 2
-    assert len(roles["replicas"]) == 0
-
-
-@pytest.mark.group(1)
-async def test_minority(ops_test: OpsTest) -> None:
-    """Kill primary unit, check reelection."""
-    app = await app_name(ops_test)
-
-    await ops_test.model.applications[app].set_config({"synchronous_node_count": "minority"})
-
-    async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(apps=[app], status="active", timeout=300)
-
-    roles = await get_cluster_roles(ops_test, ops_test.model.applications[app].units[0].name)
-
-    assert len(roles["primaries"]) == 1
-    assert len(roles["sync_standbys"]) == 1
-    assert len(roles["replicas"]) == 1
+            assert len(roles["primaries"]) == 1
+            assert len(roles["sync_standbys"]) == 2
+            assert len(roles["replicas"]) == 0
 
 
 @pytest.mark.group(1)
 async def test_majority(ops_test: OpsTest) -> None:
-    """Kill primary unit, check reelection."""
     app = await app_name(ops_test)
 
     await ops_test.model.applications[app].set_config({"synchronous_node_count": "majority"})
@@ -65,11 +52,15 @@ async def test_majority(ops_test: OpsTest) -> None:
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(apps=[app], status="active")
 
-    roles = await get_cluster_roles(ops_test, ops_test.model.applications[app].units[0].name)
+    for attempt in Retrying(stop=stop_after_attempt(3), wait=wait_fixed(5), reraise=True):
+        with attempt:
+            roles = await get_cluster_roles(
+                ops_test, ops_test.model.applications[app].units[0].name
+            )
 
-    assert len(roles["primaries"]) == 1
-    assert len(roles["sync_standbys"]) == 2
-    assert len(roles["replicas"]) == 0
+            assert len(roles["primaries"]) == 1
+            assert len(roles["sync_standbys"]) == 1
+            assert len(roles["replicas"]) == 1
 
 
 @pytest.mark.group(1)
@@ -77,13 +68,17 @@ async def test_constant(ops_test: OpsTest) -> None:
     """Kill primary unit, check reelection."""
     app = await app_name(ops_test)
 
-    await ops_test.model.applications[app].set_config({"synchronous_node_count": "1"})
+    await ops_test.model.applications[app].set_config({"synchronous_node_count": "2"})
 
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(apps=[app], status="active", timeout=300)
 
-    roles = await get_cluster_roles(ops_test, ops_test.model.applications[app].units[0].name)
+    for attempt in Retrying(stop=stop_after_attempt(3), wait=wait_fixed(5), reraise=True):
+        with attempt:
+            roles = await get_cluster_roles(
+                ops_test, ops_test.model.applications[app].units[0].name
+            )
 
-    assert len(roles["primaries"]) == 1
-    assert len(roles["sync_standbys"]) == 1
-    assert len(roles["replicas"]) == 1
+            assert len(roles["primaries"]) == 1
+            assert len(roles["sync_standbys"]) == 2
+            assert len(roles["replicas"]) == 0

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -30,7 +30,10 @@ async def test_config_parameters(ops_test: OpsTest) -> None:
     test_string = "abcXYZ123"
 
     configs = [
-        {"durability_synchronous_node_count": ["0", "1"]},  # config option is greater than 0
+        {"synchronous_node_count": ["0", "1"]},  # config option is greater than 0
+        {
+            "synchronous_node_count": [test_string, "all"]
+        },  # config option is one of `all`, `minority` or `majority`
         {
             "durability_synchronous_commit": [test_string, "on"]
         },  # config option is one of `on`, `remote_apply` or `remote_write`

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -30,6 +30,7 @@ async def test_config_parameters(ops_test: OpsTest) -> None:
     test_string = "abcXYZ123"
 
     configs = [
+        {"durability_synchronous_node_count": [0, 1]},  # config option is greater than 0
         {
             "durability_synchronous_commit": [test_string, "on"]
         },  # config option is one of `on`, `remote_apply` or `remote_write`

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -30,7 +30,7 @@ async def test_config_parameters(ops_test: OpsTest) -> None:
     test_string = "abcXYZ123"
 
     configs = [
-        {"durability_synchronous_node_count": [0, 1]},  # config option is greater than 0
+        {"durability_synchronous_node_count": ["0", "1"]},  # config option is greater than 0
         {
             "durability_synchronous_commit": [test_string, "on"]
         },  # config option is one of `on`, `remote_apply` or `remote_write`

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -279,6 +279,9 @@ def test_on_config_changed(harness):
             "charm.PostgreSQLUpgrade.idle", return_value=False, new_callable=PropertyMock
         ) as _idle,
         patch("charm.PostgresqlOperatorCharm.update_config") as _update_config,
+        patch(
+            "charm.PostgresqlOperatorCharm.updated_synchronous_node_count", return_value=True
+        ) as _updated_synchronous_node_count,
         patch("charm.Patroni.member_started", return_value=True, new_callable=PropertyMock),
         patch("charm.Patroni.get_primary"),
         patch(
@@ -321,6 +324,14 @@ def test_on_config_changed(harness):
         harness.charm._on_config_changed(mock_event)
         assert isinstance(harness.charm.unit.status, ActiveStatus)
         assert not _enable_disable_extensions.called
+        _updated_synchronous_node_count.assert_called_once_with()
+
+        # Deferst on update sync nodes failure
+        _updated_synchronous_node_count.return_value = False
+        harness.charm._on_config_changed(mock_event)
+        mock_event.defer.assert_called_once_with()
+        mock_event.defer.reset_mock()
+        _updated_synchronous_node_count.return_value = True
 
         # Leader enables extensions
         with harness.hooks_disabled():

--- a/tests/unit/test_patroni.py
+++ b/tests/unit/test_patroni.py
@@ -216,7 +216,7 @@ def test_render_patroni_yml_file(harness, patroni):
             replication_password=patroni._replication_password,
             rewind_user=REWIND_USER,
             rewind_password=patroni._rewind_password,
-            synchronous_node_count=patroni._members_count - 1,
+            synchronous_node_count=0,
             version="14",
             patroni_password=patroni._patroni_password,
         )
@@ -251,7 +251,7 @@ def test_render_patroni_yml_file(harness, patroni):
             replication_password=patroni._replication_password,
             rewind_user=REWIND_USER,
             rewind_password=patroni._rewind_password,
-            synchronous_node_count=patroni._members_count - 1,
+            synchronous_node_count=0,
             version="14",
             patroni_password=patroni._patroni_password,
         )
@@ -467,7 +467,7 @@ def test_update_synchronous_node_count(harness, patroni):
 
         _patch.assert_called_once_with(
             "http://postgresql-k8s-0:8008/config",
-            json={"synchronous_node_count": 2},
+            json={"synchronous_node_count": 0},
             verify=True,
             auth=patroni._patroni_auth,
         )


### PR DESCRIPTION
Implements DA135 configuration for synchronous node count.

Adds `all` and  `majority` sync standby policies and ability to set constant number of sync standbys.