### PR TITLE
[DPE-6344] LDAP I: Create access groups

### DIFF
--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -35,7 +35,19 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 46
+LIBPATCH = 47
+
+# Groups to distinguish HBA access
+ACCESS_GROUP_IDENTITY = "identity_access"
+ACCESS_GROUP_INTERNAL = "internal_access"
+ACCESS_GROUP_RELATION = "relation_access"
+
+# List of access groups to filter role assignments by
+ACCESS_GROUPS = [
+    ACCESS_GROUP_IDENTITY,
+    ACCESS_GROUP_INTERNAL,
+    ACCESS_GROUP_RELATION,
+]
 
 # Groups to distinguish database permissions
 PERMISSIONS_GROUP_ADMIN = "admin"
@@ -57,8 +69,16 @@ for dependencies in REQUIRED_PLUGINS.values():
 logger = logging.getLogger(__name__)
 
 
+class PostgreSQLAssignGroupError(Exception):
+    """Exception raised when assigning to a group fails."""
+
+
 class PostgreSQLCreateDatabaseError(Exception):
     """Exception raised when creating a database fails."""
+
+
+class PostgreSQLCreateGroupError(Exception):
+    """Exception raised when creating a group fails."""
 
 
 class PostgreSQLCreateUserError(Exception):
@@ -91,6 +111,10 @@ class PostgreSQLGetCurrentTimelineError(Exception):
 
 class PostgreSQLGetPostgreSQLVersionError(Exception):
     """Exception raised when retrieving PostgreSQL version fails."""
+
+
+class PostgreSQLListGroupsError(Exception):
+    """Exception raised when retrieving PostgreSQL groups list fails."""
 
 
 class PostgreSQLListUsersError(Exception):
@@ -159,6 +183,24 @@ class PostgreSQL:
         )
         connection.autocommit = True
         return connection
