### PR TITLE
Logical Replication

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -117,6 +117,9 @@ options:
       Enables tracking of function call counts and time used. Specify pl to track only procedural-language functions
     type: string
     default: "none"
+  logical_replication_subscription_request:
+    type: string
+    default: "{}"
   memory_maintenance_work_mem:
     description: |
       Sets the maximum memory (KB) to be used for maintenance operations.

--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -129,6 +129,54 @@ class PostgreSQLUpdateUserPasswordError(Exception):
     """Exception raised when updating a user password fails."""
 
 
+class PostgreSQLDatabaseExistsError(Exception):
+    """Exception raised during database existence check."""
+
+
+class PostgreSQLTableExistsError(Exception):
+    """Exception raised during table existence check."""
+
+
+class PostgreSQLIsTableEmptyError(Exception):
+    """Exception raised during table emptiness check."""
+
+
+class PostgreSQLCreatePublicationError(Exception):
+    """Exception raised when creating PostgreSQL publication."""
+
+
+class PostgreSQLPublicationExistsError(Exception):
+    """Exception raised during PostgreSQL publication existence check."""
+
+
+class PostgreSQLAlterPublicationError(Exception):
+    """Exception raised when altering PostgreSQL publication."""
+
+
+class PostgreSQLDropPublicationError(Exception):
+    """Exception raised when dropping PostgreSQL publication."""
+
+
+class PostgreSQLCreateSubscriptionError(Exception):
+    """Exception raised when creating PostgreSQL subscription."""
+
+
+class PostgreSQLSubscriptionExistsError(Exception):
+    """Exception raised during PostgreSQL subscription existence check."""
+
+
+class PostgreSQLUpdateSubscriptionError(Exception):
+    """Exception raised when updating PostgreSQL subscription."""
+
+
+class PostgreSQLRefreshSubscriptionError(Exception):
+    """Exception raised when refreshing PostgreSQL subscription."""
+
+
+class PostgreSQLDropSubscriptionError(Exception):
+    """Exception raised when dropping PostgreSQL subscription."""
+
+
 class PostgreSQL:
     """Class to encapsulate all operations related to interacting with PostgreSQL instance."""
 
@@ -274,6 +322,7 @@ class PostgreSQL:
         user: str,
         password: Optional[str] = None,
         admin: bool = False,
+        replication: bool = False,
         extra_user_roles: Optional[List[str]] = None,
     ) -> None:
         """Creates a database user.
@@ -282,6 +331,7 @@ class PostgreSQL:
             user: user to be created.
             password: password to be assigned to the user.
             admin: whether the user should have additional admin privileges.
+            replication: whether the user should have replication privileges.
             extra_user_roles: additional privileges and/or roles to be assigned to the user.
         """
         try:
@@ -317,7 +367,7 @@ class PostgreSQL:
                     user_definition = "ALTER ROLE {}"
                 else:
                     user_definition = "CREATE ROLE {}"
-                user_definition += f"WITH {'NOLOGIN' if user == 'admin' else 'LOGIN'}{' SUPERUSER' if admin else ''} ENCRYPTED PASSWORD '{password}'{'IN ROLE admin CREATEDB' if admin_role else ''}"
+                user_definition += f"WITH {'NOLOGIN' if user == 'admin' else 'LOGIN'}{' SUPERUSER' if admin else ''}{' REPLICATION' if replication else ''} ENCRYPTED PASSWORD '{password}'{'IN ROLE admin CREATEDB' if admin_role else ''}"
                 if privileges:
                     user_definition += f" {' '.join(privileges)}"
                 cursor.execute(SQL("BEGIN;"))
@@ -415,6 +465,78 @@ class PostgreSQL:
         finally:
             if connection is not None:
                 connection.close()
