### PR TITLE
[DPE-7549] Add compression and restore max-process

### DIFF
--- a/src/backups.py
+++ b/src/backups.py
@@ -1200,6 +1200,7 @@ Stderr:
             storage_path=self.charm._storage_path,
             user=BACKUP_USER,
             retention_full=s3_parameters["delete-older-than-days"],
+            process_max=max(os.cpu_count() - 2, 1),
         )
         # Delete the original file and render the one with the right info.
         filename = "/etc/pgbackrest.conf"

--- a/templates/pgbackrest.conf.j2
+++ b/templates/pgbackrest.conf.j2
@@ -1,5 +1,6 @@
 [global]
 backup-standby=y
+compress-type=zst
 repo1-retention-full-type=time
 repo1-retention-full={{ retention_full }}
 repo1-retention-history=365
@@ -43,3 +44,6 @@ pg{{ ns.count }}-user={{ user }}
 {% set ns.count = ns.count + 1 %}
 {%- endfor %}
 {%- endif %}
+
+[global:restore]
+process-max={{process_max}}

--- a/tests/unit/test_backups.py
+++ b/tests/unit/test_backups.py
@@ -1,6 +1,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 import datetime
+from os import cpu_count
 from unittest.mock import MagicMock, PropertyMock, call, mock_open, patch
 
 import pytest
@@ -1812,6 +1813,7 @@ def test_render_pgbackrest_conf_file(harness, tls_ca_chain_filename):
             storage_path=harness.charm._storage_path,
             user="backup",
             retention_full=30,
+            process_max=max(cpu_count() - 2, 1),
         )
 
         # Patch the `open` method with our mock.


### PR DESCRIPTION
Backport of https://github.com/canonical/postgresql-operator/pull/983:

* Change the default compression algorithm
* Increase processes when restoring backup

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
