### PR TITLE
[MISC] Split topology script

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -86,6 +86,7 @@ parts:
     source: .
     stage:
       - LICENSE
+      - scripts
       - templates
   libpq:
     build-packages:

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Charm script utilities."""

--- a/scripts/rotate_logs.py
+++ b/scripts/rotate_logs.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Service for rotating logs."""

--- a/src/backups.py
+++ b/src/backups.py
@@ -1205,7 +1205,7 @@ Stderr:
         with open("templates/pgbackrest.logrotate.j2") as file:
             template = Template(file.read())
         self.container.push(PGBACKREST_LOGROTATE_FILE, template.render())
-        with open("src/rotate_logs.py") as f:
+        with open("scripts/rotate_logs.py") as f:
             self.container.push(
                 "/home/postgres/rotate_logs.py",
                 f.read(),

--- a/tests/unit/test_rotate_logs.py
+++ b/tests/unit/test_rotate_logs.py
@@ -3,7 +3,7 @@
 import contextlib
 from unittest.mock import call, patch
 
-from rotate_logs import main
+from scripts.rotate_logs import main
 
 
 def test_main():

--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,10 @@ env_list = lint, unit
 
 [vars]
 src_path = "{tox_root}/src"
+scripts_path = "{tox_root}/scripts"
 tests_path = "{tox_root}/tests"
 lib_path = "{tox_root}/lib/charms/postgresql_k8s"
-all_path = {[vars]src_path} {[vars]tests_path} {[vars]lib_path}
+all_path = {[vars]src_path} {[vars]scripts_path} {[vars]tests_path} {[vars]lib_path}
 
 [testenv]
 set_env =
@@ -48,7 +49,7 @@ set_env =
 commands_pre =
     poetry install --only main,charm-libs,unit --no-root
 commands =
-    poetry run coverage run --source={[vars]src_path} \
+    poetry run coverage run --source={[vars]src_path},{[vars]scripts_path} \
         -m pytest -v --tb native -s {posargs} {[vars]tests_path}/unit
     poetry run coverage report
     poetry run coverage xml


### PR DESCRIPTION
This PR ports part of the changes introduced in [this PR](https://github.com/canonical/postgresql-operator/pull/729) VM counter-part, by creating a folder `scripts` folder, and moving there the `rotate_logs.py` script. This change is proposed in preparation for the addition of a new LDAP-Sync pebble service stand-along script, which does not belong alongside the rest of the `src` logic.

### Additional notes:
Please review the [couple of instances](https://github.com/search?q=repo%3Acanonical%2Fpostgresql-k8s-operator%20%22%2Fhome%2Fpostgres%2Frotate_logs.py%22&type=code) where the script is referenced within `/home/postgres` folder. Not sure if my proposed changes affect that.