### PR TITLE
[MISC] Sanitize PostgreSQL extra-user-roles arg

### DIFF
--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -35,7 +35,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 43
+LIBPATCH = 44
 
 # Groups to distinguish database permissions
 PERMISSIONS_GROUP_ADMIN = "admin"
@@ -223,7 +223,7 @@ class PostgreSQL:
         user: str,
         password: Optional[str] = None,
         admin: bool = False,
-        extra_user_roles: Optional[str] = None,
+        extra_user_roles: Optional[list[str]] = None,
     ) -> None:
         """Creates a database user.
 
@@ -238,7 +238,6 @@ class PostgreSQL:
             admin_role = False
             roles = privileges = None
             if extra_user_roles:
-                extra_user_roles = tuple(extra_user_roles.lower().split(","))
                 admin_role = PERMISSIONS_GROUP_ADMIN in extra_user_roles
                 valid_privileges, valid_roles = self.list_valid_privileges_and_roles()
                 roles = [
@@ -572,7 +571,7 @@ END; $$;"""
                     )
                 self.create_user(
                     PERMISSIONS_GROUP_ADMIN,
-                    extra_user_roles="pg_read_all_data,pg_write_all_data",
+                    extra_user_roles=["pg_read_all_data", "pg_write_all_data"],
                 )
                 cursor.execute("GRANT CONNECT ON DATABASE postgres TO admin;")
         except psycopg2.Error as e:

--- a/src/charm.py
+++ b/src/charm.py
@@ -1093,7 +1093,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             self.postgresql.create_user(
                 MONITORING_USER,
                 self.get_secret(APP_SCOPE, MONITORING_PASSWORD_KEY),
-                extra_user_roles="pg_monitor",
+                extra_user_roles=["pg_monitor"],
             )
 
         self.postgresql.set_up_database()

--- a/tests/unit/test_postgresql_provider.py
+++ b/tests/unit/test_postgresql_provider.py
@@ -107,12 +107,17 @@ def test_on_database_requested(harness):
         # Assert that the correct calls were made.
         user = f"relation_id_{rel_id}"
         postgresql_mock.create_user.assert_called_once_with(
-            user, "test-password", extra_user_roles=EXTRA_USER_ROLES
+            user,
+            "test-password",
+            extra_user_roles=[role.lower() for role in EXTRA_USER_ROLES.split(",")],
         )
         database_relation = harness.model.get_relation(RELATION_NAME)
         client_relations = [database_relation]
         postgresql_mock.create_database.assert_called_once_with(
-            DATABASE, user, plugins=["pgaudit"], client_relations=client_relations
+            DATABASE,
+            user,
+            plugins=["pgaudit"],
+            client_relations=client_relations,
         )
         postgresql_mock.get_postgresql_version.assert_called_once()
 


### PR DESCRIPTION
This PR contains a slight refactor to make code more compatible with the upcoming LDAP integration.

In that effort, we would need to sanitise the list of `extra-user-roles` a Juju cluster administrator could provide via the data-integrator [charm](https://github.com/canonical/data-integrator), so that none of the upcoming _access groups_ (see [spec](https://docs.google.com/document/d/1Wt9VhdYCVzPh6qfwYiKOcfQwQ6UW6765S09dFjnuBXY/edit?tab=t.0) for context) is provided as a security by-pass. With that in mind, some centralised place to perform this sanitisation is required, and such operation is easier to carry on considering the list of roles as a `list`, instead of a comma-separated `str`.