### PR TITLE
[MISC] Set Pgbackrest spool dir to archive mount

### DIFF
--- a/src/backups.py
+++ b/src/backups.py
@@ -31,6 +31,7 @@ from constants import (
     BACKUP_TYPE_OVERRIDES,
     BACKUP_USER,
     PGBACKREST_LOGROTATE_FILE,
+    POSTGRESQL_ARCHIVE_PATH,
     WORKLOAD_OS_GROUP,
     WORKLOAD_OS_USER,
 )
@@ -1184,6 +1185,7 @@ Stderr:
         # Open the template pgbackrest.conf file.
         with open("templates/pgbackrest.conf.j2") as file:
             template = Template(file.read())
+        cpu_count, _ = self.charm.get_available_resources()
         # Render the template file with the correct values.
         rendered = template.render(
             enable_tls=self.charm.is_tls_enabled and len(self.charm.peer_members_endpoints) > 0,
@@ -1200,7 +1202,8 @@ Stderr:
             storage_path=self.charm._storage_path,
             user=BACKUP_USER,
             retention_full=s3_parameters["delete-older-than-days"],
-            process_max=max(os.cpu_count() - 2, 1),
+            process_max=max(cpu_count - 2, 1),
+            archive_path=POSTGRESQL_ARCHIVE_PATH,
         )
         # Delete the original file and render the one with the right info.
         filename = "/etc/pgbackrest.conf"

--- a/src/constants.py
+++ b/src/constants.py
@@ -19,6 +19,7 @@ WORKLOAD_OS_USER = "postgres"
 METRICS_PORT = "9187"
 POSTGRESQL_DATA_PATH = "/var/lib/postgresql/data/pgdata"
 POSTGRESQL_LOGS_PATH = "/var/log/postgresql"
+POSTGRESQL_ARCHIVE_PATH = "/var/lib/postgresql/archive"
 POSTGRESQL_LOGS_PATTERN = "postgresql*.log"
 POSTGRES_LOG_FILES = [
     "/var/log/pgbackrest/*",

--- a/templates/pgbackrest.conf.j2
+++ b/templates/pgbackrest.conf.j2
@@ -1,6 +1,7 @@
 [global]
 backup-standby=y
 compress-type=zst
+spool-path={{ archive_path }}
 repo1-retention-full-type=time
 repo1-retention-full={{ retention_full }}
 repo1-retention-history=365


### PR DESCRIPTION
Set spool path in Pgbackrest config to use the archive volume when restoring

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
