### PR TITLE
[DPE-6344] LDAP III: Define config and handlers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -69,29 +69,12 @@ options:
       Enable synchronized sequential scans.
     type: boolean
     default: true
-  ldap_base_dn:
-    description: |
-      Root DN to begin the search for the user in.
-    type: string
-  ldap_bind_dn:
-    description: |
-      DN of user to bind to the directory with to perform the search.
-    type: string
-  ldap_bind_password:
-    description: |
-      Password for user to bind to the directory with to perform the search.
-    type: string
   ldap_search_filter:
     description: |
       The LDAP search filter to match users with.
       Example: (|(uid=$username)(email=$username))
     type: string
     default: "(uid=$username)"
-  ldap_url:
-    description: |
-      An RFC 4516 LDAP URL. Combines the LDAP scheme, host and port.
-      Example: ldap://ldap.example.net:3893
-    type: string
   logging_client_min_messages:
     description: |
       Sets the message levels that are sent to the client.

--- a/config.yaml
+++ b/config.yaml
@@ -69,6 +69,29 @@ options:
       Enable synchronized sequential scans.
     type: boolean
     default: true
+  ldap_base_dn:
+    description: |
+      Root DN to begin the search for the user in.
+    type: string
+  ldap_bind_dn:
+    description: |
+      DN of user to bind to the directory with to perform the search.
+    type: string
+  ldap_bind_password:
+    description: |
+      Password for user to bind to the directory with to perform the search.
+    type: string
+  ldap_search_filter:
+    description: |
+      The LDAP search filter to match users with.
+      Example: (|(uid=$username)(email=$username))
+    type: string
+    default: "(uid=$username)"
+  ldap_url:
+    description: |
+      An RFC 4516 LDAP URL. Combines the LDAP scheme, host and port.
+      Example: ldap://ldap.example.net:3893
+    type: string
   logging_client_min_messages:
     description: |
       Sets the message levels that are sent to the client.