+
+    def grant_replication_privileges(
+        self,
+        user: str,
+        database: str,
+        schematables: list[str],
+        old_schematables: list[str] | None = None,
+    ) -> None:
+        """Grant CONNECT privilege on database and SELECT privilege on tables.
+
+        Args:
+            user: target user for privileges grant.
+            database: database to grant CONNECT privilege on.
+            schematables: list of tables with schema notation to grant SELECT privileges on.
+            old_schematables: list of tables with schema notation to revoke all privileges from.
+        """
+        with self._connect_to_database(
+            database=database
+        ) as connection, connection.cursor() as cursor:
+            cursor.execute(
+                SQL("GRANT CONNECT ON DATABASE {} TO {};").format(
+                    Identifier(database), Identifier(user)
+                )
+            )
+            if old_schematables:
+                cursor.execute(
+                    SQL("REVOKE ALL PRIVILEGES ON TABLE {} FROM {};").format(
+                        SQL(",").join(
+                            Identifier(schematable.split(".")[0], schematable.split(".")[1])
+                            for schematable in old_schematables
+                        ),
+                        Identifier(user),
+                    )
+                )
+            cursor.execute(
+                SQL("GRANT SELECT ON TABLE {} TO {};").format(
+                    SQL(",").join(
+                        Identifier(schematable.split(".")[0], schematable.split(".")[1])
+                        for schematable in schematables
+                    ),
+                    Identifier(user),
+                )
+            )
+
+    def revoke_replication_privileges(
+        self, user: str, database: str, schematables: list[str]
+    ) -> None:
+        """Revoke all privileges from tables and database.
+
+        Args:
+            user: target user for privileges revocation.
+            database: database to remove all privileges from.
+            schematables: list of tables with schema notation to revoke all privileges from.
+        """
+        with self._connect_to_database(
+            database=database
+        ) as connection, connection.cursor() as cursor:
+            cursor.execute(
+                SQL("REVOKE ALL PRIVILEGES ON TABLE {} FROM {};").format(
+                    SQL(",").join(
+                        Identifier(schematable.split(".")[0], schematable.split(".")[1])
+                        for schematable in schematables
+                    ),
+                    Identifier(user),
+                )
+            )
+            cursor.execute(
+                SQL("REVOKE ALL PRIVILEGES ON DATABASE {} FROM {};").format(
+                    Identifier(database), Identifier(user)
+                )
+            )
+        pass
 
     def enable_disable_extensions(
         self, extensions: Dict[str, bool], database: Optional[str] = None
@@ -934,6 +1056,219 @@ CREATE EVENT TRIGGER update_pg_hba_on_drop_schema
         finally:
             if connection:
                 connection.close()
+
+    def database_exists(self, db: str) -> bool:
+        """Check whether specified database exists."""
+        try:
+            with self._connect_to_database() as connection, connection.cursor() as cursor:
+                cursor.execute(
+                    SQL("SELECT datname FROM pg_database WHERE datname={};").format(Literal(db))
+                )
+                return cursor.fetchone() is not None
+        except psycopg2.Error as e:
+            logger.error(f"Failed to check Postgresql database existence: {e}")
+            raise PostgreSQLDatabaseExistsError() from e
+
+    def table_exists(self, db: str, schema: str, table: str) -> bool:
+        """Check whether specified table in database exists."""
+        try:
+            with self._connect_to_database(
+                database=db
+            ) as connection, connection.cursor() as cursor:
+                cursor.execute(
+                    SQL(
+                        "SELECT tablename FROM pg_tables WHERE schemaname={} AND tablename={};"
+                    ).format(Literal(schema), Literal(table))
+                )
+                return cursor.fetchone() is not None
+        except psycopg2.Error as e:
+            logger.error(f"Failed to check Postgresql table existence: {e}")
+            raise PostgreSQLTableExistsError() from e
+
+    def is_table_empty(self, db: str, schema: str, table: str) -> bool:
+        """Check whether table is empty."""
+        try:
+            with self._connect_to_database(
+                database=db
+            ) as connection, connection.cursor() as cursor:
+                cursor.execute(SQL("SELECT COUNT(1) FROM {};").format(Identifier(schema, table)))
+                return cursor.fetchone()[0] == 0
+        except psycopg2.Error as e:
+            logger.error(f"Failed to check whether table is empty: {e}")
+            raise PostgreSQLIsTableEmptyError() from e
+
+    def create_publication(self, db: str, name: str, schematables: list[str]) -> None:
+        """Create PostgreSQL publication."""
+        try:
+            with self._connect_to_database(
+                database=db
+            ) as connection, connection.cursor() as cursor:
+                cursor.execute(
+                    SQL("CREATE PUBLICATION {} FOR TABLE {};").format(
+                        Identifier(name),
+                        SQL(",").join(
+                            Identifier(schematable.split(".")[0], schematable.split(".")[1])
+                            for schematable in schematables
+                        ),
+                    )
+                )
+        except psycopg2.Error as e:
+            logger.error(f"Failed to create Postgresql publication: {e}")
+            raise PostgreSQLCreatePublicationError() from e
+
+    def publication_exists(self, db: str, publication: str) -> bool:
+        """Check whether specified subscription in database exists."""
+        try:
+            with self._connect_to_database(
+                database=db
+            ) as connection, connection.cursor() as cursor:
+                cursor.execute(
+                    SQL("SELECT pubname FROM pg_publication WHERE pubname={};").format(
+                        Literal(publication)
+                    )
+                )
+                return cursor.fetchone() is not None
+        except psycopg2.Error as e:
+            logger.error(f"Failed to check Postgresql publication existence: {e}")
+            raise PostgreSQLPublicationExistsError() from e
+
+    def alter_publication(self, db: str, name: str, schematables: list[str]) -> None:
+        """Alter PostgreSQL publication."""
+        try:
+            with self._connect_to_database(
+                database=db
+            ) as connection, connection.cursor() as cursor:
+                cursor.execute(
+                    SQL("ALTER PUBLICATION {} SET TABLE {};").format(
+                        Identifier(name),
+                        SQL(",").join(
+                            Identifier(schematable.split(".")[0], schematable.split(".")[1])
+                            for schematable in schematables
+                        ),
+                    )
+                )
+        except psycopg2.Error as e:
+            logger.error(f"Failed to alter Postgresql publication: {e}")
+            raise PostgreSQLAlterPublicationError() from e
+
+    def drop_publication(self, db: str, publication: str) -> None:
+        """Drop PostgreSQL publication."""
+        try:
+            with self._connect_to_database(
+                database=db
+            ) as connection, connection.cursor() as cursor:
+                cursor.execute(
+                    SQL("DROP PUBLICATION IF EXISTS {};").format(
+                        Identifier(publication),
+                    )
+                )
+        except psycopg2.Error as e:
+            logger.error(f"Failed to drop Postgresql publication: {e}")
+            raise PostgreSQLDropPublicationError() from e
+
+    def create_subscription(
+        self,
+        subscription: str,
+        host: str,
+        db: str,
+        user: str,
+        password: str,
+        publication: str,
+        replication_slot: str,
+    ) -> None:
+        """Create PostgreSQL subscription."""
+        try:
+            with self._connect_to_database(
+                database=db
+            ) as connection, connection.cursor() as cursor:
+                cursor.execute(
+                    SQL(
+                        "CREATE SUBSCRIPTION {} CONNECTION {} PUBLICATION {} WITH (copy_data=true,create_slot=false,enabled=true,slot_name={});"
+                    ).format(
+                        Identifier(subscription),
+                        Literal(f"host={host} dbname={db} user={user} password={password}"),
+                        Identifier(publication),
+                        Identifier(replication_slot),
+                    )
+                )
+        except psycopg2.Error as e:
+            logger.error(f"Failed to create Postgresql subscription: {e}")
+            raise PostgreSQLCreateSubscriptionError() from e
+
+    def subscription_exists(self, db: str, subscription: str) -> bool:
+        """Check whether specified subscription in database exists."""
+        try:
+            with self._connect_to_database(
+                database=db
+            ) as connection, connection.cursor() as cursor:
+                cursor.execute(
+                    SQL("SELECT subname FROM pg_subscription WHERE subname={};").format(
+                        Literal(subscription)
+                    )
+                )
+                return cursor.fetchone() is not None
+        except psycopg2.Error as e:
+            logger.error(f"Failed to check Postgresql subscription existence: {e}")
+            raise PostgreSQLSubscriptionExistsError() from e
+
+    def update_subscription(self, db: str, subscription: str, host: str, user: str, password: str):
+        """Update PostgreSQL subscription connection details."""
+        try:
+            with self._connect_to_database(
+                database=db
+            ) as connection, connection.cursor() as cursor:
+                cursor.execute(
+                    SQL("ALTER SUBSCRIPTION {} CONNECTION {}").format(
+                        Identifier(subscription),
+                        Literal(f"host={host} dbname={db} user={user} password={password}"),
+                    )
+                )
+        except psycopg2.Error as e:
+            logger.error(f"Failed to update Postgresql subscription: {e}")
+            raise PostgreSQLUpdateSubscriptionError() from e
+
+    def refresh_subscription(self, db: str, subscription: str):
+        """Refresh PostgreSQL subscription to pull publication changes."""
+        connection = None
+        try:
+            connection = self._connect_to_database(database=db)
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    SQL("ALTER SUBSCRIPTION {} REFRESH PUBLICATION").format(
+                        Identifier(subscription)
+                    )
+                )
+        except psycopg2.Error as e:
+            logger.error(f"Failed to refresh Postgresql subscription: {e}")
+            raise PostgreSQLRefreshSubscriptionError() from e
+        finally:
+            if connection is not None:
+                connection.close()
+
+    def drop_subscription(self, db: str, subscription: str) -> None:
+        """Drop PostgreSQL subscription."""
+        try:
+            with self._connect_to_database(
+                database=db
+            ) as connection, connection.cursor() as cursor:
+                cursor.execute(
+                    SQL("ALTER SUBSCRIPTION {} DISABLE;").format(
+                        Identifier(subscription),
+                    )
+                )
+                cursor.execute(
+                    SQL("ALTER SUBSCRIPTION {} SET (slot_name=NONE);").format(
+                        Identifier(subscription),
+                    )
+                )
+                cursor.execute(
+                    SQL("DROP SUBSCRIPTION {};").format(
+                        Identifier(subscription),
+                    )
+                )
+        except psycopg2.Error as e:
+            logger.error(f"Failed to drop Postgresql subscription: {e}")
+            raise PostgreSQLDropSubscriptionError() from e
 
     @staticmethod
     def build_postgresql_group_map(group_map: Optional[str]) -> List[Tuple]:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -49,6 +49,9 @@ provides:
     interface: postgresql_async
     limit: 1
     optional: true
+  logical-replication-offer:
+    interface: postgresql_logical_replication
+    optional: true
   database:
     interface: postgresql_client
   metrics-endpoint:
@@ -59,6 +62,10 @@ provides:
 requires:
   replication:
     interface: postgresql_async
+    limit: 1
+    optional: true
+  logical-replication:
+    interface: postgresql_logical_replication
     limit: 1
     optional: true
   certificates:

--- a/src/backups.py
+++ b/src/backups.py
@@ -15,6 +15,7 @@ from io import BytesIO
 import boto3
 import botocore
 from botocore.exceptions import ClientError
+from charms.data_platform_libs.v0.s3 import CredentialsChangedEvent, S3Requirer
 from jinja2 import Template
 from lightkube import ApiError, Client
 from lightkube.resources.core_v1 import Endpoints
@@ -26,7 +27,6 @@ from ops.model import ActiveStatus, MaintenanceStatus
 from ops.pebble import ChangeError, ExecError
 from tenacity import RetryError, Retrying, stop_after_attempt, wait_fixed
 
