### PR TITLE
[DPE-8005] Handle empty region

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -84,10 +84,10 @@ jobs:
     needs:
       - collect-integration-tests
     runs-on: ${{ matrix.job.runner }}
-    timeout-minutes: 217  # Sum of steps `timeout-minutes` + 5
+    timeout-minutes: 226  # Sum of steps `timeout-minutes` + 5
     steps:
       - name: Free up disk space
-        timeout-minutes: 1
+        timeout-minutes: 10
         run: |
           printf '\nDisk usage before cleanup\n'
           df --human-readable

--- a/templates/pgbackrest.conf.j2
+++ b/templates/pgbackrest.conf.j2
@@ -6,7 +6,11 @@ repo1-retention-full={{ retention_full }}
 repo1-retention-history=365
 repo1-type=s3
 repo1-path={{ path }}
+{%- if region %}
 repo1-s3-region={{ region }}
+{% else %}
+repo1-s3-region=""
+{%- endif %}
 repo1-s3-endpoint={{ endpoint }}
 repo1-s3-bucket={{ bucket }}
 repo1-s3-uri-style={{ s3_uri_style }}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -42,7 +42,7 @@ def get_cloud_config(cloud: str) -> tuple[dict[str, str], dict[str, str]]:
             "endpoint": "https://storage.googleapis.com",
             "bucket": "data-charms-testing",
             "path": f"/postgresql-k8s/{uuid.uuid1()}",
-            "region": "",
+            "region": "us-east-1",
         }, {
             "access-key": os.environ["GCP_ACCESS_KEY"],
             "secret-key": os.environ["GCP_SECRET_KEY"],

--- a/tests/integration/test_backups_ceph.py
+++ b/tests/integration/test_backups_ceph.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+import dataclasses
+import json
+import logging
+import os
+import socket
+import subprocess
+import time
+
+import boto3
+import botocore.exceptions
+import pytest
+from pytest_operator.plugin import OpsTest
+
+from .helpers import (
+    backup_operations,
+)
+from .juju_ import juju_major_version
+
+logger = logging.getLogger(__name__)
+
+S3_INTEGRATOR_APP_NAME = "s3-integrator"
+if juju_major_version < 3:
+    tls_certificates_app_name = "tls-certificates-operator"
+    tls_channel = "legacy/stable"
+    tls_config = {"generate-self-signed-certificates": "true", "ca-common-name": "Test CA"}
+else:
+    tls_certificates_app_name = "self-signed-certificates"
+    tls_channel = "latest/stable"
+    tls_config = {"ca-common-name": "Test CA"}
+
+backup_id, value_before_backup, value_after_backup = "", None, None
+
+
+@dataclasses.dataclass(frozen=True)
+class ConnectionInformation:
+    access_key_id: str
+    secret_access_key: str
+    bucket: str
+
+
+@pytest.fixture(scope="session")
+def microceph():
+    if not os.environ.get("CI") == "true":
+        raise Exception("Not running on CI. Skipping microceph installation")
+    logger.info("Setting up TLS certificates")
+    subprocess.run(["openssl", "genrsa", "-out", "./ca.key", "2048"], check=True)
+    subprocess.run(
+        [
+            "openssl",
+            "req",
+            "-x509",
+            "-new",
+            "-nodes",
+            "-key",
+            "./ca.key",
+            "-days",
+            "1024",
+            "-out",
+            "./ca.crt",
+            "-outform",
+            "PEM",
+            "-subj",
+            "/C=US/ST=Denial/L=Springfield/O=Dis/CN=www.example.com",
+        ],
+        check=True,
+    )
+    subprocess.run(["openssl", "genrsa", "-out", "./server.key", "2048"], check=True)
+    subprocess.run(
+        [
+            "openssl",
+            "req",
+            "-new",
+            "-key",
+            "./server.key",
+            "-out",
+            "./server.csr",
+            "-subj",
+            "/C=US/ST=Denial/L=Springfield/O=Dis/CN=www.example.com",
+        ],
+        check=True,
+    )
+    host_ip = socket.gethostbyname(socket.gethostname())
+    subprocess.run(
+        f'echo "subjectAltName = IP:{host_ip}" > ./extfile.cnf',
+        shell=True,
+        check=True,
+    )
+    subprocess.run(
+        [
+            "openssl",
+            "x509",
+            "-req",
+            "-in",
+            "./server.csr",
+            "-CA",
+            "./ca.crt",
+            "-CAkey",
+            "./ca.key",
+            "-CAcreateserial",
+            "-out",
+            "./server.crt",
+            "-days",
+            "365",
+            "-extfile",
+            "./extfile.cnf",
+        ],
+        check=True,
+    )
+
+    logger.info("Setting up microceph")
+    subprocess.run(
+        ["sudo", "snap", "install", "microceph", "--channel", "squid/stable"], check=True
+    )
+    subprocess.run(["sudo", "microceph", "cluster", "bootstrap"], check=True)
+    subprocess.run(["sudo", "microceph", "disk", "add", "loop,1G,3"], check=True)
+    subprocess.run(
+        'sudo microceph enable rgw --ssl-certificate="$(sudo base64 -w0 ./server.crt)" --ssl-private-key="$(sudo base64 -w0 ./server.key)"',
+        shell=True,
+        check=True,
+    )
+    output = subprocess.run(
+        [
+            "sudo",
+            "microceph.radosgw-admin",
+            "user",
+            "create",
+            "--uid",
+            "test",
+            "--display-name",
+            "test",
+        ],
+        capture_output=True,
+        check=True,
+        encoding="utf-8",
+    ).stdout
+    key = json.loads(output)["keys"][0]
+    key_id = key["access_key"]
+    secret_key = key["secret_key"]
+    logger.info("Creating microceph bucket")
+    for attempt in range(3):
+        try:
+            boto3.client(
+                "s3",
+                endpoint_url=f"https://{host_ip}",
+                aws_access_key_id=key_id,
+                aws_secret_access_key=secret_key,
+                verify="./ca.crt",
+            ).create_bucket(Bucket=_BUCKET)
+        except botocore.exceptions.EndpointConnectionError:
+            if attempt == 2:
+                raise
+            # microceph is not ready yet
+            logger.info("Unable to connect to microceph via S3. Retrying")
+            time.sleep(1)
+        else:
+            break
+    logger.info("Set up microceph")
+    return ConnectionInformation(key_id, secret_key, _BUCKET)
+
+
+_BUCKET = "testbucket"
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="session")
+def cloud_credentials(microceph: ConnectionInformation) -> dict[str, str]:
+    """Read cloud credentials."""
+    return {
+        "access-key": microceph.access_key_id,
+        "secret-key": microceph.secret_access_key,
+    }
+
+
+@pytest.fixture(scope="session")
+def cloud_configs(microceph: ConnectionInformation):
+    host_ip = socket.gethostbyname(socket.gethostname())
+    result = subprocess.run(
+        "sudo base64 -w0 ./ca.crt", shell=True, check=True, stdout=subprocess.PIPE, text=True
+    )
+    base64_output = result.stdout
+    return {
+        "endpoint": f"https://{host_ip}",
+        "bucket": microceph.bucket,
+        "path": "/pg",
+        "region": "",
+        "s3-uri-style": "path",
+        "tls-ca-chain": f"{base64_output}",
+    }
+
+
+async def test_backup_ceph(ops_test: OpsTest, cloud_configs, cloud_credentials, charm) -> None:
+    """Build and deploy two units of PostgreSQL in microceph, test backup and restore actions."""
+    await backup_operations(
+        ops_test,
+        charm,
+        S3_INTEGRATOR_APP_NAME,
+        tls_certificates_app_name,
+        tls_config,
+        tls_channel,
+        cloud_credentials,
+        "ceph",
+        cloud_configs,
+    )

