### PR TITLE
[MISC] Define charm utility properties

### DIFF
--- a/src/backups.py
+++ b/src/backups.py
@@ -669,7 +669,7 @@ class PostgreSQLBackups(Object):
             logger.debug("_on_s3_credential_changed early exit: no connection info")
             return False
 
-        if "cluster_initialised" not in self.charm.app_peer_data:
+        if not self.charm.is_cluster_initialised:
             logger.debug("Cannot set pgBackRest configurations, PostgreSQL has not yet started.")
             event.defer()
             return False

--- a/src/backups.py
+++ b/src/backups.py
@@ -681,10 +681,7 @@ class PostgreSQLBackups(Object):
             return False
 
         # Prevents S3 change in the middle of restoring backup and patroni / pgbackrest errors caused by that.
-        if (
-            "restoring-backup" in self.charm.app_peer_data
-            or "restore-to-time" in self.charm.app_peer_data
-        ):
+        if self.charm.is_cluster_restoring_backup or self.charm.is_cluster_restoring_to_time:
             logger.info("Cannot change S3 configuration during restore")
             event.defer()
             return False
@@ -1014,7 +1011,7 @@ Stderr:
             )
         except ApiError as e:
             # If previous PITR restore was unsuccessful, there are no such endpoints.
-            if "restore-to-time" not in self.charm.app_peer_data:
+            if not self.charm.is_cluster_restoring_to_time:
                 error_message = f"Failed to remove previous cluster information with error: {e!s}"
                 logger.error(f"Restore failed: {error_message}")
                 event.fail(error_message)

--- a/src/charm.py
+++ b/src/charm.py
@@ -399,6 +399,11 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         return "restore-to-time" in self.app_peer_data
 
     @property
