### PR TITLE
[MISC] Extend relation-user listing syntax

### DIFF
--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -35,7 +35,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 51
+LIBPATCH = 53
 
 # Groups to distinguish HBA access
 ACCESS_GROUP_IDENTITY = "identity_access"
@@ -672,7 +672,9 @@ END; $$;"""
         try:
             with self._connect_to_database() as connection, connection.cursor() as cursor:
                 cursor.execute(
-                    "SELECT usename FROM pg_catalog.pg_user WHERE usename LIKE 'relation_id_%';"
+                    "SELECT usename "
+                    "FROM pg_catalog.pg_user "
+                    "WHERE usename LIKE 'relation_id_%' OR usename LIKE 'relation-%';"
                 )
                 usernames = cursor.fetchall()
                 return {username[0] for username in usernames}

--- a/tests/unit/test_postgresql.py
+++ b/tests/unit/test_postgresql.py
@@ -208,7 +208,11 @@ def test_grant_relation_access_group_memberships(harness):
         harness.charm.postgresql.grant_relation_access_group_memberships()
 
         execute.assert_has_calls([
-            call("SELECT usename FROM pg_catalog.pg_user WHERE usename LIKE 'relation_id_%';"),
+            call(
+                "SELECT usename "
+                "FROM pg_catalog.pg_user "
+                "WHERE usename LIKE 'relation_id_%' OR usename LIKE 'relation-%';"
+            ),
         ])
 
 


### PR DESCRIPTION
This PR extends the relation-user listing SQL syntax in order to account for name prefix discrepancies between K8s & VM. Ideally, we would follow the same syntax in both substrates, but I understand a migration attempt may be painful.

### Context
The discrepancy can be seen in the following files:

- `src/relations/db.py`: PostgreSQL K8s [snippet](https://github.com/canonical/postgresql-k8s-operator/blob/083b3036c243b8d53289028a5a4cd46a6b069947/src/relations/db.py#L175), PostgreSQL VM [snippet](https://github.com/canonical/postgresql-operator/blob/573517b6274a6f013ef2228ee2d0759612eee4d5/src/relations/db.py#L174).
- `src/relations/provider.py`: PostgreSQL K8s [snippet](https://github.com/canonical/postgresql-k8s-operator/blob/083b3036c243b8d53289028a5a4cd46a6b069947/src/relations/postgresql_provider.py#L103), PostgreSQL VM [snippet](https://github.com/canonical/postgresql-operator/blob/573517b6274a6f013ef2228ee2d0759612eee4d5/src/relations/postgresql_provider.py#L107).