--- a/src/charm.py
+++ b/src/charm.py
@@ -1238,11 +1238,11 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         """
         username = event.params.get("username", USER)
         if username not in PASSWORD_USERS and self.is_ldap_enabled:
-            event.fail("The action cannot be performed when LDAP is enabled")
+            event.fail("The action can be run only for system users when LDAP is enabled")
             return
         if username not in PASSWORD_USERS:
             event.fail(
-                f"The action can be run only for users used by the charm or Patroni:"
+                f"The action can be run only for system users or Patroni:"
                 f" {', '.join(PASSWORD_USERS)} not {username}"
             )
             return
@@ -1258,11 +1258,11 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
 
         username = event.params.get("username", USER)
         if username not in SYSTEM_USERS and self.is_ldap_enabled:
-            event.fail("The action will have no effect when LDAP is enabled")
+            event.fail("The action can be run only for system users when LDAP is enabled")
             return
         if username not in SYSTEM_USERS:
             event.fail(
-                f"The action can be run only for users used by the charm:"
+                f"The action can be run only for system users:"
                 f" {', '.join(SYSTEM_USERS)} not {username}"
             )
             return

--- a/src/charm.py
+++ b/src/charm.py
@@ -2393,14 +2393,10 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         if data is None:
             return {}
 
-        secret_object = self.model.get_secret(id=data.bind_password_secret)
-        secret_content = secret_object.get_content()
-        bind_password = secret_content["password"]
-
         params = {
             "ldapbasedn": data.base_dn,
             "ldapbinddn": data.bind_dn,
-            "ldapbindpasswd": bind_password,
+            "ldapbindpasswd": data.bind_password,
             "ldaptls": data.starttls,
             "ldapurl": data.urls[0],
         }

--- a/src/config.py
+++ b/src/config.py
@@ -8,7 +8,7 @@ import logging
 from typing import Literal
 
 from charms.data_platform_libs.v0.data_models import BaseConfigModel
-from pydantic import PositiveInt, root_validator, validator
+from pydantic import PositiveInt, validator
 
 logger = logging.getLogger(__name__)
 
@@ -27,11 +27,7 @@ class CharmConfig(BaseConfigModel):
     instance_max_locks_per_transaction: int | None
     instance_password_encryption: str | None
     instance_synchronize_seqscans: bool | None
-    ldap_base_dn: str | None
-    ldap_bind_dn: str | None
-    ldap_bind_password: str | None
     ldap_search_filter: str | None
-    ldap_url: str | None
     logging_client_min_messages: str | None
     logging_log_connections: bool | None
     logging_log_disconnections: bool | None
@@ -200,20 +196,6 @@ class CharmConfig(BaseConfigModel):
         """Return plugin config names in a iterable."""
         return filter(lambda x: x.startswith("plugin_"), cls.keys())
 
-    @root_validator(skip_on_failure=False)
-    @classmethod
-    def check_ldap_search_options(cls, values):
-        """Check all LDAP necessary config options are provided."""
-        ldap_url = values.get("ldap_url")
-        ldap_base_dn = values.get("ldap_base_dn")
-        ldap_bind_dn = values.get("ldap_bind_dn")
-        ldap_bind_password = values.get("ldap_bind_password")
-
-        if ldap_url and not all((ldap_base_dn, ldap_bind_dn, ldap_bind_password)):
-            raise ValueError("To use LDAP: base_dn, bind_dn and bind_password are required")
-
-        return values
-
     @validator("durability_synchronous_commit")
     @classmethod
     def durability_synchronous_commit_values(cls, value: str) -> str | None:
@@ -247,15 +229,6 @@ class CharmConfig(BaseConfigModel):
         """Check instance_max_locks_per_transaction config option is between 64 and 2147483647."""
         if value < 64 or value > 2147483647:
             raise ValueError("Value is not between 64 and 2147483647")
-
-        return value
-
-    @validator("ldap_url")
-    @classmethod
-    def ldap_url_values(cls, value: str) -> str | None:
-        """Check LDAP URL config option does not start with `ldaps`."""
-        if value.startswith("ldaps"):
-            raise ValueError("To use TLS encryption state the normal `ldap` scheme")
 
         return value
 

--- a/src/ldap.py
+++ b/src/ldap.py
@@ -1,0 +1,79 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""LDAP implementation."""
+
+import logging
+
+from charms.glauth_k8s.v0.ldap import (
+    LdapProviderData,
+    LdapReadyEvent,
+    LdapRequirer,
+    LdapUnavailableEvent,
+)
+from charms.postgresql_k8s.v0.postgresql_tls import (
+    TLS_TRANSFER_RELATION,
+)
+from ops import Relation
+from ops.framework import Object
+from ops.model import ActiveStatus, BlockedStatus
+
+logger = logging.getLogger(__name__)
+
+
+class PostgreSQLLDAP(Object):
+    """In this class, we manage PostgreSQL LDAP access."""
+
+    def __init__(self, charm, relation_name: str):
+        """Manager of PostgreSQL LDAP."""
+        super().__init__(charm, "ldap")
+        self.charm = charm
+        self.relation_name = relation_name
+
+        # LDAP relation handles the config options for LDAP access
+        self.ldap = LdapRequirer(self.charm, self.relation_name)
+        self.framework.observe(self.ldap.on.ldap_ready, self._on_ldap_ready)
+        self.framework.observe(self.ldap.on.ldap_unavailable, self._on_ldap_unavailable)
+
+    @property
+    def ca_transferred(self) -> bool:
+        """Return whether the CA certificate has been transferred."""
+        return self.model.relations[TLS_TRANSFER_RELATION] is not None
+
+    @property
+    def _relation(self) -> Relation:
+        """Return the relation object."""
+        return self.model.get_relation(self.relation_name)
+
+    def _on_ldap_ready(self, event: LdapReadyEvent) -> None:
+        """Handler for the LDAP ready event."""
+        if not self.ca_transferred:
+            self.charm.unit.status = BlockedStatus("LDAP insecure. Send LDAP server certificate")
+            event.defer()
+            return
+
+        logger.debug("Enabling LDAP connection")
+        if self.charm.unit.is_leader():
+            self.charm.app_peer_data.update({"ldap_enabled": "True"})
+
+        self.charm.update_config()
+        self.charm.unit.status = ActiveStatus()
+
+    def _on_ldap_unavailable(self, _: LdapUnavailableEvent) -> None:
+        """Handler for the LDAP unavailable event."""
+        logger.debug("Disabling LDAP connection")
+        if self.charm.unit.is_leader():
+            self.charm.app_peer_data.update({"ldap_enabled": "False"})
+
+        self.charm.update_config()
+
+    def get_relation_data(self) -> LdapProviderData | None:
+        """Get the LDAP info from the LDAP Provider class."""
+        data = self.ldap.consume_ldap_relation_data(relation=self._relation)
+        if data is None:
+            logger.warning("LDAP relation is not ready")
+
+        if not self.charm.is_connectivity_enabled:
+            logger.warning("LDAP server will not be accessible")
+
+        return data

