### PR TITLE
[MISC] Early set of read-only-endpoints

### DIFF
--- a/src/relations/postgresql_provider.py
+++ b/src/relations/postgresql_provider.py
@@ -264,10 +264,11 @@ class PostgreSQLProvider(Object):
                         relation.id, "password"
                     )
 
-                self.database_provides.set_read_only_uris(
-                    relation.id,
-                    f"postgresql://{user}:{password}@{endpoints}/{database}",
-                )
+                if user and password:
+                    self.database_provides.set_read_only_uris(
+                        relation.id,
+                        f"postgresql://{user}:{password}@{endpoints}/{database}",
+                    )
             # Reset the creds for the next iteration
             user = None
             password = None


### PR DESCRIPTION
## Issue
Setting `read-only-uri` before username generation will trigger a database created event in the client before the database is actually created

## Solution
Only set the uri if credentials are set

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
