### PR TITLE
[DPE-6675] Add wal_keep_size config option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -15,6 +15,12 @@ options:
       crashes and there are replicas.
     type: string
     default: "on"
+  durability_wal_keep_size:
+    description: |
+      Sets the minimum size of the WAL file to be kept for the replication.
+      Allowed values are: from 0 to 2147483647.
+    type: int
+    default: 4096
   instance_default_text_search_config:
     description: |
       Selects the text search configuration that is used by those variants of the text

--- a/src/charm.py
+++ b/src/charm.py
@@ -1959,6 +1959,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             "max_connections": max_connections,
             "max_prepared_transactions": self.config.memory_max_prepared_transactions,
             "shared_buffers": self.config.memory_shared_buffers,
+            "wal_keep_size": self.config.durability_wal_keep_size,
         })
 
         self._handle_postgresql_restart_need()

--- a/src/config.py
+++ b/src/config.py
@@ -204,6 +204,15 @@ class CharmConfig(BaseConfigModel):
 
         return value
 
+    @validator("durability_wal_keep_size")
+    @classmethod
+    def durability_wal_keep_size_values(cls, value: int) -> int | None:
+        """Check durability_wal_keep_size config option is between 0 and 2147483647."""
+        if value < 0 or value > 2147483647:
+            raise ValueError("Value is not between 0 and 2147483647")
+
+        return value
+
     @validator("instance_password_encryption")
     @classmethod
     def instance_password_encryption_values(cls, value: str) -> str | None:

--- a/src/config.py
+++ b/src/config.py
@@ -18,6 +18,7 @@ class CharmConfig(BaseConfigModel):
 
     synchronous_node_count: Literal["all", "majority"] | PositiveInt
     durability_synchronous_commit: str | None
+    durability_wal_keep_size: int | None
     instance_default_text_search_config: str | None
     instance_max_locks_per_transaction: int | None
     instance_password_encryption: str | None


### PR DESCRIPTION
## Issue
The `wal_keep_size` PostgreSQL parameter is not configurable through the charm.

## Solution
Add that parameter as a config option.

It needs to be set through Patroni dynamic configuration as per https://patroni.readthedocs.io/en/latest/patroni_configuration.html.