--- a/src/ldap.py
+++ b/src/ldap.py
@@ -38,7 +38,13 @@ class PostgreSQLLDAP(Object):
     @property
     def ca_transferred(self) -> bool:
         """Return whether the CA certificate has been transferred."""
-        return self.model.relations[TLS_TRANSFER_RELATION] is not None
+        ca_transferred_relations = self.model.relations[TLS_TRANSFER_RELATION]
+
+        for relation in ca_transferred_relations:
+            if relation.app.name == self._relation.app.name:
+                return True
+
+        return False
 
     @property
     def _relation(self) -> Relation:

--- a/src/patroni.py
+++ b/src/patroni.py
@@ -114,6 +114,17 @@ class Patroni:
         snap_meta = container.pull("/meta.charmed-postgresql/snap.yaml")
         return yaml.safe_load(snap_meta)["version"]
 
+    @staticmethod
+    def _dict_to_hba_string(_dict: dict[str, Any]) -> str:
+        """Transform a dictionary into a Host Based Authentication valid string."""
+        for key, value in _dict.items():
+            if isinstance(value, bool):
+                _dict[key] = int(value)
+            if isinstance(value, str):
+                _dict[key] = f'"{value}"'
+
+        return " ".join(f"{key}={value}" for key, value in _dict.items())
+
     def _get_alternative_patroni_url(
         self, attempt: AttemptManager, alternative_endpoints: list[str] | None = None
     ) -> str:
@@ -503,6 +514,7 @@ class Patroni:
         self,
         connectivity: bool = False,
         is_creating_backup: bool = False,
+        enable_ldap: bool = False,
         enable_tls: bool = False,
         is_no_sync_member: bool = False,
         stanza: str | None = None,
@@ -518,6 +530,7 @@ class Patroni:
 
         Args:
             connectivity: whether to allow external connections to the database.
+            enable_ldap: whether to enable LDAP authentication.
             enable_tls: whether to enable TLS.
             is_creating_backup: whether this unit is creating a backup.
             is_no_sync_member: whether this member shouldn't be a synchronous standby
@@ -534,9 +547,13 @@ class Patroni:
         # Open the template patroni.yml file.
         with open("templates/patroni.yml.j2") as file:
             template = Template(file.read())
+
+        ldap_params = self._charm.get_ldap_parameters()
+
         # Render the template file with the correct values.
         rendered = template.render(
             connectivity=connectivity,
+            enable_ldap=enable_ldap,
             enable_tls=enable_tls,
             endpoint=self._endpoint,
             endpoints=self._endpoints,
@@ -562,6 +579,7 @@ class Patroni:
             pg_parameters=parameters,
             primary_cluster_endpoint=self._charm.async_replication.get_primary_cluster_endpoint(),
             extra_replication_endpoints=self._charm.async_replication.get_standby_endpoints(),
+            ldap_parameters=self._dict_to_hba_string(ldap_params),
             patroni_password=self._patroni_password,
         )
         self._render_file(f"{self._storage_path}/patroni.yml", rendered, 0o644)

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -140,7 +140,11 @@ postgresql:
   {%- if not connectivity %}
   - {{ 'hostssl' if enable_tls else 'host' }} all all 0.0.0.0/0 reject
   - {{ 'hostssl' if enable_tls else 'host' }} all all {{ endpoint }}.{{ namespace }}.svc.cluster.local md5