+
+    def create_access_groups(self) -> None:
+        """Create access groups to distinguish HBA authentication methods."""
+        connection = None
+        try:
+            with self._connect_to_database() as connection, connection.cursor() as cursor:
+                for group in ACCESS_GROUPS:
+                    cursor.execute(
+                        SQL("CREATE ROLE {} NOLOGIN;").format(
+                            Identifier(group),
+                        )
+                    )
+        except psycopg2.Error as e:
+            logger.error(f"Failed to create access groups: {e}")
+            raise PostgreSQLCreateGroupError() from e
+        finally:
+            if connection is not None:
+                connection.close()
 
     def create_database(
         self,
@@ -320,6 +362,50 @@ class PostgreSQL:
         except psycopg2.Error as e:
             logger.error(f"Failed to delete user: {e}")
             raise PostgreSQLDeleteUserError() from e
+
+    def grant_internal_access_group_memberships(self) -> None:
+        """Grant membership to the internal access-group to existing internal users."""
+        connection = None
+        try:
+            with self._connect_to_database() as connection, connection.cursor() as cursor:
+                for user in self.system_users:
+                    cursor.execute(
+                        SQL("GRANT {} TO {};").format(
+                            Identifier(ACCESS_GROUP_INTERNAL),
+                            Identifier(user),
+                        )
+                    )
+        except psycopg2.Error as e:
+            logger.error(f"Failed to grant internal access group memberships: {e}")
+            raise PostgreSQLAssignGroupError() from e
+        finally:
+            if connection is not None:
+                connection.close()
+
+    def grant_relation_access_group_memberships(self) -> None:
+        """Grant membership to the relation access-group to existing relation users."""
+        rel_users = self.list_users_from_relation()
+        if not rel_users:
+            return
+
+        connection = None
+        try:
+            with self._connect_to_database() as connection, connection.cursor() as cursor:
+                rel_groups = SQL(",").join(Identifier(group) for group in [ACCESS_GROUP_RELATION])
+                rel_users = SQL(",").join(Identifier(user) for user in rel_users)
+
+                cursor.execute(
+                    SQL("GRANT {groups} TO {users};").format(
+                        groups=rel_groups,
+                        users=rel_users,
+                    )
+                )
+        except psycopg2.Error as e:
+            logger.error(f"Failed to grant relation access group memberships: {e}")
+            raise PostgreSQLAssignGroupError() from e
+        finally:
+            if connection is not None:
+                connection.close()
 
     def enable_disable_extensions(
         self, extensions: Dict[str, bool], database: Optional[str] = None
@@ -534,6 +620,23 @@ END; $$;"""
             # Connection errors happen when PostgreSQL has not started yet.
             return False
 
+    def list_access_groups(self) -> Set[str]:
+        """Returns the list of PostgreSQL database access groups.
+
+        Returns:
+            List of PostgreSQL database access groups.
+        """
+        try:
+            with self._connect_to_database() as connection, connection.cursor() as cursor:
+                cursor.execute(
+                    "SELECT groname FROM pg_catalog.pg_group WHERE groname LIKE '%_access';"
+                )
+                access_groups = cursor.fetchall()
+                return {group[0] for group in access_groups}
+        except psycopg2.Error as e:
+            logger.error(f"Failed to list PostgreSQL database access groups: {e}")
+            raise PostgreSQLListGroupsError() from e
+
     def list_users(self) -> Set[str]:
         """Returns the list of PostgreSQL database users.
 
@@ -543,6 +646,23 @@ END; $$;"""
         try:
             with self._connect_to_database() as connection, connection.cursor() as cursor:
                 cursor.execute("SELECT usename FROM pg_catalog.pg_user;")
+                usernames = cursor.fetchall()
+                return {username[0] for username in usernames}
+        except psycopg2.Error as e:
+            logger.error(f"Failed to list PostgreSQL database users: {e}")
+            raise PostgreSQLListUsersError() from e
+
+    def list_users_from_relation(self) -> Set[str]:
+        """Returns the list of PostgreSQL database users that were created by a relation.
+
+        Returns:
+            List of PostgreSQL database users.
+        """
+        try:
+            with self._connect_to_database() as connection, connection.cursor() as cursor:
+                cursor.execute(
+                    "SELECT usename FROM pg_catalog.pg_user WHERE usename LIKE 'relation_id_%';"
+                )
                 usernames = cursor.fetchall()
                 return {username[0] for username in usernames}
         except psycopg2.Error as e:

--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -636,6 +636,9 @@ END; $$;"""
         except psycopg2.Error as e:
             logger.error(f"Failed to list PostgreSQL database access groups: {e}")
             raise PostgreSQLListGroupsError() from e
+        finally:
+            if connection is not None:
+                connection.close()
 
     def list_users(self) -> Set[str]:
         """Returns the list of PostgreSQL database users.
@@ -651,6 +654,9 @@ END; $$;"""
         except psycopg2.Error as e:
             logger.error(f"Failed to list PostgreSQL database users: {e}")
             raise PostgreSQLListUsersError() from e
+        finally:
+            if connection is not None:
+                connection.close()
 
     def list_users_from_relation(self) -> Set[str]:
         """Returns the list of PostgreSQL database users that were created by a relation.
@@ -668,6 +674,9 @@ END; $$;"""
         except psycopg2.Error as e:
             logger.error(f"Failed to list PostgreSQL database users: {e}")
             raise PostgreSQLListUsersError() from e
+        finally:
+            if connection is not None:
+                connection.close()
 
     def list_valid_privileges_and_roles(self) -> Tuple[Set[str], Set[str]]:
         """Returns two sets with valid privileges and roles.

--- a/src/charm.py
+++ b/src/charm.py
@@ -35,6 +35,7 @@ from charms.data_platform_libs.v0.data_models import TypedCharmBase
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 from charms.loki_k8s.v1.loki_push_api import LogProxyConsumer
 from charms.postgresql_k8s.v0.postgresql import (
+    ACCESS_GROUPS,
     REQUIRED_PLUGINS,
     PostgreSQL,
     PostgreSQLEnableDisableExtensionError,
@@ -1097,6 +1098,11 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             )
 
         self.postgresql.set_up_database()
+
+        access_groups = self.postgresql.list_access_groups()
+        if access_groups != set(ACCESS_GROUPS):
+            self.postgresql.create_access_groups()
+            self.postgresql.grant_internal_access_group_memberships()
 
         # Mark the cluster as initialised.
         self._peers.data[self.app]["cluster_initialised"] = "True"

--- a/src/relations/db.py
+++ b/src/relations/db.py
@@ -7,6 +7,7 @@ import logging
 from typing import Iterable
 
 from charms.postgresql_k8s.v0.postgresql import (
+    ACCESS_GROUP_RELATION,
     PostgreSQLCreateDatabaseError,
     PostgreSQLCreateUserError,
     PostgreSQLDeleteUserError,
@@ -173,9 +174,11 @@ class DbProvides(Object):
             # created in a previous relation changed event.
             user = f"relation_id_{relation.id}"
             password = unit_relation_databag.get("password", new_password())
-            self.charm.postgresql.create_user(user, password, self.admin)
-            plugins = self.charm.get_plugins()
+            self.charm.postgresql.create_user(
+                user, password, self.admin, extra_user_roles=[ACCESS_GROUP_RELATION]
+            )
 
+            plugins = self.charm.get_plugins()
             self.charm.postgresql.create_database(
                 database, user, plugins=plugins, client_relations=self.charm.client_relations
             )

--- a/src/relations/postgresql_provider.py
+++ b/src/relations/postgresql_provider.py
@@ -10,6 +10,8 @@ from charms.data_platform_libs.v0.data_interfaces import (
     DatabaseRequestedEvent,
 )
 from charms.postgresql_k8s.v0.postgresql import (
+    ACCESS_GROUP_RELATION,
+    ACCESS_GROUPS,
     INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE,
     PostgreSQLCreateDatabaseError,
     PostgreSQLCreateUserError,
@@ -71,7 +73,10 @@ class PostgreSQLProvider(Object):
         if extra_roles is None:
             return []
 
-        return [role.lower() for role in extra_roles.split(",")]
+        # Make sure the access-groups are not in the list
+        extra_roles_list = [role.lower() for role in extra_roles.split(",")]
+        extra_roles_list = [role for role in extra_roles_list if role not in ACCESS_GROUPS]
+        return extra_roles_list
 
     def _on_database_requested(self, event: DatabaseRequestedEvent) -> None:
         """Handle the legacy postgresql-client relation changed event.
@@ -89,8 +94,9 @@ class PostgreSQLProvider(Object):
         # Retrieve the database name and extra user roles using the charm library.
         database = event.database
 
-        # Make sure that certain groups are not in the list
+        # Make sure the relation access-group is added to the list
         extra_user_roles = self._sanitize_extra_roles(event.extra_user_roles)
+        extra_user_roles.append(ACCESS_GROUP_RELATION)
 
         try:
             # Creates the user and the database for this specific relation.

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
 from charms.postgresql_k8s.v0.postgresql import (
+    ACCESS_GROUP_RELATION,
     PostgreSQLCreateDatabaseError,
     PostgreSQLCreateUserError,
     PostgreSQLGetPostgreSQLVersionError,
@@ -230,7 +231,9 @@ def test_set_up_relation(harness):
             )
         assert harness.charm.legacy_db_relation.set_up_relation(relation)
         user = f"relation_id_{rel_id}"
-        postgresql_mock.create_user.assert_called_once_with(user, "test-password", False)
+        postgresql_mock.create_user.assert_called_once_with(
+            user, "test-password", False, extra_user_roles=[ACCESS_GROUP_RELATION]
+        )
         postgresql_mock.create_database.assert_called_once_with(
             DATABASE, user, plugins=["pgaudit"], client_relations=[relation]
         )
@@ -275,7 +278,9 @@ def test_set_up_relation(harness):
             )
             clear_relation_data(harness)
         assert harness.charm.legacy_db_relation.set_up_relation(relation)
-        postgresql_mock.create_user.assert_called_once_with(user, "test-password", False)
+        postgresql_mock.create_user.assert_called_once_with(
+            user, "test-password", False, extra_user_roles=[ACCESS_GROUP_RELATION]
+        )
         postgresql_mock.create_database.assert_called_once_with(
             DATABASE, user, plugins=["pgaudit"], client_relations=[relation]
         )

--- a/tests/unit/test_postgresql_provider.py
+++ b/tests/unit/test_postgresql_provider.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
 from charms.postgresql_k8s.v0.postgresql import (
+    ACCESS_GROUP_RELATION,
     PostgreSQLCreateDatabaseError,
     PostgreSQLCreateUserError,
     PostgreSQLGetPostgreSQLVersionError,
@@ -106,10 +107,12 @@ def test_on_database_requested(harness):
 
         # Assert that the correct calls were made.
         user = f"relation_id_{rel_id}"
+        expected_user_roles = [role.lower() for role in EXTRA_USER_ROLES.split(",")]
+        expected_user_roles.append(ACCESS_GROUP_RELATION)
         postgresql_mock.create_user.assert_called_once_with(
             user,
             "test-password",
-            extra_user_roles=[role.lower() for role in EXTRA_USER_ROLES.split(",")],
+            extra_user_roles=expected_user_roles,
         )
         database_relation = harness.model.get_relation(RELATION_NAME)
         client_relations = [database_relation]


### PR DESCRIPTION
This is the 1st PR to introduce LDAP support into PostgreSQL. The complete list of changes can be seen in [this branch](https://github.com/canonical/postgresql-k8s-operator/tree/sinclert/ldap-integration-all).

### Contents

This PR defines three different _access groups_, in order to differentiate authentication methods within the `pg_hba.conf` file when LDAP is activated (i.e. the GLAuth charm related). These _access groups_ are not yet put into such file, but they are leveraged in order to:
- Assign any charm internal user to the _internal-access_ group.
- Assign any charm relation user to the _relation-access_ group.

### References

- PostgreSQL-LDAP [specification](https://docs.google.com/document/d/1Wt9VhdYCVzPh6qfwYiKOcfQwQ6UW6765S09dFjnuBXY/edit?tab=t.0).