### PR TITLE
[DPE-6344] Persist transferred certificates upon start

### DIFF
--- a/lib/charms/postgresql_k8s/v0/postgresql_tls.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql_tls.py
@@ -23,7 +23,7 @@ import ipaddress
 import logging
 import re
 import socket
-from typing import List, Optional
+from typing import Iterator, List, Optional
 
 from charms.certificate_transfer_interface.v0.certificate_transfer import (
     CertificateAvailableEvent as CertificateAddedEvent,
@@ -55,7 +55,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version.
-LIBPATCH = 14
+LIBPATCH = 15
 
 logger = logging.getLogger(__name__)
 SCOPE = "unit"
@@ -268,6 +268,17 @@ class PostgreSQLTLS(Object):
             "sans_ip": sans_ip,
             "sans_dns": sans_dns,
         }
+
+    def get_ca_secret_names(self) -> Iterator[str]:
+        """Get a secret-name for each relation fulfilling the CA transfer interface.
+
+        Returns:
+            Secret name for a CA transfer fulfilled interface.
+        """
+        relations = self.charm.model.relations.get(TLS_TRANSFER_RELATION, [])
+
+        for relation in relations:
+            yield f"ca-{relation.app.name}"
 
     def get_tls_files(self) -> (Optional[str], Optional[str], Optional[str]):
         """Prepare TLS files in special PostgreSQL way.

--- a/src/charm.py
+++ b/src/charm.py
@@ -998,7 +998,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             return
 
         try:
-            self.push_tls_files_to_workload(container)
+            self.push_tls_files_to_workload()
             for ca_secret_name in self.tls.get_ca_secret_names():
                 self.push_ca_file_into_workload(ca_secret_name)
         except (PathError, ProtocolError) as e:
@@ -1895,10 +1895,9 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             group=WORKLOAD_OS_GROUP,
         )
 
-    def push_tls_files_to_workload(self, container: Container = None) -> bool:
+    def push_tls_files_to_workload(self) -> bool:
         """Uploads TLS files to the workload container."""
-        if container is None:
-            container = self.unit.get_container("postgresql")
+        container = self.unit.get_container("postgresql")
 
         key, ca, cert = self.tls.get_tls_files()
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -999,6 +999,8 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
 
         try:
             self.push_tls_files_to_workload(container)
+            for ca_secret_name in self.tls.get_ca_secret_names():
+                self.push_ca_file_into_workload(ca_secret_name)
         except (PathError, ProtocolError) as e:
             logger.error(
                 "Deferring on_postgresql_pebble_ready: Cannot push TLS certificates: %r", e


### PR DESCRIPTION
This PR solves a bug when, upon having a PostgreSQL-K8s charm properly connected to a GLAuth charm (see [this guide](https://charmhub.io/postgresql-k8s/docs/h-enable-ldap)), any refresh to the operator revision will not persist the already transferred certificates to the new unit.

### Notes:
- This should not be happening on PostgreSQL-VM, as the file-system there is stable between refreshes.
- The `push_tls_files_to_workload` method signature has been harmonized with respect to its siblings (see https://github.com/canonical/postgresql-k8s-operator/commit/e21a6a6d9d0f27f409bc33adc3d8b67d5e4d739a).