-  {% else %}
+  {%- elif enable_ldap %}
+  - {{ 'hostssl' if enable_tls else 'host' }} all +identity_access 0.0.0.0/0 ldap {{ ldap_parameters }}
+  - {{ 'hostssl' if enable_tls else 'host' }} all +internal_access 0.0.0.0/0 md5
+  - {{ 'hostssl' if enable_tls else 'host' }} all +relation_access 0.0.0.0/0 md5
+  {%- else %}
   - {{ 'hostssl' if enable_tls else 'host' }} all all 0.0.0.0/0 md5
   {%- endif %}
   - {{ 'hostssl' if enable_tls else 'host' }} replication replication 127.0.0.1/32 md5

--- a/tests/integration/test_ldap.py
+++ b/tests/integration/test_ldap.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+
+import pytest
+from pytest_operator.plugin import OpsTest
+
+from . import markers
+from .helpers import (
+    DATABASE_APP_NAME,
+    build_and_deploy,
+    execute_query_on_unit,
+    get_password,
+    get_unit_address,
+)
+
+logger = logging.getLogger(__name__)
+
+GLAUTH_PSQL_APP_NAME = "postgresql-k8s"
+GLAUTH_CERT_APP_NAME = "self-signed-certificates"
+GLAUTH_APP_NAME = "glauth-k8s"
+
+
+@pytest.mark.abort_on_fail
+@markers.juju3
+async def test_build_and_deploy(ops_test: OpsTest, charm) -> None:
+    """Build and deploy three units of PostgreSQL."""
+    await build_and_deploy(ops_test, charm, num_units=1, wait_for_idle=True)
+
+
+@pytest.mark.abort_on_fail
+@markers.juju3
+async def test_glauth_integration(ops_test: OpsTest):
+    glauth_psql_app_name = f"glauth-{GLAUTH_PSQL_APP_NAME}"
+    glauth_cert_app_name = f"glauth-{GLAUTH_CERT_APP_NAME}"
+
+    # Deploy GLAuth charm
+    await asyncio.gather(
+        ops_test.model.deploy(
+            GLAUTH_PSQL_APP_NAME,
+            application_name=glauth_psql_app_name,
+            channel="14/stable",
+            trust=True,
+        ),
+        ops_test.model.deploy(
+            GLAUTH_CERT_APP_NAME,
+            application_name=glauth_cert_app_name,
+            channel="latest/stable",
+            trust=False,
+        ),
+        ops_test.model.deploy(
+            GLAUTH_APP_NAME,
+            application_name=GLAUTH_APP_NAME,
+            channel="latest/edge",
+            trust=True,
+        ),
+    )
+
+    async with ops_test.fast_forward():
+        await asyncio.gather(
+            ops_test.model.wait_for_idle(apps=[glauth_psql_app_name], status="active"),
+            ops_test.model.wait_for_idle(apps=[glauth_cert_app_name], status="active"),
+            ops_test.model.wait_for_idle(apps=[GLAUTH_APP_NAME], status="blocked"),
+        )
+
+        # Add both relations to GLAuth (PostgreSQL and self-signed-certificates)
+        logger.info("Adding relations to GLAuth")
+        await asyncio.gather(
+            ops_test.model.add_relation(GLAUTH_APP_NAME, glauth_psql_app_name),
+            ops_test.model.add_relation(GLAUTH_APP_NAME, glauth_cert_app_name),
+        )
+        await asyncio.gather(
+            ops_test.model.wait_for_idle(apps=[glauth_psql_app_name], status="active"),
+            ops_test.model.wait_for_idle(apps=[glauth_cert_app_name], status="active"),
+            ops_test.model.wait_for_idle(apps=[GLAUTH_APP_NAME], status="active"),
+        )
+
+        # Add relation to PostgreSQL
+        logger.info("Adding relation to PostgreSQL")
+        await ops_test.model.add_relation(
+            f"{GLAUTH_APP_NAME}:ldap",
+            f"{DATABASE_APP_NAME}:ldap",
+        )
+        await ops_test.model.add_relation(
+            f"{GLAUTH_APP_NAME}:send-ca-cert",
+            f"{DATABASE_APP_NAME}:receive-ca-cert",
+        )
+
+        await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME], status="active")
+
+        database_units = ops_test.model.applications[DATABASE_APP_NAME].units
+        address = await get_unit_address(ops_test, database_units[0].name)
+        password = await get_password(ops_test)
+
+        # Validate the 'operator' user can still access the instance
+        await execute_query_on_unit(address, password, "SELECT VERSION();")

