### PR TITLE
Use Patroni API for is_restart_pending()

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -94,7 +94,7 @@ from ops.pebble import (
     ServiceStatus,
 )
 from requests import ConnectionError as RequestsConnectionError
-from tenacity import RetryError, Retrying, stop_after_attempt, stop_after_delay, wait_fixed
+from tenacity import RetryError, Retrying, stop_after_delay, wait_fixed
 
 from backups import CANNOT_RESTORE_PITR, S3_BLOCK_MESSAGES, PostgreSQLBackups
 from config import CharmConfig
@@ -2237,18 +2237,11 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             self._patroni.reload_patroni_configuration()
         except Exception as e:
             logger.error(f"Reload patroni call failed! error: {e!s}")
-        # Wait for some more time than the Patroni's loop_wait default value (10 seconds),
-        # which tells how much time Patroni will wait before checking the configuration
-        # file again to reload it.
-        try:
-            for attempt in Retrying(stop=stop_after_attempt(5), wait=wait_fixed(3)):
-                with attempt:
-                    restart_postgresql = restart_postgresql or self.postgresql.is_restart_pending()
-                    if not restart_postgresql:
-                        raise Exception
-        except RetryError:
-            # Ignore the error, as it happens only to indicate that the configuration has not changed.
-            pass
+
+        restart_pending = self._patroni.is_restart_pending()
+        logger.debug(f"Checking if restart pending: {restart_postgresql} or {restart_pending}")
+        restart_postgresql = restart_postgresql or restart_pending
+
         self.unit_peer_data.update({"tls": "enabled" if self.is_tls_enabled else ""})
         self.postgresql_client_relation.update_tls_flag("True" if self.is_tls_enabled else "False")
 

--- a/src/patroni.py
+++ b/src/patroni.py
@@ -364,6 +364,23 @@ class Patroni:
         logger.debug("replication is healthy")
         return True
 
+    def is_restart_pending(self) -> bool:
+        """Returns whether the Patroni/PostgreSQL restart pending."""
+        patroni_status = requests.get(
+            f"{self._patroni_url}/patroni",
+            verify=self._verify,
+            timeout=PATRONI_TIMEOUT,
+            auth=self._patroni_auth,
+        )
+        try:
+            pending_restart = patroni_status.json()["pending_restart"]
+        except KeyError:
+            pending_restart = False
+            pass
+        logger.debug(f"Patroni API is_restart_pending: {pending_restart}")
+
+        return pending_restart
+
     @property
     def primary_endpoint_ready(self) -> bool:
         """Is the primary endpoint redirecting connections to the primary pod.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1590,20 +1590,19 @@ def test_handle_postgresql_restart_need(harness):
 
             _is_tls_enabled.return_value = values[0]
             postgresql_mock.is_tls_enabled = PropertyMock(return_value=values[1])
-            postgresql_mock.is_restart_pending = PropertyMock(return_value=values[2])
-
-            harness.charm._handle_postgresql_restart_need()
-            _reload_patroni_configuration.assert_called_once()
-            if values[0]:
-                assert "tls" in harness.get_relation_data(rel_id, harness.charm.unit)
-            else:
-                assert "tls" not in harness.get_relation_data(rel_id, harness.charm.unit)
-            if (values[0] != values[1]) or values[2]:
-                _generate_metrics_jobs.assert_called_once_with(values[0])
-                _restart.assert_called_once()
-            else:
-                _generate_metrics_jobs.assert_not_called()
-                _restart.assert_not_called()
+            with patch("charm.Patroni.is_restart_pending", return_value=values[2]):
+                harness.charm._handle_postgresql_restart_need()
+                _reload_patroni_configuration.assert_called_once()
+                if values[0]:
+                    assert "tls" in harness.get_relation_data(rel_id, harness.charm.unit)
+                else:
+                    assert "tls" not in harness.get_relation_data(rel_id, harness.charm.unit)
+                if (values[0] != values[1]) or values[2]:
+                    _generate_metrics_jobs.assert_called_once_with(values[0])
+                    _restart.assert_called_once()
+                else:
+                    _generate_metrics_jobs.assert_not_called()
+                    _restart.assert_not_called()
 
 
 def test_set_active_status(harness):


### PR DESCRIPTION
The previous is_restart_pending() waited for long due to the Patroni's loop_wait default value (10 seconds), which tells how much time Patroni will wait before checking the configuration file again to reload it.

Instead of checking PostgreSQL pending_restart from pg_settings, let's check Patroni API pending_restart=True flag.

## Issue

## Solution

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