--- a/tests/spread/test_backups_ceph.py/task.yaml
+++ b/tests/spread/test_backups_ceph.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_backups_ceph.py
+environment:
+  TEST_MODULE: test_backups_ceph.py
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/unit/test_backups.py
+++ b/tests/unit/test_backups.py
@@ -331,7 +331,7 @@ def test_create_bucket_if_not_exists(harness, tls_ca_chain_filename):
             new_callable=PropertyMock(return_value=tls_ca_chain_filename),
         ) as _tls_ca_chain_filename,
         patch("charm.PostgreSQLBackups._retrieve_s3_parameters") as _retrieve_s3_parameters,
-        patch("backups.botocore.client.Config") as _config,
+        patch("backups.Config") as _config,
     ):
         # Test when there are missing S3 parameters.
         _retrieve_s3_parameters.return_value = ([], ["bucket", "access-key", "secret-key"])
@@ -1891,7 +1891,6 @@ def test_retrieve_s3_parameters(
                 "delete-older-than-days": "9999999",
                 "endpoint": "https://s3.amazonaws.com",
                 "path": "/",
-                "region": None,
                 "s3-uri-style": "host",
                 "secret-key": "test-secret-key",
             },
@@ -2014,8 +2013,8 @@ def test_upload_content_to_s3(harness, tls_ca_chain_filename):
     with (
         patch("tempfile.NamedTemporaryFile") as _named_temporary_file,
         patch("charm.PostgreSQLBackups._construct_endpoint") as _construct_endpoint,
-        patch("boto3.session.Session.resource") as _resource,
-        patch("backups.botocore.client.Config") as _config,
+        patch("backups.Session.resource") as _resource,
+        patch("backups.Config") as _config,
         patch(
             "charm.PostgreSQLBackups._tls_ca_chain_filename",
             new_callable=PropertyMock(return_value=tls_ca_chain_filename),


### PR DESCRIPTION
Port of https://github.com/canonical/postgresql-operator/pull/1117, https://github.com/canonical/postgresql-operator/pull/1149 and https://github.com/canonical/postgresql-operator/pull/1154 for 16/edge k8s:

* Handle empty region when creating backups
* Handle invalid stanza name in Pgbackrest output (happens when no region is set in GCP) to block as failure to initialise stanza and not as foreign backup
* Add ceph test

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