--- a/tests/spread/test_ldap/task.yaml
+++ b/tests/spread/test_ldap/task.yaml
@@ -1,0 +1,9 @@
+summary: test_ldap.py
+environment:
+  TEST_MODULE: test_ldap.py
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results
+systems:
+  - -ubuntu-24.04-arm

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1936,24 +1936,13 @@ def test_on_promote_to_primary(harness):
 
 def test_get_ldap_parameters(harness):
     with (
-        patch("charm.PostgresqlOperatorCharm.config", new_callable=PropertyMock) as _config,
-        patch("charm.PostgresqlOperatorCharm._ldap_config_to_params") as _config_to_params,
-        patch("charm.PostgresqlOperatorCharm._ldap_databag_to_params") as _databag_to_params,
+        patch("charm.PostgreSQLLDAP.get_relation_data") as _get_relation_data,
         patch(
             target="charm.PostgresqlOperatorCharm.is_cluster_initialised",
             new_callable=PropertyMock,
             return_value=True,
         ) as _cluster_initialised,
     ):
-        # When LDAP is not configured or related, no params are returned
-        _config.return_value = MagicMock(ldap_url=None)
-
-        harness.charm.get_ldap_parameters()
-        _config_to_params.assert_not_called()
-        _databag_to_params.assert_not_called()
-
-        # When LDAP is configured, params string is built from the config values
-        _config.return_value = MagicMock(ldap_url="ldap://0.0.0.0:3893")
         with harness.hooks_disabled():
             harness.update_relation_data(
                 harness.model.get_relation(PEER).id,
@@ -1962,13 +1951,9 @@ def test_get_ldap_parameters(harness):
             )
 
         harness.charm.get_ldap_parameters()
-        _config_to_params.assert_called_once()
-        _config_to_params.reset_mock()
-        _databag_to_params.assert_not_called()
-        _databag_to_params.reset_mock()
+        _get_relation_data.assert_not_called()
+        _get_relation_data.reset_mock()
 
-        # When LDAP is related, params string is built from the databag values
-        _config.return_value = MagicMock(ldap_url=None)
         with harness.hooks_disabled():
             harness.update_relation_data(
                 harness.model.get_relation(PEER).id,
@@ -1977,7 +1962,5 @@ def test_get_ldap_parameters(harness):
             )
 
         harness.charm.get_ldap_parameters()
-        _config_to_params.assert_not_called()
-        _config_to_params.reset_mock()
-        _databag_to_params.assert_called_once()
-        _databag_to_params.reset_mock()
+        _get_relation_data.assert_called_once()
+        _get_relation_data.reset_mock()

