### PR TITLE
Update Charmhub home page (16)

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -3,10 +3,17 @@
 
 name: postgresql-k8s
 display-name: Charmed PostgreSQL K8s
-summary: Charmed PostgreSQL K8s operator
+summary: Charmed PostgreSQL 16 for Kubernetes
 description: |
-  Charm to operate the PostgreSQL database on Kubernetes clusters
-docs: https://discourse.charmhub.io/t/charmed-postgresql-k8s-documenation/9307
+   PostgreSQL is an open-source relational database management system
+   built to handle a wide range of workloads. This charmed operator deploys 
+   and operates PostgreSQL on Kubernetes.
+
+   For deployment on virtual machines, see [Charmed PostgreSQL VM](https://charmhub.io/postgresql).
+
+   To learn more about how to deploy and manage this charm, see the 
+   [official documentation](https://canonical-charmed-postgresql-k8s.readthedocs-hosted.com/16/).
+docs: https://canonical-charmed-postgresql-k8s.readthedocs-hosted.com/16/
 source: https://github.com/canonical/postgresql-k8s-operator
 issues: https://github.com/canonical/postgresql-k8s-operator/issues
 website:


### PR DESCRIPTION
This PR updates the `metadata.yaml` for PostgreSQL 16 releases on Charmhub in order to version the home page with the docs.

It addresses issue https://github.com/canonical/postgresql-operator/issues/1082

## Changes
* Replaced `docs:` link with new RTD docs - this [new Charmhub feature](https://github.com/canonical/charmhub.io/pull/2159) will create a dedicated button in the sidebar.
* Updated `summary:` and `description:` keys, since they will be the new title and content of the Charmhub home page.
* Removed old broken link to `chat.charmhub.io`

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.