-from charms.data_platform_libs.v0.s3 import CredentialsChangedEvent, S3Requirer
 from constants import (
     BACKUP_TYPE_OVERRIDES,
     BACKUP_USER,

--- a/src/backups.py
+++ b/src/backups.py
@@ -15,7 +15,6 @@ from io import BytesIO
 import boto3
 import botocore
 from botocore.exceptions import ClientError
-from charms.data_platform_libs.v0.s3 import CredentialsChangedEvent, S3Requirer
 from jinja2 import Template
 from lightkube import ApiError, Client
 from lightkube.resources.core_v1 import Endpoints
@@ -27,6 +26,7 @@ from ops.model import ActiveStatus, MaintenanceStatus
 from ops.pebble import ChangeError, ExecError
 from tenacity import RetryError, Retrying, stop_after_attempt, wait_fixed
 
+from charms.data_platform_libs.v0.s3 import CredentialsChangedEvent, S3Requirer
 from constants import (
     BACKUP_TYPE_OVERRIDES,
     BACKUP_USER,
@@ -35,6 +35,10 @@ from constants import (
     WORKLOAD_OS_USER,
 )
 from relations.async_replication import REPLICATION_CONSUMER_RELATION, REPLICATION_OFFER_RELATION
+from relations.logical_replication import (
+    LOGICAL_REPLICATION_OFFER_RELATION,
+    LOGICAL_REPLICATION_RELATION,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1090,7 +1094,7 @@ Stderr:
 
         return None
 
-    def _pre_restore_checks(self, event: ActionEvent) -> bool:
+    def _pre_restore_checks(self, event: ActionEvent) -> bool:  # noqa: C901
         """Run some checks before starting the restore.
 
         Returns:
@@ -1145,14 +1149,25 @@ Stderr:
             event.fail(error_message)
             return False
 
-        logger.info("Checking that the cluster is not replicating data to a standby cluster")
+        logger.info("Checking that cluster does not have an active async replication relation")
         for relation in [
             self.model.get_relation(REPLICATION_CONSUMER_RELATION),
             self.model.get_relation(REPLICATION_OFFER_RELATION),
         ]:
             if not relation:
                 continue
-            error_message = "Unit cannot restore backup as the cluster is replicating data to a standby cluster"
+            error_message = "Unit cannot restore backup with an active async replication relation"
+            logger.error(f"Restore failed: {error_message}")
+            event.fail(error_message)
+            return False
+
+        logger.info("Checking that cluster does not have an active logical replication relation")
+        if self.model.get_relation(LOGICAL_REPLICATION_RELATION) or len(
+            self.model.relations.get(LOGICAL_REPLICATION_OFFER_RELATION, ())
+        ):
+            error_message = (
+                "Unit cannot restore backup with an active logical replication connection"
+            )
             logger.error(f"Restore failed: {error_message}")
             event.fail(error_message)
             return False

--- a/src/charm.py
+++ b/src/charm.py
@@ -37,6 +37,24 @@ except ModuleNotFoundError:
         main(WrongArchitectureWarningCharm, use_juju_for_storage=True)
     raise
 
+from charms.data_platform_libs.v0.data_interfaces import DataPeerData, DataPeerUnitData
+from charms.data_platform_libs.v0.data_models import TypedCharmBase
+from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
+from charms.loki_k8s.v1.loki_push_api import LogProxyConsumer
+from charms.postgresql_k8s.v0.postgresql import (
+    ACCESS_GROUP_IDENTITY,
+    ACCESS_GROUPS,
+    REQUIRED_PLUGINS,
+    PostgreSQL,
+    PostgreSQLEnableDisableExtensionError,
+    PostgreSQLGetCurrentTimelineError,
+    PostgreSQLUpdateUserPasswordError,
+)
+from charms.postgresql_k8s.v0.postgresql_tls import PostgreSQLTLS
+from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
+from charms.rolling_ops.v0.rollingops import RollingOpsManager, RunWithLock
+from charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
+from charms.tempo_coordinator_k8s.v0.tracing import TracingEndpointRequirer
 from lightkube import ApiError, Client
 from lightkube.models.core_v1 import ServicePort, ServiceSpec
 from lightkube.models.meta_v1 import ObjectMeta
@@ -75,24 +93,6 @@ from requests import ConnectionError as RequestsConnectionError
 from tenacity import RetryError, Retrying, stop_after_attempt, stop_after_delay, wait_fixed
 
 from backups import CANNOT_RESTORE_PITR, S3_BLOCK_MESSAGES, PostgreSQLBackups
-from charms.data_platform_libs.v0.data_interfaces import DataPeerData, DataPeerUnitData
-from charms.data_platform_libs.v0.data_models import TypedCharmBase
-from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
-from charms.loki_k8s.v1.loki_push_api import LogProxyConsumer
-from charms.postgresql_k8s.v0.postgresql import (
-    ACCESS_GROUP_IDENTITY,
-    ACCESS_GROUPS,
-    REQUIRED_PLUGINS,
-    PostgreSQL,
-    PostgreSQLEnableDisableExtensionError,
-    PostgreSQLGetCurrentTimelineError,
-    PostgreSQLUpdateUserPasswordError,
-)
-from charms.postgresql_k8s.v0.postgresql_tls import PostgreSQLTLS
-from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
-from charms.rolling_ops.v0.rollingops import RollingOpsManager, RunWithLock
-from charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
-from charms.tempo_coordinator_k8s.v0.tracing import TracingEndpointRequirer
 from config import CharmConfig
 from constants import (
     APP_SCOPE,

--- a/src/config.py
+++ b/src/config.py
@@ -7,9 +7,8 @@
 import logging
 from typing import Literal
 
-from pydantic import PositiveInt, validator
-
 from charms.data_platform_libs.v0.data_models import BaseConfigModel
+from pydantic import PositiveInt, validator
 
 logger = logging.getLogger(__name__)
 

--- a/src/config.py
+++ b/src/config.py
@@ -7,8 +7,9 @@
 import logging
 from typing import Literal
 
-from charms.data_platform_libs.v0.data_models import BaseConfigModel
 from pydantic import PositiveInt, validator
+
+from charms.data_platform_libs.v0.data_models import BaseConfigModel
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +36,7 @@ class CharmConfig(BaseConfigModel):
     logging_log_lock_waits: bool | None
     logging_log_min_duration_statement: int | None
     logging_track_functions: str | None
+    logical_replication_subscription_request: str | None
     memory_maintenance_work_mem: int | None
     memory_max_prepared_transactions: int | None
     memory_shared_buffers: int | None

--- a/src/relations/logical_replication.py
+++ b/src/relations/logical_replication.py
@@ -1,0 +1,624 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Logical Replication implementation.
+
+TODO: add description after specification is accepted.
+"""
+
+import json
+import logging
+from typing import (
+    TYPE_CHECKING,
+)
+
+from ops import (
+    BlockedStatus,
+    EventBase,
+    Object,
+    Relation,
+    RelationBrokenEvent,
+    RelationChangedEvent,
+    RelationDepartedEvent,
+    RelationJoinedEvent,
+    Secret,
+    SecretChangedEvent,
+    SecretNotFoundError,
+)
+
+from utils import new_password
+
+if TYPE_CHECKING:
+    from charm import PostgresqlOperatorCharm
+
+logger = logging.getLogger(__name__)
+
+LOGICAL_REPLICATION_OFFER_RELATION = "logical-replication-offer"
+LOGICAL_REPLICATION_RELATION = "logical-replication"
+SECRET_LABEL = "logical-replication-relation"  # noqa: S105
+LOGICAL_REPLICATION_VALIDATION_ERROR_STATUS = "Logical replication setup is invalid. Check logs"
+
+
+class PostgreSQLLogicalReplication(Object):
+    """Defines the logical-replication logic."""
+
+    def __init__(self, charm: "PostgresqlOperatorCharm"):
+        super().__init__(charm, "postgresql_logical_replication")
+        self.charm = charm
+        # Relations
+        self.charm.framework.observe(
+            self.charm.on[LOGICAL_REPLICATION_OFFER_RELATION].relation_joined,
+            self._on_offer_relation_joined,
+        )
+        self.charm.framework.observe(
+            self.charm.on[LOGICAL_REPLICATION_OFFER_RELATION].relation_changed,
+            self._on_offer_relation_changed,
+        )
+        self.charm.framework.observe(
+            self.charm.on[LOGICAL_REPLICATION_OFFER_RELATION].relation_departed,
+            self._on_offer_relation_departed,
+        )
+        self.charm.framework.observe(
+            self.charm.on[LOGICAL_REPLICATION_OFFER_RELATION].relation_broken,
+            self._on_offer_relation_broken,
+        )
+        self.charm.framework.observe(
+            self.charm.on[LOGICAL_REPLICATION_RELATION].relation_joined, self._on_relation_joined
+        )
+        self.charm.framework.observe(
+            self.charm.on[LOGICAL_REPLICATION_RELATION].relation_changed, self._on_relation_changed
+        )
+        self.charm.framework.observe(
+            self.charm.on[LOGICAL_REPLICATION_RELATION].relation_departed,
+            self._on_relation_departed,
+        )
+        self.charm.framework.observe(
+            self.charm.on[LOGICAL_REPLICATION_RELATION].relation_broken, self._on_relation_broken
+        )
+        # Events
+        self.framework.observe(self.charm.on.secret_changed, self._on_secret_changed)
+
+    # region Relations
+
+    def _on_offer_relation_joined(self, event: RelationJoinedEvent) -> None:
+        if not self.charm.unit.is_leader():
+            logger.debug(
+                f"{LOGICAL_REPLICATION_OFFER_RELATION} #{event.relation.id} join early exit due to unit not being a leader"
+            )
+            return
+        if not self.charm.primary_endpoint:
+            logger.debug(
+                f"Deferring {LOGICAL_REPLICATION_OFFER_RELATION} #{event.relation.id} join due to primary unavailability"
+            )
+            event.defer()
+            return
+
+        secret = self._get_secret(event.relation.id)
+        logger.debug(
+            f"Sharing logical replciation secret to the {LOGICAL_REPLICATION_OFFER_RELATION} #{event.relation.id}"
+        )
+        secret.grant(event.relation)
+
+        self._save_published_resources_info(str(event.relation.id), secret.id, {})
+        event.relation.data[self.model.app]["secret-id"] = secret.id
+
+    def _on_offer_relation_changed(self, event: RelationChangedEvent) -> None:
+        if not self.charm.unit.is_leader():
+            logger.debug(
+                f"{LOGICAL_REPLICATION_OFFER_RELATION} #{event.relation.id} change early exit due to unit not being a leader"
+            )
+            return
+        if not self.charm.primary_endpoint:
+            logger.debug(
+                f"Deferring {LOGICAL_REPLICATION_OFFER_RELATION} #{event.relation.id} change due to primary unavailability"
+            )
+            event.defer()
+            return
+        self._process_offer(event.relation)
+
+    def _on_offer_relation_departed(self, event: RelationDepartedEvent) -> None:
+        if event.departing_unit == self.charm.unit and self.charm._peers is not None:
+            logger.debug(
+                f"Marking unit as departed for {LOGICAL_REPLICATION_OFFER_RELATION} #{event.relation.id} to skip break"
+            )
+            self.charm.unit_peer_data.update({"departing": "True"})
+
+    def _on_offer_relation_broken(self, event: RelationBrokenEvent) -> None:
+        if not self.charm._peers or self.charm.is_unit_departing:
+            logger.debug(
+                f"{LOGICAL_REPLICATION_OFFER_RELATION} #{event.relation.id} break early exit due to unit departure"
+            )
+            return
+        if not self.charm.unit.is_leader():
+            logger.debug(
+                f"{LOGICAL_REPLICATION_OFFER_RELATION} #{event.relation.id} break early exit due to unit not being a leader"
+            )
+            return
+        if not self.charm.primary_endpoint:
+            logger.debug(
+                f"Deferring {LOGICAL_REPLICATION_OFFER_RELATION} #{event.relation.id} break due to primary unavailability"
+            )
+            event.defer()
+            return
+
+        published_resources = json.loads(
+            self.charm.app_peer_data.get("logical-replication-published-resources", "{}")
+        )
+        active_relation_ids = [
+            str(relation.id)
+            for relation in self.model.relations.get(LOGICAL_REPLICATION_OFFER_RELATION, ())
+        ]
+
+        for relation_id, relation_resources in published_resources.copy().items():
+            if relation_id in active_relation_ids:
+                continue
+            logger.info(
+                f"Cleaning up published logical replication resources for the redundant {LOGICAL_REPLICATION_OFFER_RELATION} #{relation_id}"
+            )
+            try:
+                secret = self.model.get_secret(id=relation_resources["secret-id"])
+                self.charm.postgresql.delete_user(secret.peek_content()["username"])
+                secret.remove_all_revisions()
+            except SecretNotFoundError:
+                pass
+            for database, publication in relation_resources["publications"].items():
+                self.charm.postgresql.drop_publication(database, publication["publication-name"])
+            del published_resources[relation_id]
+            self.charm.app_peer_data["logical-replication-published-resources"] = json.dumps(
+                published_resources
+            )
+
+        self.charm.update_config()
+
+    def _on_relation_joined(self, event: RelationJoinedEvent) -> None:
+        if not self.charm.unit.is_leader():
+            logger.debug(
+                f"{LOGICAL_REPLICATION_RELATION} #{event.relation.id} join early exit due to unit not being a leader"
+            )
+            return
+        if self.charm.app_peer_data.get("logical-replication-validation") == "ongoing":
+            logger.debug(
+                f"Deferring {LOGICAL_REPLICATION_RELATION} #{event.relation.id} join due to still ongoing logical replication config validation"
+            )
+            event.defer()
+            return
+        if self.charm.app_peer_data.get("logical-replication-validation") == "error":
+            logger.debug(
+                f"{LOGICAL_REPLICATION_RELATION} #{event.relation.id} join early exit due to validation error"
+            )
+            return
+        event.relation.data[self.model.app]["subscription-request"] = (
+            self.charm.config.logical_replication_subscription_request or ""
+        )
+
+    def _on_relation_changed(self, event: RelationChangedEvent) -> None:
+        if not self._relation_changed_checks(event):
+            return
+
+        for error in json.loads(event.relation.data[event.app].get("errors", "[]")):
+            logger.error(
+                f"Got logical replication error from the publisher in {LOGICAL_REPLICATION_RELATION} #{event.relation.id}: {error}"
+            )
+            self.charm.unit.status = BlockedStatus(LOGICAL_REPLICATION_VALIDATION_ERROR_STATUS)
+
+        secret_content = self.model.get_secret(
+            id=event.relation.data[event.app]["secret-id"]
+        ).get_content(refresh=True)
+        subscriptions = json.loads(
+            self.charm.app_peer_data.get("logical-replication-subscriptions", "{}")
+        )
+        publications = json.loads(event.relation.data[event.app].get("publications", "{}"))
+
+        for database, publication in publications.items():
+            subscription_name = self._subscription_name(event.relation.id, database)
+            if database in subscriptions:
+                self.charm.postgresql.refresh_subscription(database, subscription_name)
+                logger.info(
+                    f"Refreshed subscription {subscription_name} in database {database} due to relation change"
+                )
+            else:
+                publication_name = publication["publication-name"]
+                self.charm.postgresql.create_subscription(
+                    subscription_name,
+                    secret_content["primary"],
+                    database,
+                    secret_content["username"],
+                    secret_content["password"],
+                    publication_name,
+                    publication["replication-slot-name"],
+                )
+                logger.info(
+                    f"Created new subscription {subscription_name} for publication {publication_name} in database {database}"
+                )
+                subscriptions[database] = subscription_name
+
+        for database, subscription in subscriptions.copy().items():
+            if database in publications:
+                continue
+            self.charm.postgresql.drop_subscription(database, subscription)
+            logger.info(f"Dropped redundant subscription {subscription} from database {database}")
+            del subscriptions[database]
+
+        self.charm.app_peer_data["logical-replication-subscriptions"] = json.dumps(subscriptions)
+
+    def _on_relation_departed(self, event: RelationDepartedEvent) -> None:
+        if event.departing_unit == self.charm.unit and self.charm._peers is not None:
+            self.charm.unit_peer_data.update({"departing": "True"})
+
+    def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
+        if not self.charm._peers or self.charm.is_unit_departing:
+            logger.debug(f"{LOGICAL_REPLICATION_RELATION} break skipped due to departing unit")
+            return
+        if not self.charm.unit.is_leader():
+            logger.debug(
+                f"{LOGICAL_REPLICATION_RELATION} #{event.relation.id} break early exit due to unit not being a leader"
+            )
+            return
+        if not self.charm.primary_endpoint:
+            logger.debug(
+                f"Deferring {LOGICAL_REPLICATION_RELATION} break until primary is available"
+            )
+            event.defer()
+            return
+
+        subscriptions = json.loads(
+            self.charm.app_peer_data.get("logical-replication-subscriptions", "{}")
+        )
+        for database, subscription in subscriptions.items():
+            self.charm.postgresql.drop_subscription(database, subscription)
+            logger.info(
+                f"Dropped subscription {subscriptions} from database {database} due to relation break"
+            )
+        self.charm.app_peer_data["logical-replication-subscriptions"] = ""
+
+    # endregion
+
+    # region Events
+
+    def _on_secret_changed(self, event: SecretChangedEvent) -> None:
+        if not self.charm.unit.is_leader():
+            logger.debug(
+                "Logical replication secret change early exit due to unit not being a leader"
+            )
+            return
+        if not self.charm.primary_endpoint:
+            logger.debug("Deferring logical replication secret change until primary is available")
+            event.defer()
+            return
+
+        if (
+            relation := self.model.get_relation(LOGICAL_REPLICATION_RELATION)
+        ) and event.secret.label.startswith(SECRET_LABEL):
+            logger.info("Logical replication secret changed, updating subscriptions")
+            secret_content = self.model.get_secret(
+                id=relation.data[relation.app]["secret-id"], label=SECRET_LABEL
+            ).get_content(refresh=True)
+            subscriptions = json.loads(
+                self.charm.app_peer_data.get("logical-replication-subscriptions", "{}")
+            )
+            for database, subscription in subscriptions.items():
+                self.charm.postgresql.update_subscription(
+                    database,
+                    subscription,
+                    secret_content["primary"],
+                    secret_content["username"],
+                    secret_content["password"],
+                )
+
+    # endregion
+
+    def apply_changed_config(self, event: EventBase) -> bool:
+        """Validate & apply (relation) logical_replication_subscription_request config parameter."""
+        if not self.charm.unit.is_leader():
+            return True
+        if not self.charm.primary_endpoint:
+            logger.debug(
+                "Marking logical replication config validation as ongoing and deferring event until primary as available"
+            )
+            self.charm.app_peer_data["logical-replication-validation"] = "ongoing"
+            event.defer()
+            return False
+        if self._validate_subscription_request():
+            self._apply_updated_subscription_request()
+        return True
+
+    def retry_validations(self) -> None:
+        """Run recurrent logical replication validation attempt.
+
+        For subscribers - try to validate & apply subscription request.
+        For publishers - try to validate & process all the offer relations.
+        """
+        if not self.charm.unit.is_leader() or not self.charm.primary_endpoint:
+            return
+        if (
+            self.charm.app_peer_data.get("logical-replication-validation") == "error"
+            and self._validate_subscription_request()
+        ):
+            self._apply_updated_subscription_request()
+        for relation in self.model.relations.get(LOGICAL_REPLICATION_OFFER_RELATION, ()):
+            if json.loads(relation.data[self.model.app].get("errors", "[]")):
+                self._process_offer(relation)
+
+    def has_remote_publisher_errors(self) -> bool:
+        """Check if remote publisher in logical-replication relation has any errors."""
+        return bool(
+            relation := self.model.get_relation(LOGICAL_REPLICATION_RELATION)
+        ) and json.loads(relation.data[relation.app].get("errors", "[]"))
+
+    def replication_slots(self) -> dict[str, str]:
+        """Get list of all managed replication slots.
+
+        Returns: dictionary in <slot>: <database> format.
+        """
+        return {
+            publication["replication-slot-name"]: database
+            for resources in json.loads(
+                self.charm.app_peer_data.get("logical-replication-published-resources", "{}")
+            ).values()
+            for database, publication in resources["publications"].items()
+        }
+
+    def _apply_updated_subscription_request(self) -> None:
+        if not (relation := self.model.get_relation(LOGICAL_REPLICATION_RELATION)):
+            return
+        logger.debug(
+            "Logical replication config validation is passed, applying config to the active relations"
+        )
+        subscription_request_config = json.loads(
+            self.charm.config.logical_replication_subscription_request or "{}"
+        )
+        subscriptions = json.loads(
+            self.charm.app_peer_data.get("logical-replication-subscriptions", "{}")
+        )
+        relation.data[self.model.app]["subscription-request"] = (
+            self.charm.config.logical_replication_subscription_request
+        )
+        for database, subscription in subscriptions.copy().items():
+            if database in subscription_request_config:
+                continue
+            self.charm.postgresql.drop_subscription(database, subscription)
+            logger.info(f"Dropped redundant subscription {subscription} from database {database}")
+            del subscriptions[database]
+        self.charm.app_peer_data["logical-replication-subscriptions"] = json.dumps(subscriptions)
+
+    def _validate_subscription_request(self) -> bool:
+        try:
+            subscription_request_config = json.loads(
+                self.charm.config.logical_replication_subscription_request or "{}"
+            )
+        except json.JSONDecodeError as err:
+            return self._fail_validation(f"JSON decode error {err}")
+
+        relation = self.model.get_relation(LOGICAL_REPLICATION_RELATION)
+        subscription_request_relation = (
+            json.loads(relation.data[self.model.app].get("subscription-request", "{}"))
+            if relation
+            else {}
+        )
+
+        for database, schematables in subscription_request_config.items():
+            if not self.charm.postgresql.database_exists(database):
+                return self._fail_validation(f"database {database} doesn't exist")
+            for schematable in schematables:
+                try:
+                    schema, table = schematable.split(".")
+                except ValueError:
+                    return self._fail_validation(f"table format isn't right at {schematable}")
+                if not self.charm.postgresql.table_exists(database, schema, table):
+                    return self._fail_validation(
+                        f"table {schematable} in database {database} doesn't exist"
+                    )
+                already_subscribed = (
+                    database in subscription_request_relation
+                    and schematable in subscription_request_relation[database]
+                )
+                if not already_subscribed and not self.charm.postgresql.is_table_empty(
+                    database, schema, table
+                ):
+                    return self._fail_validation(
+                        f"table {schematable} in database {database} isn't empty"
+                    )
+
+        self.charm.app_peer_data["logical-replication-validation"] = ""
+        return True
+
+    def _fail_validation(self, message: str | None = None) -> bool:
+        if message:
+            logger.error(f"Logical replication validation: {message}")
+        self.charm.app_peer_data["logical-replication-validation"] = "error"
+        self.charm.unit.status = BlockedStatus(LOGICAL_REPLICATION_VALIDATION_ERROR_STATUS)
+        return False
+
+    def _validate_new_publication(
+        self,
+        database: str,
+        schematables: list[str],
+        publication_schematables: list[str] | None = None,
+    ) -> str | None:
+        if not self.charm.postgresql.database_exists(database):
+            return f"database {database} doesn't exist"
+        for schematable in schematables:
+            if publication_schematables is not None and schematable in publication_schematables:
+                continue
+            schema, table = schematable.split(".")
+            if not self.charm.postgresql.table_exists(database, schema, table):
+                return f"table {schematable} in database {database} doesn't exist"
+        return None
+
+    def _relation_changed_checks(self, event: RelationChangedEvent) -> bool:
+        if not self.charm.unit.is_leader():
+            logger.debug(
+                f"{LOGICAL_REPLICATION_RELATION} #{event.relation.id} change early exit due to unit not being a leader"
+            )
+            return False
+        if not event.relation.data[event.app].get("secret-id"):
+            logger.warning(
+                f"{LOGICAL_REPLICATION_RELATION} #{event.relation.id} change early exit due to secret absence in remote application bag (unusual behavior)"
+            )
+            return False
+        if not self.charm.primary_endpoint:
+            logger.debug(
+                f"Deferring {LOGICAL_REPLICATION_RELATION} #{event.relation.id} change due to primary unavailability"
+            )
+            event.defer()
+            return False
+        return True
+
+    def _process_offer(self, relation: Relation) -> None:
+        logger.debug(
+            f"Started processing offer for {LOGICAL_REPLICATION_OFFER_RELATION} #{relation.id}"
+        )
+
+        subscriptions_request = json.loads(
+            relation.data[relation.app].get("subscription-request", "{}")
+        )
+        publications = json.loads(relation.data[self.model.app].get("publications", "{}"))
+        secret = self._get_secret(relation.id)
+        user = secret.peek_content()["username"]
+        errors = []
+
+        for database, publication in publications.copy().items():
+            if database in subscriptions_request:
+                continue
+            logger.info(
+                f"Dropping redundant publication {publication['publication-name']} in database {database} from {LOGICAL_REPLICATION_OFFER_RELATION} #{relation.id}"
+            )
+            self.charm.postgresql.drop_publication(database, publication["publication-name"])
+            del publications[database]
+            logger.info(
+                f"Revoking replication privileges on database {database} from user {user} from {LOGICAL_REPLICATION_OFFER_RELATION} #{relation.id}"
+            )
+            self.charm.postgresql.revoke_replication_privileges(
+                user, database, publication["tables"]
+            )
+
+        for database, tables in subscriptions_request.items():
+            if database not in publications:
+                if validation_error := self._validate_new_publication(database, tables):
+                    errors.append(validation_error)
+                    logger.error(
+                        f"Cannot create new publication for {LOGICAL_REPLICATION_OFFER_RELATION} #{relation.id}: {validation_error}"
+                    )
+                    continue
+                publication_name = self._publication_name(relation.id, database)
+                if self.charm.postgresql.publication_exists(database, publication_name):
+                    error = f"conflicting publication {publication_name} in database {database}"
+                    errors.append(error)
+                    logger.error(
+                        f"Cannot create new publication for {LOGICAL_REPLICATION_OFFER_RELATION} #{relation.id}: {error}"
+                    )
+                    continue
+                logger.info(
+                    f"Granting replication privileges on database {database} for user {user} for {LOGICAL_REPLICATION_OFFER_RELATION} #{relation.id}"
+                )
+                self.charm.postgresql.grant_replication_privileges(user, database, tables)
+                logger.info(
+                    f"Creating new publication {publication_name} for tables {', '.join(tables)} in database {database} for {LOGICAL_REPLICATION_OFFER_RELATION} #{relation.id}"
+                )
+                self.charm.postgresql.create_publication(database, publication_name, tables)
+                publications[database] = {
+                    "publication-name": publication_name,
+                    "replication-slot-name": self._replication_slot_name(relation.id, database),
+                    "tables": tables,
+                }
+            elif sorted(publication_tables := publications[database]["tables"]) != sorted(tables):
+                publication_name = publications[database]["publication-name"]
+                if validation_error := self._validate_new_publication(
+                    database, tables, publication_tables
+                ):
+                    errors.append(validation_error)
+                    logger.error(
+                        f"Cannot alter publication {publication_name} for {LOGICAL_REPLICATION_OFFER_RELATION} #{relation.id}: {validation_error}"
+                    )
+                    continue
+                if not self.charm.postgresql.publication_exists(database, publication_name):
+                    errors.append(
+                        f"managed publication {publication_name} in database {database} can't be found"
+                    )
+                    logger.error(
+                        f"Can't find managed publication {publication_name} in database {database} for {LOGICAL_REPLICATION_OFFER_RELATION} #{relation.id}"
+                    )
+                    continue
+                logger.info(
+                    f"Altering replication privileges on database {database} for user {user} for {LOGICAL_REPLICATION_OFFER_RELATION} #{relation.id}"
+                )
+                self.charm.postgresql.grant_replication_privileges(
+                    user, database, tables, publication_tables
+                )
+                logger.info(
+                    f"Altering publication {publication_name} tables from {','.join(publication_tables)} to {','.join(tables)} in database {database} for {LOGICAL_REPLICATION_OFFER_RELATION} #{relation.id}"
+                )
+                self.charm.postgresql.alter_publication(database, publication_name, tables)
+                publications[database]["tables"] = tables
+            self._save_published_resources_info(str(relation.id), secret.id, publications)
+            relation.data[self.model.app]["publications"] = json.dumps(publications)
+
+        self._save_published_resources_info(str(relation.id), secret.id, publications)
+        relation.data[self.model.app].update({
+            "errors": json.dumps(errors),
+            "publications": json.dumps(publications),
+        })
+        self.charm.update_config()
+
+        logger.debug(
+            f"Successfully processed offer for {LOGICAL_REPLICATION_OFFER_RELATION} #{relation.id}"
+        )
+
+    def _publication_name(self, relation_id: int, database: str) -> str:
+        return f"relation_{relation_id}_{database}"
+
+    def _replication_slot_name(self, relation_id: int, database: str) -> str:
+        return f"relation_{relation_id}_{database}"
+
+    def _subscription_name(self, relation_id: int, database: str) -> str:
+        return f"relation_{relation_id}_{database}"
+
+    def _save_published_resources_info(
+        self,
+        relation_id: str,
+        secret_id: str,
+        publications: dict[str, dict[str, str | list[str]]],
+    ) -> None:
+        published_resources = json.loads(
+            self.charm.app_peer_data.get("logical-replication-published-resources", "{}")
+        )
+        published_resources[relation_id] = {
+            "secret-id": secret_id,
+            "publications": publications,
+        }
+        self.charm.app_peer_data["logical-replication-published-resources"] = json.dumps(
+            published_resources
+        )
+
+    def _create_user(self, relation_id: int) -> tuple[str, str]:
+        user = f"logical-replication-relation-{relation_id}"
+        password = new_password()
+        logger.info(
+            f"Creating new user {user} for {LOGICAL_REPLICATION_OFFER_RELATION} #{relation_id}"
+        )
+        self.charm.postgresql.create_user(user, password, replication=True)
+        return user, password
+
+    def _get_secret(self, relation_id: int) -> Secret:
+        """Returns logical replication secret. Updates, if content changed."""
+        secret_label = f"{SECRET_LABEL}-{relation_id}"
+        try:
+            # Avoid recreating the secret.
+            secret = self.charm.model.get_secret(label=secret_label)
+            if not secret.id:
+                # Workaround for the secret id not being set with model uuid.
+                secret._id = f"secret://{self.model.uuid}/{secret.get_info().id.split(':')[1]}"
+            return secret
+        except SecretNotFoundError:
+            logger.debug(
+                f"Creating new secret for {LOGICAL_REPLICATION_OFFER_RELATION} #{relation_id}"
+            )
+        username, password = self._create_user(relation_id)
+        return self.charm.model.app.add_secret(
+            content={
+                "primary": self.charm.primary_endpoint,
+                "username": username,
+                "password": password,
+            },
+            label=secret_label,
+        )

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -47,6 +47,16 @@ bootstrap:
         logging_collector: 'on'
         wal_level: logical
         shared_preload_libraries: 'timescaledb,pgaudit'
+    {%- if slots %}
+    slots:
+    {%- for slot, database in slots.items() %}
+      {{slot}}:
+        database: {{database}}
+        plugin: pgoutput
+        type: logical
+    {%- endfor -%}
+    {% endif %}
+
   {%- if restoring_backup %}
   method: pgbackrest
   pgbackrest:

--- a/tests/integration/ha_tests/test_logical_replication.py
+++ b/tests/integration/ha_tests/test_logical_replication.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 import json
 from asyncio import gather
 

--- a/tests/integration/ha_tests/test_logical_replication.py
+++ b/tests/integration/ha_tests/test_logical_replication.py
@@ -1,0 +1,408 @@
+import json
+from asyncio import gather
+
+import psycopg2
+import pytest as pytest
+from pytest_operator.plugin import OpsTest
+
+from integration import markers
+from integration.ha_tests.helpers import get_cluster_roles
+from integration.helpers import CHARM_BASE, get_leader_unit
+from integration.new_relations.helpers import build_connection_string
+
+DATABASE_APP_NAME = "postgresql"
+SECOND_DATABASE_APP_NAME = "postgresql2"
+THIRD_DATABASE_APP_NAME = "postgresql3"
+
+DATA_INTEGRATOR_APP_NAME = "data-integrator"
+SECOND_DATA_INTEGRATOR_APP_NAME = "data-integrator2"
+THIRD_DATA_INTEGRATOR_APP_NAME = "data-integrator3"
+DATA_INTEGRATOR_RELATION = "postgresql"
+
+DATABASE_APP_CONFIG = {"profile": "testing"}
+
+TESTING_DATABASE = "testdb"
+
+
+@markers.juju3
+@pytest.mark.abort_on_fail
+async def test_deploy(ops_test: OpsTest, charm):
+    await gather(
+        ops_test.model.deploy(
+            charm,
+            application_name=DATABASE_APP_NAME,
+            num_units=3,
+            base=CHARM_BASE,
+            config=DATABASE_APP_CONFIG,
+        ),
+        ops_test.model.deploy(
+            charm,
+            application_name=SECOND_DATABASE_APP_NAME,
+            num_units=3,
+            base=CHARM_BASE,
+            config=DATABASE_APP_CONFIG,
+        ),
+        ops_test.model.deploy(
+            charm,
+            application_name=THIRD_DATABASE_APP_NAME,
+            num_units=1,
+            base=CHARM_BASE,
+            config=DATABASE_APP_CONFIG,
+        ),
+        ops_test.model.deploy(
+            DATA_INTEGRATOR_APP_NAME,
+            application_name=DATA_INTEGRATOR_APP_NAME,
+            num_units=1,
+            channel="latest/stable",
+            config={"database-name": TESTING_DATABASE},
+        ),
+        ops_test.model.deploy(
+            DATA_INTEGRATOR_APP_NAME,
+            application_name=SECOND_DATA_INTEGRATOR_APP_NAME,
+            num_units=1,
+            channel="latest/stable",
+            config={"database-name": TESTING_DATABASE},
+        ),
+        ops_test.model.deploy(
+            DATA_INTEGRATOR_APP_NAME,
+            application_name=THIRD_DATA_INTEGRATOR_APP_NAME,
+            num_units=1,
+            channel="latest/stable",
+            config={"database-name": TESTING_DATABASE},
+        ),
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[DATABASE_APP_NAME, SECOND_DATABASE_APP_NAME, THIRD_DATABASE_APP_NAME],
+        status="active",
+        timeout=2500,
+        # There can be error spikes during PostgreSQL deployment, that are not related to Logical Replication
+        raise_on_error=False,
+    )
+    async with ops_test.fast_forward():
+        await gather(
+            ops_test.model.integrate(DATABASE_APP_NAME, DATA_INTEGRATOR_APP_NAME),
+            ops_test.model.integrate(SECOND_DATABASE_APP_NAME, SECOND_DATA_INTEGRATOR_APP_NAME),
+            ops_test.model.integrate(THIRD_DATABASE_APP_NAME, THIRD_DATA_INTEGRATOR_APP_NAME),
+            ops_test.model.integrate(
+                f"{DATABASE_APP_NAME}:logical-replication-offer",
+                f"{SECOND_DATABASE_APP_NAME}:logical-replication",
+            ),
+        )
+        await ops_test.model.wait_for_idle(status="active", timeout=500)
+
+
+@markers.juju3
+@pytest.mark.abort_on_fail
+async def test_pg2_publisher_error(ops_test: OpsTest):
+    await _create_test_table(ops_test, SECOND_DATA_INTEGRATOR_APP_NAME)
+
+    pg2_config = DATABASE_APP_CONFIG.copy()
+    pg2_config["logical_replication_subscription_request"] = json.dumps({
+        TESTING_DATABASE: ["public.test_table"]
+    })
+    await ops_test.model.applications[SECOND_DATABASE_APP_NAME].set_config(pg2_config)
+
+    await _wait_for_leader_on_blocked(ops_test, SECOND_DATABASE_APP_NAME)
+
+
+@markers.juju3
+@pytest.mark.abort_on_fail
+async def test_pg3_local_error(ops_test: OpsTest):
+    pg3_config = DATABASE_APP_CONFIG.copy()
+    pg3_config["logical_replication_subscription_request"] = json.dumps({
+        "bad_database": ["bad_format"]
+    })
+    await ops_test.model.applications[THIRD_DATABASE_APP_NAME].set_config(pg3_config)
+    await _wait_for_leader_on_blocked(ops_test, THIRD_DATABASE_APP_NAME)
+
+    await ops_test.model.integrate(
+        f"{DATABASE_APP_NAME}:logical-replication-offer",
+        f"{THIRD_DATABASE_APP_NAME}:logical-replication",
+    )
+    await ops_test.model.applications[THIRD_DATABASE_APP_NAME].set_config(pg3_config)
+    await _wait_for_leader_on_blocked(ops_test, THIRD_DATABASE_APP_NAME)
+
+    pg3_config["logical_replication_subscription_request"] = json.dumps({
+        TESTING_DATABASE: ["public.test_table2"]
+    })
+    await ops_test.model.applications[THIRD_DATABASE_APP_NAME].set_config(pg3_config)
+    await _wait_for_leader_on_blocked(ops_test, THIRD_DATABASE_APP_NAME)
+
+
+@markers.juju3
+@pytest.mark.abort_on_fail
+async def test_resolve_errors(ops_test: OpsTest):
+    await gather(
+        _create_test_table(ops_test, DATA_INTEGRATOR_APP_NAME),
+        _create_test_table(ops_test, DATA_INTEGRATOR_APP_NAME, "test_table2"),
+        _create_test_table(ops_test, THIRD_DATA_INTEGRATOR_APP_NAME, "test_table2"),
+    )
+
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(status="active")
+
+
+@markers.juju3
+@pytest.mark.abort_on_fail
+async def test_replication(ops_test: OpsTest):
+    await gather(
+        _insert_test_data(ops_test, DATA_INTEGRATOR_APP_NAME, "first"),
+        _insert_test_data(ops_test, DATA_INTEGRATOR_APP_NAME, "first", "test_table2"),
+    )
+
+    await gather(
+        _check_test_data(ops_test, SECOND_DATA_INTEGRATOR_APP_NAME, "first"),
+        _check_test_data(ops_test, THIRD_DATA_INTEGRATOR_APP_NAME, "first", "test_table2"),
+    )
+
+
+@markers.juju3
+@pytest.mark.abort_on_fail
+async def test_switchover(ops_test: OpsTest):
+    publisher_leader = await get_leader_unit(ops_test, DATABASE_APP_NAME)
+    publisher_roles = await get_cluster_roles(ops_test, publisher_leader.name)
+    publisher_candidate = ops_test.model.units[publisher_roles["sync_standbys"][0]]
+    action = await publisher_candidate.run_action("promote-to-primary", scope="unit", force=True)
+    await action.wait()
+
+    subscriber_leader = await get_leader_unit(ops_test, SECOND_DATABASE_APP_NAME)
+    subscriber_roles = await get_cluster_roles(ops_test, subscriber_leader.name)
+    subscriber_candidate = ops_test.model.units[subscriber_roles["sync_standbys"][0]]
+    action = await subscriber_candidate.run_action("promote-to-primary", scope="unit", force=True)
+    await action.wait()
+
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(status="active", timeout=500)
+
+
+@markers.juju3
+@pytest.mark.abort_on_fail
+async def test_replication_after_switchover(ops_test: OpsTest):
+    await gather(
+        _insert_test_data(ops_test, DATA_INTEGRATOR_APP_NAME, "second"),
+        _insert_test_data(ops_test, DATA_INTEGRATOR_APP_NAME, "second", "test_table2"),
+    )
+    await gather(
+        _check_test_data(ops_test, SECOND_DATA_INTEGRATOR_APP_NAME, "second"),
+        _check_test_data(ops_test, THIRD_DATA_INTEGRATOR_APP_NAME, "second", "test_table2"),
+    )
+
+
+@markers.juju3
+@pytest.mark.abort_on_fail
+async def test_pg3_extend_subscription(ops_test: OpsTest):
+    await _create_test_table(ops_test, THIRD_DATA_INTEGRATOR_APP_NAME)
+
+    pg3_config = DATABASE_APP_CONFIG.copy()
+    pg3_config["logical_replication_subscription_request"] = json.dumps({
+        TESTING_DATABASE: ["public.test_table", "public.test_table2"]
+    })
+    await ops_test.model.applications[THIRD_DATABASE_APP_NAME].set_config(pg3_config)
+
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(status="active", timeout=500)
+
+    await gather(
+        _check_test_data(ops_test, THIRD_DATA_INTEGRATOR_APP_NAME, "second"),
+        _check_test_data(ops_test, THIRD_DATA_INTEGRATOR_APP_NAME, "second", "test_table2"),
+    )
+
+
+@markers.juju3
+@pytest.mark.abort_on_fail
+async def test_pg2_change_subscription(ops_test: OpsTest):
+    await _create_test_table(ops_test, SECOND_DATA_INTEGRATOR_APP_NAME, "test_table2")
+
+    pg2_config = DATABASE_APP_CONFIG.copy()
+    pg2_config["logical_replication_subscription_request"] = json.dumps({
+        TESTING_DATABASE: ["public.test_table2"]
+    })
+    await ops_test.model.applications[SECOND_DATABASE_APP_NAME].set_config(pg2_config)
+
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(status="active", timeout=500)
+
+    await gather(
+        _check_test_data(
+            ops_test, SECOND_DATA_INTEGRATOR_APP_NAME, "second"
+        ),  # old data will be left behind
+        _check_test_data(ops_test, SECOND_DATA_INTEGRATOR_APP_NAME, "second", "test_table2"),
+    )
+
+
+@markers.juju3
+@pytest.mark.abort_on_fail
+async def test_replication_after_subscriptions_changes(ops_test: OpsTest):
+    await gather(
+        _insert_test_data(ops_test, DATA_INTEGRATOR_APP_NAME, "third"),
+        _insert_test_data(ops_test, DATA_INTEGRATOR_APP_NAME, "third", "test_table2"),
+    )
+    await gather(
+        _check_test_data(ops_test, SECOND_DATA_INTEGRATOR_APP_NAME, "second"),
+        _check_test_data(ops_test, SECOND_DATA_INTEGRATOR_APP_NAME, "third", "test_table2"),
+        _check_test_data(ops_test, THIRD_DATA_INTEGRATOR_APP_NAME, "third"),
+        _check_test_data(ops_test, THIRD_DATA_INTEGRATOR_APP_NAME, "third", "test_table2"),
+    )
+
+
+@markers.juju3
+@pytest.mark.abort_on_fail
+async def test_pg2_dynamic_error(ops_test: OpsTest):
+    pg2_config = DATABASE_APP_CONFIG.copy()
+    pg2_config["logical_replication_subscription_request"] = json.dumps({
+        TESTING_DATABASE: ["public.test_table", "public.test_table2"]
+    })
+    await ops_test.model.applications[SECOND_DATABASE_APP_NAME].set_config(pg2_config)
+    await _wait_for_leader_on_blocked(ops_test, SECOND_DATABASE_APP_NAME)
+
+
+@markers.juju3
+@pytest.mark.abort_on_fail
+async def test_replication_during_dynamic_error(ops_test: OpsTest):
+    await gather(
+        _insert_test_data(ops_test, DATA_INTEGRATOR_APP_NAME, "fourth"),
+        _insert_test_data(ops_test, DATA_INTEGRATOR_APP_NAME, "fourth", "test_table2"),
+    )
+    await gather(
+        _check_test_data(ops_test, SECOND_DATA_INTEGRATOR_APP_NAME, "second"),
+        _check_test_data(ops_test, SECOND_DATA_INTEGRATOR_APP_NAME, "fourth", "test_table2"),
+        _check_test_data(ops_test, THIRD_DATA_INTEGRATOR_APP_NAME, "fourth"),
+        _check_test_data(ops_test, THIRD_DATA_INTEGRATOR_APP_NAME, "fourth", "test_table2"),
+    )
+
+
+@markers.juju3
+@pytest.mark.abort_on_fail
+async def test_pg2_resolve_dynamic_error(ops_test: OpsTest):
+    connection_string = await build_connection_string(
+        ops_test,
+        SECOND_DATA_INTEGRATOR_APP_NAME,
+        DATA_INTEGRATOR_RELATION,
+        database=TESTING_DATABASE,
+    )
+    with (
+        psycopg2.connect(connection_string) as connection,
+        connection.cursor() as cursor,
+    ):
+        cursor.execute("DELETE FROM test_table;")
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(status="active", timeout=500)
+    await _check_test_data(ops_test, SECOND_DATA_INTEGRATOR_APP_NAME, "fourth")
+
+
+@markers.juju3
+@pytest.mark.abort_on_fail
+async def test_pg2_remove(ops_test: OpsTest):
+    await ops_test.model.remove_application(SECOND_DATA_INTEGRATOR_APP_NAME, block_until_done=True)
+    await ops_test.model.remove_application(SECOND_DATABASE_APP_NAME, block_until_done=True)
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(status="active", timeout=1000)
+    connection_string = await build_connection_string(
+        ops_test,
+        DATA_INTEGRATOR_APP_NAME,
+        DATA_INTEGRATOR_RELATION,
+        database=TESTING_DATABASE,
+    )
+    with psycopg2.connect(connection_string) as connection, connection.cursor() as cursor:
+        cursor.execute("SELECT COUNT(1) FROM pg_replication_slots where slot_type='logical';")
+        assert cursor.fetchone()[0] == 1, (
+            "unused replication slot should be removed in the publisher cluster"
+        )
+
+
+@markers.juju3
+@pytest.mark.abort_on_fail
+async def test_replication_after_pg2_removal(ops_test: OpsTest):
+    await gather(
+        _insert_test_data(ops_test, DATA_INTEGRATOR_APP_NAME, "fifth"),
+        _insert_test_data(ops_test, DATA_INTEGRATOR_APP_NAME, "fifth", "test_table2"),
+    )
+    await gather(
+        _check_test_data(ops_test, THIRD_DATA_INTEGRATOR_APP_NAME, "fifth"),
+        _check_test_data(ops_test, THIRD_DATA_INTEGRATOR_APP_NAME, "fifth", "test_table2"),
+    )
+
+
+@markers.juju3
+@pytest.mark.abort_on_fail
+async def test_pg3_remove_relation(ops_test: OpsTest):
+    await ops_test.model.applications[DATABASE_APP_NAME].remove_relation(
+        f"{DATABASE_APP_NAME}:logical-replication-offer",
+        f"{THIRD_DATABASE_APP_NAME}:logical-replication",
+    )
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(status="active", timeout=500)
+    connection_string = await build_connection_string(
+        ops_test,
+        THIRD_DATA_INTEGRATOR_APP_NAME,
+        DATA_INTEGRATOR_RELATION,
+        database=TESTING_DATABASE,
+    )
+    with psycopg2.connect(connection_string) as connection, connection.cursor() as cursor:
+        cursor.execute("SELECT COUNT(1) FROM pg_subscription;")
+        assert cursor.fetchone()[0] == 0, (
+            "unused PostgreSQL subscription should be removed in the subscriber cluster"
+        )
+
+
+async def _wait_for_leader_on_blocked(ops_test: OpsTest, app_name: str) -> None:
+    leader_unit = await get_leader_unit(ops_test, app_name)
+    await ops_test.model.block_until(lambda: leader_unit.workload_status == "blocked")
+
+
+async def _create_test_table(
+    ops_test: OpsTest, data_integrator_app_name: str, table_name: str = "test_table"
+) -> None:
+    with (
+        psycopg2.connect(
+            await build_connection_string(
+                ops_test,
+                data_integrator_app_name,
+                DATA_INTEGRATOR_RELATION,
+                database=TESTING_DATABASE,
+            )
+        ) as connection,
+        connection.cursor() as cursor,
+    ):
+        cursor.execute(f"CREATE TABLE {table_name} (test_column text);")
+
+
+async def _insert_test_data(
+    ops_test: OpsTest, data_integrator_app_name: str, data: str, table_name: str = "test_table"
+) -> None:
+    with (
+        psycopg2.connect(
+            await build_connection_string(
+                ops_test,
+                data_integrator_app_name,
+                DATA_INTEGRATOR_RELATION,
+                database=TESTING_DATABASE,
+            )
+        ) as connection,
+        connection.cursor() as cursor,
+    ):
+        cursor.execute(
+            f"INSERT INTO {table_name} (test_column) VALUES (%s);",
+            (data,),
+        )
+
+
+async def _check_test_data(
+    ops_test: OpsTest, data_integrator_app_name: str, data: str, table_name: str = "test_table"
+) -> bool:
+    with (
+        psycopg2.connect(
+            await build_connection_string(
+                ops_test,
+                data_integrator_app_name,
+                DATA_INTEGRATOR_RELATION,
+                database=TESTING_DATABASE,
+            )
+        ) as connection,
+        connection.cursor() as cursor,
+    ):
+        cursor.execute(
+            f"SELECT EXISTS (SELECT 1 FROM {table_name} WHERE test_column = %s);",
+            (data,),
+        )
+        return cursor.fetchone()[0]

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1456,6 +1456,7 @@ def test_update_config(harness):
         patch(
             "charm.PostgresqlOperatorCharm._handle_postgresql_restart_need"
         ) as _handle_postgresql_restart_need,
+        patch("charm.Patroni.ensure_slots_controller_by_patroni"),
         patch(
             "charm.PostgresqlOperatorCharm._restart_metrics_service"
         ) as _restart_metrics_service,
@@ -1503,6 +1504,7 @@ def test_update_config(harness):
             restore_to_latest=False,
             parameters={"test": "test"},
             user_databases_map={"operator": "all", "replication": "all", "rewind": "all"},
+            slots=None,
         )
         _handle_postgresql_restart_need.assert_called_once()
         _restart_metrics_service.assert_called_once()
@@ -1533,6 +1535,7 @@ def test_update_config(harness):
             restore_to_latest=False,
             parameters={"test": "test"},
             user_databases_map={"operator": "all", "replication": "all", "rewind": "all"},
+            slots=None,
         )
         _handle_postgresql_restart_need.assert_called_once()
         _restart_metrics_service.assert_called_once()


### PR DESCRIPTION
This is an implementation of the Logical Replication specification (On-Review): https://docs.google.com/document/d/1f84Z4cZwUD4q4bJsXTTC_PUaZr7pPB0Q6HnQ9cgCX_o/edit?usp=sharing.

# Basic testing
1. deploy `postgresql` and `postgresql2`
2. deploy two `data-integrator` charms with the `database-name=testdb` config and integrate them with the both of `postgresql` charms
3. establish logical replication relation: `juju integrate postgresql:logical-replication-offer postgresql2:logical-replication`
4. create testing table with data in the `postgresql`: `create table asd (message text); insert into asd values ('hello');`
5. create the same table (but empty) on the `postgresql2` side
6. configure logical replication: `juju config postgresql2 logical_replication_subscription_request='{"testdb": ["public.asd"]}'`
7. check testing table on `postgresql2` side: `select * from asd;`, and observe the data copied from the `postgresql` publisher
8. add another data to the testing table on `postgresql` side and observe it was pushed to the `postgresql2` subscriber