--- a/tests/unit/test_ldap.py
+++ b/tests/unit/test_ldap.py
@@ -1,0 +1,97 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from unittest.mock import (
+    MagicMock,
+    PropertyMock,
+    patch,
+)
+
+import pytest
+from charms.glauth_k8s.v0.ldap import LdapProviderData
+from ops.testing import Harness
+
+from charm import PostgresqlOperatorCharm
+from constants import PEER
+
+
+@pytest.fixture(autouse=True)
+def harness():
+    harness = Harness(PostgresqlOperatorCharm)
+
+    # Set up the initial relation and hooks.
+    peer_relation_id = harness.add_relation(PEER, "postgresql-k8s")
+    harness.add_relation_unit(peer_relation_id, "postgresql-k8s/0")
+    harness.set_leader(True)
+
+    harness.begin()
+    yield harness
+    harness.cleanup()
+
+
+def test_on_ldap_ready_with_certificate(harness):
+    mock_event = MagicMock()
+
+    with (
+        patch("charm.PostgresqlOperatorCharm.update_config") as _update_config,
+        patch("charm.PostgreSQLLDAP.ca_transferred", new_callable=PropertyMock) as _ca_transferred,
+    ):
+        _ca_transferred.return_value = True
+        harness.charm.ldap._on_ldap_ready(mock_event)
+        _update_config.assert_called_once()
+
+        peer_rel_id = harness.model.get_relation(PEER).id
+        app_databag = harness.get_relation_data(peer_rel_id, harness.charm.app)
+        assert "ldap_enabled" in app_databag
+
+
+def test_on_ldap_ready_without_certificate(harness):
+    mock_event = MagicMock()
+
+    with (
+        patch("charm.PostgresqlOperatorCharm.update_config") as _update_config,
+        patch("charm.PostgreSQLLDAP.ca_transferred", new_callable=PropertyMock) as _ca_transferred,
+    ):
+        _ca_transferred.return_value = False
+        harness.charm.ldap._on_ldap_ready(mock_event)
+        _update_config.assert_not_called()
+
+        peer_rel_id = harness.model.get_relation(PEER).id
+        app_databag = harness.get_relation_data(peer_rel_id, harness.charm.app)
+        assert "ldap_enabled" not in app_databag
+
+
+def test_on_ldap_unavailable(harness):
+    mock_event = MagicMock()
+
+    with patch("charm.PostgresqlOperatorCharm.update_config") as _update_config:
+        harness.charm.ldap._on_ldap_unavailable(mock_event)
+        _update_config.assert_called_once()
+
+        peer_rel_id = harness.model.get_relation(PEER).id
+        app_databag = harness.get_relation_data(peer_rel_id, harness.charm.app)
+        assert app_databag["ldap_enabled"] == "False"
+
+
+def test_get_relation_data(harness):
+    mock_data = LdapProviderData(
+        auth_method="simple",
+        base_dn="dc=example,dc=net",
+        bind_dn="cn=serviceuser,dc=example,dc=net",
+        bind_password="password",
+        bind_password_secret=None,
+        starttls=False,
+        ldaps_urls=[],
+        urls=[],
+    )
+
+    mock_data_dict = mock_data.model_dump(exclude_none=True)
+    mock_data_dict["bind_password"] = mock_data.bind_password
+
+    assert harness.charm.ldap.get_relation_data() is None
+
+    with harness.hooks_disabled():
+        ldap_relation_id = harness.add_relation("ldap", "glauth-k8s")
+        harness.update_relation_data(ldap_relation_id, "glauth-k8s", mock_data_dict)
+
+    assert harness.charm.ldap.get_relation_data() == mock_data

--- a/tests/unit/test_patroni.py
+++ b/tests/unit/test_patroni.py
@@ -71,6 +71,24 @@ def mocked_requests_get(*args, **kwargs):
     raise requests.exceptions.Timeout()
 
 
+def test_dict_to_hba_string(harness, patroni):
+    mock_data = {
+        "ldapbasedn": "dc=example,dc=net",
+        "ldapbinddn": "cn=serviceuser,dc=example,dc=net",
+        "ldapbindpasswd": "password",
+        "ldaptls": False,
+        "ldapurl": "ldap://0.0.0.0:3893",
+    }
+
+    assert patroni._dict_to_hba_string(mock_data) == (
+        'ldapbasedn="dc=example,dc=net" '
+        'ldapbinddn="cn=serviceuser,dc=example,dc=net" '
+        'ldapbindpasswd="password" '
+        "ldaptls=0 "
+        'ldapurl="ldap://0.0.0.0:3893"'
+    )
+
+
 def test_get_primary(harness, patroni):
     with patch("requests.get") as _get:
         # Mock Patroni cluster API.


### PR DESCRIPTION
This is the 3rd PR to introduce LDAP support into PostgreSQL. The complete list of changes can be seen in [this branch](https://github.com/canonical/postgresql-k8s-operator/tree/sinclert/ldap-integration-all).

### Contents

This PR extends the charm configuration to include all the initially proposed configuration options, which are useful for local debugging (some of them will go away before marking the integration complete). In addition, it creates the [PostgreSQLLDAP](https://github.com/canonical/postgresql-k8s-operator/blob/ldap-integration/handler-methods/src/ldap.py) class to hold all the GLAuth related handlers, similar to how other classes within the charm hold all the handlers for a particular functionality (i.e. `PostgreSQLBackups`, `PostgreSQLUpgrades`, etc).

### References

- PostgreSQL-LDAP [specification](https://docs.google.com/document/d/1Wt9VhdYCVzPh6qfwYiKOcfQwQ6UW6765S09dFjnuBXY/edit?tab=t.0).

---

Depends on PRs https://github.com/canonical/postgresql-k8s-operator/pull/881 and https://github.com/canonical/postgresql-k8s-operator/pull/883.
