### PR TITLE
fix: add forward slash to source paths

### DIFF
--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -13,82 +13,82 @@
 # redirect/from/file/ redirect/to/file/
 
 # Tutorials
-t-set-up tutorial/
-t-deploy tutorial/
-t-access tutorial/
-t-scale tutorial/
-t-manage-passwords tutorial/
-t-integrate tutorial/
-t-enable-tls tutorial/
-t-clean-up tutorial/
+t-set-up/ tutorial/
+t-deploy/ tutorial/
+t-access/ tutorial/
+t-scale/ tutorial/
+t-manage-passwords/ tutorial/
+t-integrate/ tutorial/
+t-enable-tls/ tutorial/
+t-clean-up/ tutorial/
 
 # How-to guides
-h-deploy how-to/deploy
-h-deploy-canonical-k8s how-to/deploy/canonical-k8s
-h-deploy-gke how-to/deploy/gke
-h-deploy-eks how-to/deploy/eks
-h-deploy-aks how-to/deploy/aks
-h-deploy-multi-az how-to/deploy/multi-az
-h-deploy-terraform how-to/deploy/terraform
-h-deploy-airgapped how-to/deploy/air-gapped
+h-deploy/ how-to/deploy
+h-deploy-canonical-k8s/ how-to/deploy/canonical-k8s
+h-deploy-gke/ how-to/deploy/gke
+h-deploy-eks/ how-to/deploy/eks
+h-deploy-aks/ how-to/deploy/aks
+h-deploy-multi-az/ how-to/deploy/multi-az
+h-deploy-terraform/ how-to/deploy/terraform
+h-deploy-airgapped/ how-to/deploy/air-gapped
 
-h-integrate how-to/integrate-with-another-application
-h-manage-passwords how-to/manage-passwords
-h-external-access how-to/external-network-access
-h-scale how-to/scale-replicas
-h-enable-tls how-to/enable-tls
-h-enable-ldap how-to/enable-ldap
+h-integrate/ how-to/integrate-with-another-application
+h-manage-passwords/ how-to/manage-passwords
+h-external-access/ how-to/external-network-access
+h-scale/ how-to/scale-replicas
+h-enable-tls/ how-to/enable-tls
+h-enable-ldap/ how-to/enable-ldap
 
-h-enable-plugins-extensions how-to/enable-plugins-extensions
+h-enable-plugins-extensions/ how-to/enable-plugins-extensions
 
-h-backup how-to/back-up-and-restore/
-h-configure-s3-aws how-to/back-up-and-restore/configure-s3-aws
-h-configure-s3-radosgw how-to/back-up-and-restore/configure-s3-radosgw
-h-create-backup how-to/back-up-and-restore/create-a-backup
-h-restore-backup how-to/back-up-and-restore/restore-a-backup
-h-manage-backup-retention how-to/back-up-and-restore/manage-backup-retention
-h-migrate-cluster how-to/back-up-and-restore/migrate-a-cluster
+h-backup/ how-to/back-up-and-restore/
+h-configure-s3-aws/ how-to/back-up-and-restore/configure-s3-aws
+h-configure-s3-radosgw/ how-to/back-up-and-restore/configure-s3-radosgw
+h-create-backup/ how-to/back-up-and-restore/create-a-backup
+h-restore-backup/ how-to/back-up-and-restore/restore-a-backup
+h-manage-backup-retention/ how-to/back-up-and-restore/manage-backup-retention
+h-migrate-cluster/ how-to/back-up-and-restore/migrate-a-cluster
 
-h-monitor how-to/monitoring-cos/
-h-enable-monitoring how-to/monitoring-cos/enable-monitoring
-h-enable-alert-rules how-to/monitoring-cos/enable-alert-rules
-h-enable-tracing how-to/monitoring-cos/enable-tracing
+h-monitor/ how-to/monitoring-cos/
+h-enable-monitoring/ how-to/monitoring-cos/enable-monitoring
+h-enable-alert-rules/ how-to/monitoring-cos/enable-alert-rules
+h-enable-tracing/ how-to/monitoring-cos/enable-tracing
 
-h-upgrade how-to/upgrade/
-h-upgrade-minor how-to/upgrade/perform-a-minor-upgrade
-h-rollback-minor how-to/upgrade/perform-a-minor-rollback
+h-upgrade/ how-to/upgrade/
+h-upgrade-minor/ how-to/upgrade/perform-a-minor-upgrade
+h-rollback-minor/ how-to/upgrade/perform-a-minor-rollback
 
-h-async how-to/cross-regional-async-replication/
-h-async-set-up how-to/cross-regional-async-replication/set-up-clusters
-h-async-integrate how-to/cross-regional-async-replication/integrate-with-a-client-app
-h-async-remove-recover how-to/cross-regional-async-replication/remove-or-recover-a-cluster
+h-async/ how-to/cross-regional-async-replication/
+h-async-set-up/ how-to/cross-regional-async-replication/set-up-clusters
+h-async-integrate/ how-to/cross-regional-async-replication/integrate-with-a-client-app
+h-async-remove-recover/ how-to/cross-regional-async-replication/remove-or-recover-a-cluster
 
-h-development how-to/development/
-h-development-integrate how-to/development/integrate-with-your-charm
-h-migrate-pgdump how-to/development/migrate-data-via-pg-dump
-h-migrate-backup-restore how-to/development/migrate-data-via-backup-restore
+h-development/ how-to/development/
+h-development-integrate/ how-to/development/integrate-with-your-charm
+h-migrate-pgdump/ how-to/development/migrate-data-via-pg-dump
+h-migrate-backup-restore/ how-to/development/migrate-data-via-backup-restore
 
 # Reference
-r-releases reference/releases
-r-system-requirements reference/system-requirements
-r-software-testing reference/software-testing
-r-performance reference/performance-and-resources
+r-releases/ reference/releases
+r-system-requirements/ reference/system-requirements
+r-software-testing/ reference/software-testing
+r-performance/ reference/performance-and-resources
 
-r-troubleshooting reference/troubleshooting/
+r-troubleshooting/ reference/troubleshooting/
 
-r-plugins-extensions reference/plugins-extensions
-r-alert-rules reference/alert-rules
-r-statuses reference/statuses
-r-contacts reference/contacts
+r-plugins-extensions/ reference/plugins-extensions
+r-alert-rules/ reference/alert-rules
+r-statuses/ reference/statuses
+r-contacts/ reference/contacts
 
 # Explanation
-e-architecture explanation/architecture
-e-interfaces-endpoints explanation/interfaces-and-endpoints
-e-juju-details explanation/juju
-e-legacy-charm explanation/legacy-charm
-e-users explanation/users
-e-logs explanation/logs
-e-connection-pooling explanation/connection-pooling
+e-architecture/ explanation/architecture
+e-interfaces-endpoints/ explanation/interfaces-and-endpoints
+e-juju-details/ explanation/juju
+e-legacy-charm/ explanation/legacy-charm
+e-users/ explanation/users
+e-logs/ explanation/logs
+e-connection-pooling/ explanation/connection-pooling
 
-e-security explanation/security/
-e-cryptography explanation/security/cryptography
+e-security/ explanation/security/
+e-cryptography/ explanation/security/cryptography


### PR DESCRIPTION
## Issue
Redirects configured in `redirects.txt` do not take effect when built on on RTD, despite a successful build with no errors.

I believe this has to do with how either RTD or the Sphinx builder recognizes files in the HTML output. Since the source paths did not have a forward slash, it did not generate `index.html` files for them.
 
## Solution
Added a forward slash to all source paths.

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
