### PR TITLE
[MISC] Add missing connection vars

### DIFF
--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -35,7 +35,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 48
+LIBPATCH = 49
 
 # Groups to distinguish HBA access
 ACCESS_GROUP_IDENTITY = "identity_access"
@@ -626,6 +626,7 @@ END; $$;"""
         Returns:
             List of PostgreSQL database access groups.
         """
+        connection = None
         try:
             with self._connect_to_database() as connection, connection.cursor() as cursor:
                 cursor.execute(
@@ -646,6 +647,7 @@ END; $$;"""
         Returns:
             List of PostgreSQL database users.
         """
+        connection = None
         try:
             with self._connect_to_database() as connection, connection.cursor() as cursor:
                 cursor.execute("SELECT usename FROM pg_catalog.pg_user;")
@@ -664,6 +666,7 @@ END; $$;"""
         Returns:
             List of PostgreSQL database users.
         """
+        connection = None
         try:
             with self._connect_to_database() as connection, connection.cursor() as cursor:
                 cursor.execute(


### PR DESCRIPTION
This PR fixes a subtle crash where the PostgreSQL charm lib could not establish the connection when listing groups / users, causing an `UnboundLocalError` error (see failing [CI job](https://github.com/canonical/postgresql-operator/actions/runs/14311792544/job/40234376532))

The correct handling of this _connection failure_ is something that the PostgreSQL-VM operation relies on, as it was not experienced when developing the LDAP integration for the PostgreSQL-K8s one.
