### PR TITLE
[DPE-8318] Predefined roles docs

### DIFF
--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -10,6 +10,7 @@ Additional context about key concepts behind the PostgreSQL charm, including des
 
 ## Operational concepts
 * [Users]
+* [Roles]
 * [Logs]
 * [Connection pooling]
 
@@ -28,6 +29,7 @@ Charm event flowcharts:
 [Architecture]: /explanation/architecture
 [Interfaces and endpoints]: /explanation/interfaces-and-endpoints
 [Users]: /explanation/users
+[/Roles]: /explanation/roles
 [Logs]: /explanation/logs
 [Juju]: /explanation/juju
 [Legacy charm]: /explanation/legacy-charm

--- a/docs/explanation/legacy-charm.md
+++ b/docs/explanation/legacy-charm.md
@@ -2,8 +2,8 @@
 
 There are [two types of charms](https://documentation.ubuntu.com/juju/3.6/reference/charm/#by-generation) stored under the same charm name `postgresql-k8s`:
 
-1. [Reactive](https://documentation.ubuntu.com/juju/3.6/reference/charm/#reactive)  charm in the channel `latest/stable` (called `legacy`)
-2. [Ops-based](https://documentation.ubuntu.com/juju/3.6/reference/charm/#ops) charm in the channel `14/stable` (called `modern`)
+1. [Reactive](https://documentation.ubuntu.com/juju/3.6/reference/charm/#reactive-charm)  charm in the channel `latest/stable` (called `legacy`)
+2. [Ops-based](https://documentation.ubuntu.com/juju/3.6/reference/charm/#ops-charm) charm in the channel `14/stable` (called `modern`)
 
 The legacy charm provided endpoints `db` and `db-admin` (for the interface `pgsql`). The modern charm provides old endpoints as well + new endpoint `database` (for the interface `postgresql_client`). Read more details about the available [endpoints/interfaces](/explanation/interfaces-and-endpoints).
 

--- a/docs/explanation/roles.md
+++ b/docs/explanation/roles.md
@@ -1,0 +1,136 @@
+# Roles
+
+There are several definitions of roles in Charmed PostgreSQL:
+* Predefined PostgreSQL roles
+* Instance-level DB/relation-specific roles
+  *  LDAP-specific roles 
+* Extra user roles relation flag
+
+```{seealso}
+[](/explanation/users)
+```
+
+## PostgreSQL 16 roles
+
+```text
+test123=> SELECT * FROM pg_roles;
+           rolname           | rolsuper | rolinherit | rolcreaterole | rolcreatedb | rolcanlogin | rolreplication | rolconnlimit | rolpassword | rolvaliduntil | rolbypassrls | rolconfig |  oid
+-----------------------------+----------+------------+---------------+-------------+-------------+----------------+--------------+-------------+---------------+--------------+-----------+-------
+ pg_database_owner           | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           |  6171
+ pg_read_all_data            | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           |  6181
+ pg_write_all_data           | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           |  6182
+ pg_monitor                  | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           |  3373
+ pg_read_all_settings        | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           |  3374
+ pg_read_all_stats           | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           |  3375
+ pg_stat_scan_tables         | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           |  3377
+ pg_read_server_files        | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           |  4569
+ pg_write_server_files       | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           |  4570
+ pg_execute_server_program   | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           |  4571
+ pg_signal_backend           | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           |  4200
+ pg_checkpoint               | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           |  4544
+ pg_use_reserved_connections | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           |  4550
+ pg_create_subscription      | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           |  6304
+...
+```
+
+## Charmed PostgreSQL 16 roles
+
+Charmed PostgreSQL 16 introduces the following instance-level predefined roles:
+
+* `charmed_stats` (inherit from pg_monitor)
+* `charmed_read` (inherit from pg_read_all_data and `charmed_stats`)
+* `charmed_dml` (inherit from pg_write_all_data and `charmed_read`)
+* `charmed_backup` (inherit from pg_checkpoint and `charmed_stats`)
+* `charmed_dba` (allowed to escalate to any other user, including the superuser `operator`)
+* `charmed_admin` (inherit from `charmed_dml` and allowed to escalate to the database-specific `charmed_<database-name>_owner` role, which is explained later in this document)
+* `charmed_databases_owner` (allowed to create databases; it can be requested through the CREATEDB extra user role)
+
+Currently, `charmed_backup` and `charmed_dba` cannot be requested through the relation as extra user roles.
+
+```text
+test123=> SELECT * FROM pg_roles;
+           rolname           | rolsuper | rolinherit | rolcreaterole | rolcreatedb | rolcanlogin | rolreplication | rolconnlimit | rolpassword | rolvaliduntil | rolbypassrls | rolconfig |  oid
+-----------------------------+----------+------------+---------------+-------------+-------------+----------------+--------------+-------------+---------------+--------------+-----------+-------
+...
+ charmed_stats               | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           | 16386
+ charmed_read                | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           | 16388
+ charmed_dml                 | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           | 16390
+ charmed_backup              | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           | 16392
+ charmed_dba                 | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           | 16393
+ charmed_admin               | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           | 16394
+ charmed_databases_owner     | f        | t          | f             | t           | t           | f              |           -1 | ********    |               | f            |           | 16395
+...
+```
+
+Charmed PostgreSQL 16 also introduces catalogue/database level roles, with permissions tied to each database that's created. Example for a database named `test`:
+
+```text
+test123=> SELECT * FROM pg_roles WHERE rolname LIKE 'charmed_test_%';
+      rolname       | rolsuper | rolinherit | rolcreaterole | rolcreatedb | rolcanlogin | rolreplication | rolconnlimit | rolpassword | rolvaliduntil | rolbypassrls | rolconfig |  oid
+--------------------+----------+------------+---------------+-------------+-------------+----------------+--------------+-------------+---------------+--------------+-----------+-------
+ charmed_test_owner | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           | 16396
+ charmed_test_admin | f        | f          | f             | f           | f           | f              |           -1 | ********    |               | f            |           | 16397
+ charmed_test_dml   | f        | t          | f             | f           | f           | f              |           -1 | ********    |               | f            |           | 16398
+```
+
+The `charmed_<database-name>_admin` role is assigned to each relation user (explained in the next section) with access to the specific database. When that user connects to the database, it's auto-escalated to the `charmed_<database-name>_owner` user, which will own every object inside the database, simplifying the permissions to perform operations on those objects when a new user requests access to that same database.
+
+There is also a `charmed_<database-name>_dml` role that is assigned to each relation user to still allow them to read and write to the database objects even if the mechanism to auto-escalate the relation user to the `charmed_<database-name>_owner` role doesn't work.
+
+### Relation-specific roles
+
+For each application/relation, the dedicated user has been created:
+
+```text
+postgres=# SELECT * FROM pg_roles;
+          rolname           | rolsuper | rolinherit | rolcreaterole | rolcreatedb | rolcanlogin | rolreplication | rolconnlimit | rolpassword | rolvaliduntil | rolbypassrls | rolconfig |  oid
+----------------------------+----------+------------+---------------+-------------+-------------+----------------+--------------+-------------+---------------+--------------+-----------+-------
+...
+ relation_id_12             | f        | t          | t             | t           | t           | f              |           -1 | ********    |               | f            |           | 16416
+...
+
+postgres=# SELECT * FROM pg_user;
+          usename           | usesysid | usecreatedb | usesuper | userepl | usebypassrls |  passwd  | valuntil | useconfig
+----------------------------+----------+-------------+----------+---------+--------------+----------+----------+-----------
+ ...
+ relation_id_12             |    16416 | t           | f        | f       | f            | ******** |          |
+```
+
+When the same application is being related through PgBouncer, the extra users/roles are created following the same logic as above:
+
+```text
+postgres=# SELECT * FROM pg_roles;
+          rolname           | rolsuper | rolinherit | rolcreaterole | rolcreatedb | rolcanlogin | rolreplication | rolconnlimit | rolpassword | rolvaliduntil | rolbypassrls | rolconfig |  oid
+----------------------------+----------+------------+---------------+-------------+-------------+----------------+--------------+-------------+---------------+--------------+-----------+-------
+...
+ relation-14                | t        | t          | f             | f           | t           | f              |           -1 | ********    |               | f            |           | 16403
+ pgbouncer_auth_relation_14 | t        | t          | f             | f           | t           | f              |           -1 | ********    |               | f            |           | 16410
+ relation_id_13             | f        | t          | t             | t           | t           | f              |           -1 | ********    |               | f            |           | 16417
+...
+
+postgres=# SELECT * FROM pg_user;
+          usename           | usesysid | usecreatedb | usesuper | userepl | usebypassrls |  passwd  | valuntil | useconfig
+----------------------------+----------+-------------+----------+---------+--------------+----------+----------+-----------
+ ...
+ relation-14                |    16403 | f           | t        | f       | f            | ******** |          |
+ pgbouncer_auth_relation_14 |    16410 | f           | t        | f       | f            | ******** |          |
+ relation_id_13             |    16417 | t           | f        | f       | f            | ******** |          |
+```
+
+In this case, there are  several records created to:
+ * `relation_id_13` - for relation between Application and PgBouncer
+ * `relation-14` - for relation between PgBouncer and PostgreSQL
+ * `pgbouncer_auth_relation_14` - to authenticate end-users, which connects PgBouncer
+
+### Charmed PostgreSQL LDAP roles
+
+To map LDAP users to PostgreSQL users, the dedicated LDAP groups have to be created before hand using [Data Integrator](https://charmhub.io/data-integrator) charm.
+The result of such mapping will be a new PostgreSQL Roles:
+
+```text
+postgres=# SELECT * FROM pg_roles;
+    rolname    | rolsuper | rolinherit | rolcreaterole | rolcreatedb | rolcanlogin | rolreplication | rolconnlimit | rolpassword | rolvaliduntil | rolbypassrls | rolconfig |  oid
+----------------------------+----------+------------+---------------+-------------+-------------+----------------+--------------+-------------+---------------+--------------+-----------+-------
+...
+ myrole        | t        | t          | f             | f           | t           | f              |           -1 | ********    |               | f            |           | 16422
+```

--- a/docs/explanation/security/index.md
+++ b/docs/explanation/security/index.md
@@ -23,7 +23,7 @@ Charmed PostgreSQL K8s can be deployed on top of several Kubernetes distribution
 
 ### Juju
 
-Juju is the component responsible for orchestrating the entire lifecycle, from deployment to Day 2 operations. For more information on Juju security hardening, see the [Juju security page](https://canonical-juju.readthedocs-hosted.com/en/latest/user/explanation/juju-security/) and the [How to harden your deployment](https://documentation.ubuntu.com/juju/3.6/howto/manage-your-deployment/#harden-your-deployment) guide.
+Juju is the component responsible for orchestrating the entire lifecycle, from deployment to Day 2 operations. For more information on Juju security hardening, see the [Juju security page](https://canonical-juju.readthedocs-hosted.com/en/latest/user/explanation/juju-security/) and the [How to harden your deployment](https://documentation.ubuntu.com/juju/3.6/howto/manage-your-juju-deployment/harden-your-juju-deployment/#harden-your-deployment) guide.
 
 #### Cloud credentials
 

--- a/docs/explanation/users.md
+++ b/docs/explanation/users.md
@@ -109,13 +109,7 @@ juju relate postgresql-k8s myclientapp
 
 ### Extra user roles
 
-When an application charm requests a new user through the relation/integration it can specify that the user should have the `admin` role in the `extra-user-roles` field. The `admin` role enables the new user to read and write to all databases (for the `postgres` system database it can only read data) and also to create and delete non-system databases.
-
-```{note}
-`extra-user-roles` is only supported by the modern interface `postgresql_client`. It is not supported for the legacy `pgsql` interface. R
-
-Read more about the supported charm interfaces in [](/explanation/interfaces-and-endpoints).
-```
+When an application charm requests a new user through the relation/integration, it can specify that the user should be part of a predefined role to give them additional permissions. Please check [](/explanation/roles) for the list of available roles.
 
 ## Identity users
 


### PR DESCRIPTION
## Issue
There is no documentation for the new predefined roles.

## Solution
Document those roles, as it was done for the PG 16 VM charm.

Update the users' documentation to reflect the new roles structure (removing the `admin` extra user role, which exists only for the PG 14 charm).

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