+    def is_unit_departing(self) -> bool:
+        """Returns whether the unit is departing."""
+        return "departing" in self.unit_peer_data
+
+    @property
     def postgresql(self) -> PostgreSQL:
         """Returns an instance of the object used to interact with the database."""
         return PostgreSQL(

--- a/src/charm.py
+++ b/src/charm.py
@@ -456,7 +456,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         if not self.unit.is_leader() or event.departing_unit == self.unit:
             return
 
-        if "cluster_initialised" not in self._peers.data[self.app]:
+        if not self.is_cluster_initialised:
             logger.debug(
                 "Deferring on_peer_relation_departed: Cluster must be initialized before members can leave"
             )
@@ -521,7 +521,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         """Reconfigure cluster members."""
         # The cluster must be initialized first in the leader unit
         # before any other member joins the cluster.
-        if "cluster_initialised" not in self._peers.data[self.app]:
+        if not self.is_cluster_initialised:
             if self.unit.is_leader():
                 if self._initialize_cluster(event):
                     logger.debug("Deferring on_peer_relation_changed: Leader initialized cluster")
@@ -769,7 +769,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
 
         # Reconfiguration can be successful only if the cluster is initialised
         # (i.e. first unit has bootstrap the cluster).
-        if "cluster_initialised" not in self._peers.data[self.app]:
+        if not self.is_cluster_initialised:
             return
 
         try:
@@ -941,7 +941,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         # Otherwise, each unit will create a different cluster and
         # any update in the members list on the units won't have effect
         # on fixing that.
-        if not self.unit.is_leader() and "cluster_initialised" not in self._peers.data[self.app]:
+        if not self.unit.is_leader() and not self.is_cluster_initialised:
             logger.debug(
                 "Deferring on_postgresql_pebble_ready: Not leader and cluster not initialized"
             )

--- a/src/charm.py
+++ b/src/charm.py
@@ -404,6 +404,11 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         return "departing" in self.unit_peer_data
 
     @property
+    def is_unit_stopped(self) -> bool:
+        """Returns whether the unit is stopped."""
+        return "stopped" in self.unit_peer_data
+
+    @property
     def postgresql(self) -> PostgreSQL:
         """Returns an instance of the object used to interact with the database."""
         return PostgreSQL(
@@ -1437,7 +1442,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         if (
             not self.is_cluster_restoring_backup
             and not self.is_cluster_restoring_to_time
-            and "stopped" not in self.unit_peer_data
+            and not self.is_unit_stopped
             and services[0].current != ServiceStatus.ACTIVE
         ):
             logger.warning(

--- a/src/relations/async_replication.py
+++ b/src/relations/async_replication.py
@@ -467,7 +467,7 @@ class PostgreSQLAsyncReplication(Object):
         return self.charm.app == self.get_primary_cluster()
 
     def _on_async_relation_broken(self, _) -> None:
-        if self.charm._peers is None or "departing" in self.charm._peers.data[self.charm.unit]:
+        if self.charm._peers is None or self.charm.is_unit_departing:
             logger.debug("Early exit on_async_relation_broken: Skipping departing unit.")
             return
 

--- a/src/relations/async_replication.py
+++ b/src/relations/async_replication.py
@@ -509,11 +509,11 @@ class PostgreSQLAsyncReplication(Object):
         if not self._stop_database(event):
             return
 
-        if not all(
+        if not (self.charm.is_unit_stopped or self._is_following_promoted_cluster()) or not all(
             "stopped" in self.charm._peers.data[unit]
             or self.charm._peers.data[unit].get("unit-promoted-cluster-counter")
             == self._get_highest_promoted_cluster_counter_value()
-            for unit in {*self.charm._peers.units, self.charm.unit}
+            for unit in self.charm._peers.units
         ):
             self.charm.unit.status = WaitingStatus(
                 "Waiting for the database to be stopped in all units"
@@ -692,10 +692,7 @@ class PostgreSQLAsyncReplication(Object):
 
     def _stop_database(self, event: RelationChangedEvent) -> bool:
         """Stop the database."""
-        if (
-            "stopped" not in self.charm._peers.data[self.charm.unit]
-            and not self._is_following_promoted_cluster()
-        ):
+        if not self.charm.is_unit_stopped and not self._is_following_promoted_cluster():
             if not self.charm.unit.is_leader() and not self.container.exists(POSTGRESQL_DATA_PATH):
                 logger.debug("Early exit on_async_relation_changed: following promoted cluster.")
                 return False

--- a/src/relations/db.py
+++ b/src/relations/db.py
@@ -310,7 +310,7 @@ class DbProvides(Object):
             event.defer()
             return
 
-        if "departing" in self.charm._peers.data[self.charm.unit]:
+        if self.charm.is_unit_departing:
             logger.debug("Early exit on_relation_broken: Skipping departing unit")
             return
 

--- a/src/relations/db.py
+++ b/src/relations/db.py
@@ -81,10 +81,7 @@ class DbProvides(Object):
         Generate password and handle user and database creation for the related application.
         """
         # Check for some conditions before trying to access the PostgreSQL instance.
-        if (
-            "cluster_initialised" not in self.charm._peers.data[self.charm.app]
-            or not self.charm._patroni.member_started
-        ):
+        if not self.charm.is_cluster_initialised or not self.charm._patroni.member_started:
             logger.debug(
                 "Deferring on_relation_changed: Cluster not initialized or patroni not running"
             )
@@ -271,10 +268,7 @@ class DbProvides(Object):
         Remove unit name from allowed_units key.
         """
         # Check for some conditions before trying to access the PostgreSQL instance.
-        if (
-            "cluster_initialised" not in self.charm._peers.data[self.charm.app]
-            or not self.charm._patroni.member_started
-        ):
+        if not self.charm.is_cluster_initialised or not self.charm._patroni.member_started:
             logger.debug(
                 "Deferring on_relation_departed: Cluster not initialized or patroni not running"
             )
@@ -309,10 +303,7 @@ class DbProvides(Object):
     def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Remove the user created for this relation."""
         # Check for some conditions before trying to access the PostgreSQL instance.
-        if (
-            "cluster_initialised" not in self.charm._peers.data[self.charm.app]
-            or not self.charm._patroni.member_started
-        ):
+        if not self.charm.is_cluster_initialised or not self.charm._patroni.member_started:
             logger.debug(
                 "Deferring on_relation_broken: Cluster not initialized or patroni not running"
             )

--- a/src/relations/postgresql_provider.py
+++ b/src/relations/postgresql_provider.py
@@ -71,10 +71,7 @@ class PostgreSQLProvider(Object):
         Generate password and handle user and database creation for the related application.
         """
         # Check for some conditions before trying to access the PostgreSQL instance.
-        if (
-            "cluster_initialised" not in self.charm._peers.data[self.charm.app]
-            or not self.charm._patroni.member_started
-        ):
+        if not self.charm.is_cluster_initialised or not self.charm._patroni.member_started:
             logger.debug(
                 "Deferring on_database_requested: Cluster must be initialized before database can be requested"
             )
@@ -159,7 +156,7 @@ class PostgreSQLProvider(Object):
         # Check for some conditions before trying to access the PostgreSQL instance.
         if (
             not self.charm._peers
-            or "cluster_initialised" not in self.charm._peers.data[self.charm.app]
+            or not self.charm.is_cluster_initialised
             or not self.charm._patroni.member_started
         ):
             logger.debug(

--- a/src/relations/postgresql_provider.py
+++ b/src/relations/postgresql_provider.py
@@ -167,7 +167,7 @@ class PostgreSQLProvider(Object):
 
         self._update_unit_status(event.relation)
 
-        if "departing" in self.charm._peers.data[self.charm.unit]:
+        if self.charm.is_unit_departing:
             logger.debug("Early exit on_relation_broken: Skipping departing unit")
             return
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -663,7 +663,9 @@ def test_on_peer_relation_departed(harness):
         patch(
             "charm.PostgresqlOperatorCharm._get_endpoints_to_remove"
         ) as _get_endpoints_to_remove,
-        patch("charm.PostgresqlOperatorCharm._peers", new_callable=PropertyMock) as _peers,
+        patch(
+            "charm.PostgresqlOperatorCharm.app_peer_data", new_callable=PropertyMock
+        ) as _app_peer_data,
         patch(
             "charm.PostgresqlOperatorCharm._get_endpoints_to_remove", return_value=sentinel.units
         ) as _get_endpoints_to_remove,
@@ -680,7 +682,7 @@ def test_on_peer_relation_departed(harness):
         harness.charm._on_peer_relation_departed(event)
         event.defer.assert_called_once_with()
 
-        _peers.return_value.data = {harness.charm.app: {"cluster_initialised": True}}
+        _app_peer_data.return_value = {"cluster_initialised": True}
         harness.charm._on_peer_relation_departed(event)
         _get_endpoints_to_remove.assert_called_once_with()
         _remove_from_endpoints.assert_called_once_with(sentinel.units)


### PR DESCRIPTION
This PR defines a set of charm properties to reduce the chance of introducing typos when checking for specific keys in the app / unit data-bags, as well as reduce the cognitive load of logical statements.

The **new** properties are:
- `is_cluster_restoring_backup`.
- `is_cluster_restoring_to_time`.
- `is_unit_departing`
- `is_unit_stopped`.

The **existing** properties, now used throughout the codebase are:
- `is_cluster_initialised`.