### PR TITLE
Add optional flags to provides endpoints

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -51,13 +51,10 @@ provides:
     optional: true
   database:
     interface: postgresql_client
-    optional: true
   db:
     interface: pgsql
-    optional: true
   db-admin:
     interface: pgsql
-    optional: true
   metrics-endpoint:
     interface: prometheus_scrape
     optional: true

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -51,14 +51,19 @@ provides:
     optional: true
   database:
     interface: postgresql_client
+    optional: true
   db:
     interface: pgsql
+    optional: true
   db-admin:
     interface: pgsql
+    optional: true
   metrics-endpoint:
     interface: prometheus_scrape
+    optional: true
   grafana-dashboard:
     interface: grafana_dashboard
+    optional: true
 
 requires:
   replication:


### PR DESCRIPTION
Filed by @canonical/solutions-qa 

## Issue

Since provides endpoints can be non-optional, can the default value of `optional` is [false](https://canonical-charmcraft.readthedocs-hosted.com/stable/reference/files/charmcraft-yaml-file/#endpoint-role-endpoint-name-optional), these endpoints are assumed non-optional.

## Solution

Set `optional` flag on provides endpoints to indicate correct optionality.

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
