### PR TITLE
DPE-6901 Replace md5 with scram-sha-256 in patroni/pg_hba.conf

### DIFF
--- a/src/patroni.py
+++ b/src/patroni.py
@@ -616,6 +616,7 @@ class Patroni:
             patroni_password=self._patroni_password,
             user_databases_map=user_databases_map,
             slots=slots,
+            instance_password_encryption=self._charm.config.instance_password_encryption,
         )
         self._render_file(f"{self._storage_path}/patroni.yml", rendered, 0o644)
 

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -77,17 +77,17 @@ bootstrap:
       create_replica_methods: ["basebackup"]
   {% else %}
   initdb:
-  - auth-host: md5
+  - auth-host: scram-sha-256
   - auth-local: trust
   - encoding: UTF8
   - data-checksums
   - waldir: /var/lib/postgresql/logs
   {%- endif %}
   pg_hba:
-  - {{ 'hostssl' if enable_tls else 'host' }} all all 0.0.0.0/0 md5
-  - {{ 'hostssl' if enable_tls else 'host' }} replication replication 127.0.0.1/32 md5
+  - {{ 'hostssl' if enable_tls else 'host' }} all all 0.0.0.0/0 {{ instance_password_encryption }}
+  - {{ 'hostssl' if enable_tls else 'host' }} replication replication 127.0.0.1/32 scram-sha-256
   {%- for endpoint in extra_replication_endpoints %}
-  - {{ 'hostssl' if enable_tls else 'host' }} replication replication {{ endpoint }}/32 md5
+  - {{ 'hostssl' if enable_tls else 'host' }} replication replication {{ endpoint }}/32 scram-sha-256
   {%- endfor %}
 bypass_api_service: true
 log:
@@ -147,27 +147,31 @@ postgresql:
   - local all backup peer map=operator
   - local all monitoring password
   {%- if not connectivity %}
-  - {{ 'hostssl' if enable_tls else 'host' }} all all {{ endpoint }}.{{ namespace }}.svc.cluster.local md5
+  - {{ 'hostssl' if enable_tls else 'host' }} all all {{ endpoint }}.{{ namespace }}.svc.cluster.local {{ instance_password_encryption }}
   - {{ 'hostssl' if enable_tls else 'host' }} all all 0.0.0.0/0 reject
   {%- elif enable_ldap %}
   - {{ 'hostssl' if enable_tls else 'host' }} all +identity_access 0.0.0.0/0 ldap {{ ldap_parameters }}
-  - {{ 'hostssl' if enable_tls else 'host' }} all +internal_access 0.0.0.0/0 md5
-  {%- for user, databases in user_databases_map.items() %}
-  - {{ 'hostssl' if enable_tls else 'host' }} {{ databases }} {{ user }} 0.0.0.0/0 md5
-  {%- endfor %}
+  - {{ 'hostssl' if enable_tls else 'host' }} all +internal_access 0.0.0.0/0 {{ instance_password_encryption }}
+  {%-   for user, databases in user_databases_map.items() %}
+  - {{ 'hostssl' if enable_tls else 'host' }} {{ databases }} {{ user }} 0.0.0.0/0 {{ instance_password_encryption }}
+  {%-   endfor %}
   {%- else %}
-  - {{ 'hostssl' if enable_tls else 'host' }} all +internal_access 0.0.0.0/0 md5
-  {%- for user, databases in user_databases_map.items() %}
+  - {{ 'hostssl' if enable_tls else 'host' }} all +internal_access 0.0.0.0/0 {{ instance_password_encryption }}
+  {%-   for user, databases in user_databases_map.items() %}
+  {%-     if 'pgbouncer_auth_relation_' in user %}
   - {{ 'hostssl' if enable_tls else 'host' }} {{ databases }} {{ user }} 0.0.0.0/0 md5
-  {%- endfor %}
+  {%-     else %}
+  - {{ 'hostssl' if enable_tls else 'host' }} {{ databases }} {{ user }} 0.0.0.0/0 {{ instance_password_encryption }}
+  {%-     endif %}
+  {%-   endfor %}
   {%- endif %}
-  - {{ 'hostssl' if enable_tls else 'host' }} replication replication 127.0.0.1/32 md5
-  - {{ 'hostssl' if enable_tls else 'host' }} replication replication 127.0.0.6/32 md5
+  - {{ 'hostssl' if enable_tls else 'host' }} replication replication 127.0.0.1/32 scram-sha-256
+  - {{ 'hostssl' if enable_tls else 'host' }} replication replication 127.0.0.6/32 scram-sha-256
   {%- for endpoint in extra_replication_endpoints %}
-  - {{ 'hostssl' if enable_tls else 'host' }} replication replication {{ endpoint }}/32 md5
+  - {{ 'hostssl' if enable_tls else 'host' }} replication replication {{ endpoint }}/32 scram-sha-256
   {%- endfor %}
   {%- for endpoint in endpoints %}
-  - {{ 'hostssl' if enable_tls else 'host' }} replication replication {{ endpoint }}.{{ namespace }}.svc.cluster.local md5
+  - {{ 'hostssl' if enable_tls else 'host' }} replication replication {{ endpoint }}.{{ namespace }}.svc.cluster.local scram-sha-256
   {%- endfor %}
   pg_ident:
   - operator postgres backup

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -47,6 +47,9 @@ async def test_config_parameters(ops_test: OpsTest, charm) -> None:
         {
             "instance_password_encryption": [test_string, "scram-sha-256"]
         },  # config option is one of `md5` or `scram-sha-256`
+        {
+            "instance_password_encryption": [test_string, "md5"]
+        },  # config option is one of `md5` or `scram-sha-256`
         {"logging_client_min_messages": [test_string, "notice"]},
         # config option is one of 'debug5', 'debug4', 'debug3', 'debug2', 'debug1', 'log', 'notice', 'warning' or 'error'.
         {

--- a/tests/unit/test_patroni.py
+++ b/tests/unit/test_patroni.py
@@ -235,6 +235,7 @@ def test_render_patroni_yml_file(harness, patroni):
             synchronous_node_count=0,
             version="16",
             patroni_password=patroni._patroni_password,
+            instance_password_encryption="scram-sha-256",
         )
 
         # Setup a mock for the `open` method, set returned data to postgresql.conf template.
@@ -270,6 +271,7 @@ def test_render_patroni_yml_file(harness, patroni):
             synchronous_node_count=0,
             version="16",
             patroni_password=patroni._patroni_password,
+            instance_password_encryption="scram-sha-256",
         )
         assert expected_content_with_tls != expected_content
 


### PR DESCRIPTION
## Issue

Charmed PG16 has migrated to scram-sha-256 by default, but there are still md5 leftovers.

## Solution

Insist on scram-sha-256 in Patroni config unless user configured to use md5 in charm config.
Keep pgbouncer_auth_relation_% users in md5.

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
