### PR TITLE
[MISC] Define charm constants

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -86,6 +86,7 @@ from config import CharmConfig
 from constants import (
     APP_SCOPE,
     BACKUP_USER,
+    DATABASE_DEFAULT_NAME,
     METRICS_PORT,
     MONITORING_PASSWORD_KEY,
     MONITORING_USER,
@@ -416,7 +417,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             current_host=self.endpoint,
             user=USER,
             password=self.get_secret(APP_SCOPE, f"{USER}-password"),
-            database="postgres",
+            database=DATABASE_DEFAULT_NAME,
             system_users=SYSTEM_USERS,
         )
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -3,6 +3,7 @@
 
 """File containing constants to be used in the charm."""
 
+DATABASE_DEFAULT_NAME = "postgres"
 DATABASE_PORT = "5432"
 PEER = "database-peers"
 BACKUP_USER = "backup"

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -32,6 +32,8 @@ from tenacity import (
     wait_fixed,
 )
 
+from constants import DATABASE_DEFAULT_NAME
+
 CHARM_BASE = "ubuntu@22.04"
 CHARM_SERIES = "jammy"
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
@@ -325,7 +327,7 @@ async def execute_query_on_unit(
     unit_address: str,
     password: str,
     query: str,
-    database: str = "postgres",
+    database: str = DATABASE_DEFAULT_NAME,
     sslmode: str | None = None,
 ):
     """Execute given PostgreSQL query on a unit.

--- a/tests/integration/new_relations/test_relations_coherence.py
+++ b/tests/integration/new_relations/test_relations_coherence.py
@@ -9,6 +9,8 @@ import psycopg2
 import pytest
 from pytest_operator.plugin import OpsTest
 
+from constants import DATABASE_DEFAULT_NAME
+
 from ..helpers import CHARM_BASE, DATABASE_APP_NAME, build_and_deploy
 from .helpers import build_connection_string
 from .test_new_relations_1 import DATA_INTEGRATOR_APP_NAME
@@ -120,14 +122,14 @@ async def test_relations(ops_test: OpsTest, charm):
 
         for database in [
             DATA_INTEGRATOR_APP_NAME.replace("-", "_"),
-            "postgres",
+            DATABASE_DEFAULT_NAME,
         ]:
             logger.info(f"connecting to the following database: {database}")
             connection_string = await build_connection_string(
                 ops_test, DATA_INTEGRATOR_APP_NAME, "postgresql", database=database
             )
             connection = None
-            should_fail = database == "postgres"
+            should_fail = database == DATABASE_DEFAULT_NAME
             try:
                 with psycopg2.connect(
                     connection_string
@@ -136,7 +138,7 @@ async def test_relations(ops_test: OpsTest, charm):
                     data = cursor.fetchone()
                     assert data[0] == "some data"
 
-                    # Write some data (it should fail in the "postgres" database).
+                    # Write some data (it should fail in the default database name).
                     random_name = f"test_{''.join(secrets.choice(string.ascii_lowercase) for _ in range(10))}"
                     cursor.execute(f"CREATE TABLE {random_name}(data TEXT);")
                     if should_fail:

--- a/tests/unit/test_postgresql.py
+++ b/tests/unit/test_postgresql.py
@@ -5,6 +5,7 @@ from unittest.mock import call, patch
 import psycopg2
 import pytest
 from charms.postgresql_k8s.v0.postgresql import (
+    PERMISSIONS_GROUP_ADMIN,
     PostgreSQLCreateDatabaseError,
     PostgreSQLGetLastArchivedWALError,
 )
@@ -12,7 +13,14 @@ from ops.testing import Harness
 from psycopg2.sql import SQL, Composed, Identifier, Literal
 
 from charm import PostgresqlOperatorCharm
-from constants import PEER
+from constants import (
+    BACKUP_USER,
+    MONITORING_USER,
+    PEER,
+    REPLICATION_USER,
+    REWIND_USER,
+    USER,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -75,7 +83,7 @@ def test_create_database(harness):
                     SQL("GRANT ALL PRIVILEGES ON DATABASE "),
                     Identifier(database),
                     SQL(" TO "),
-                    Identifier("admin"),
+                    Identifier(PERMISSIONS_GROUP_ADMIN),
                     SQL(";"),
                 ])
             ),
@@ -84,7 +92,7 @@ def test_create_database(harness):
                     SQL("GRANT ALL PRIVILEGES ON DATABASE "),
                     Identifier(database),
                     SQL(" TO "),
-                    Identifier("backup"),
+                    Identifier(BACKUP_USER),
                     SQL(";"),
                 ])
             ),
@@ -93,7 +101,7 @@ def test_create_database(harness):
                     SQL("GRANT ALL PRIVILEGES ON DATABASE "),
                     Identifier(database),
                     SQL(" TO "),
-                    Identifier("replication"),
+                    Identifier(REPLICATION_USER),
                     SQL(";"),
                 ])
             ),
@@ -102,7 +110,7 @@ def test_create_database(harness):
                     SQL("GRANT ALL PRIVILEGES ON DATABASE "),
                     Identifier(database),
                     SQL(" TO "),
-                    Identifier("rewind"),
+                    Identifier(REWIND_USER),
                     SQL(";"),
                 ])
             ),
@@ -111,7 +119,7 @@ def test_create_database(harness):
                     SQL("GRANT ALL PRIVILEGES ON DATABASE "),
                     Identifier(database),
                     SQL(" TO "),
-                    Identifier("operator"),
+                    Identifier(USER),
                     SQL(";"),
                 ])
             ),
@@ -120,7 +128,7 @@ def test_create_database(harness):
                     SQL("GRANT ALL PRIVILEGES ON DATABASE "),
                     Identifier(database),
                     SQL(" TO "),
-                    Identifier("monitoring"),
+                    Identifier(MONITORING_USER),
                     SQL(";"),
                 ])
             ),


### PR DESCRIPTION
This PR moves certain string into constant values, so that they could be referenced throughout the codebase.

These two in particular (i.e. the `admin` permission group and the `postgres` default database name) will be used in the upcoming LDAP support. These changes are proposed an isolation, as they have nothing to do with the LDAP support itself.