### PR TITLE
[DPE-6344] Remove CA transferred check

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -1760,7 +1760,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
 
         ldap_base_dn = ldap_params["ldapbasedn"]
         ldap_bind_username = ldap_params["ldapbinddn"]
-        ldap_bing_password = ldap_params["ldapbindpasswd"]
+        ldap_bind_password = ldap_params["ldapbindpasswd"]
         ldap_group_mappings = self.postgresql.build_postgresql_group_map(self.config.ldap_map)
 
         return {
@@ -1773,7 +1773,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
                 "LDAP_PORT": ldap_port,
                 "LDAP_BASE_DN": ldap_base_dn,
                 "LDAP_BIND_USERNAME": ldap_bind_username,
-                "LDAP_BIND_PASSWORD": ldap_bing_password,
+                "LDAP_BIND_PASSWORD": ldap_bind_password,
                 "LDAP_GROUP_IDENTITY": json.dumps(ACCESS_GROUP_IDENTITY),
                 "LDAP_GROUP_MAPPINGS": json.dumps(ldap_group_mappings),
                 "POSTGRES_HOST": "127.0.0.1",
@@ -1991,7 +1991,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
 
         if not self.is_primary and sync_service[0].is_running():
             logger.debug("Stopping LDAP sync service. It must only run in the primary")
-            container.stop(self.pg_ldap_sync_service)
+            container.stop(self.ldap_sync_service)
 
         if self.is_primary and not self.is_ldap_enabled:
             logger.debug("Stopping LDAP sync service")

--- a/tests/unit/test_ldap.py
+++ b/tests/unit/test_ldap.py
@@ -3,7 +3,6 @@
 
 from unittest.mock import (
     MagicMock,
-    PropertyMock,
     patch,
 )
 
@@ -29,36 +28,16 @@ def harness():
     harness.cleanup()
 
 
-def test_on_ldap_ready_with_certificate(harness):
+def test_on_ldap_ready(harness):
     mock_event = MagicMock()
 
-    with (
-        patch("charm.PostgresqlOperatorCharm.update_config") as _update_config,
-        patch("charm.PostgreSQLLDAP.ca_transferred", new_callable=PropertyMock) as _ca_transferred,
-    ):
-        _ca_transferred.return_value = True
+    with patch("charm.PostgresqlOperatorCharm.update_config") as _update_config:
         harness.charm.ldap._on_ldap_ready(mock_event)
         _update_config.assert_called_once()
 
         peer_rel_id = harness.model.get_relation(PEER).id
         app_databag = harness.get_relation_data(peer_rel_id, harness.charm.app)
         assert "ldap_enabled" in app_databag
-
-
-def test_on_ldap_ready_without_certificate(harness):
-    mock_event = MagicMock()
-
-    with (
-        patch("charm.PostgresqlOperatorCharm.update_config") as _update_config,
-        patch("charm.PostgreSQLLDAP.ca_transferred", new_callable=PropertyMock) as _ca_transferred,
-    ):
-        _ca_transferred.return_value = False
-        harness.charm.ldap._on_ldap_ready(mock_event)
-        _update_config.assert_not_called()
-
-        peer_rel_id = harness.model.get_relation(PEER).id
-        app_databag = harness.get_relation_data(peer_rel_id, harness.charm.app)
-        assert "ldap_enabled" not in app_databag
 
 
 def test_on_ldap_unavailable(harness):


### PR DESCRIPTION
This PR removes the `ca_transferred` property from the PostgreSQLLDAP class, so that relationship could be established cross-model, which is not possible at the moment. This change harmonizes the logic with respect to its PostgreSQL-VM operator equivalent.

### Additional changes
- Fixes a typo related to how the pebble service is called, when it needs to be stopped.
