### PR TITLE
Revert "Remove secret's old revision (#1127)"

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -68,7 +68,6 @@ from ops.charm import (
     HookEvent,
     LeaderElectedEvent,
     RelationDepartedEvent,
-    SecretRemoveEvent,
     WorkloadEvent,
 )
 from ops.model import (
@@ -239,7 +238,6 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         self.framework.observe(self.on.promote_to_primary_action, self._on_promote_to_primary)
         self.framework.observe(self.on.get_primary_action, self._on_get_primary)
         self.framework.observe(self.on.update_status, self._on_update_status)
-        self.framework.observe(self.on.secret_remove, self._on_secret_remove)
 
         self._certs_path = "/usr/local/share/ca-certificates"
         self._storage_path = self.meta.storages["pgdata"].location
@@ -1360,17 +1358,6 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
                 event.fail("Unit is not sync standby")
             except SwitchoverFailedError:
                 event.fail("Switchover failed or timed out, check the logs for details")
-
-    def _on_secret_remove(self, event: SecretRemoveEvent) -> None:
-        # A secret removal (entire removal, not just a revision removal) causes
-        # https://github.com/juju/juju/issues/20794. This check is to avoid the
-        # errors that would happen if we tried to remove the revision in that case
-        # (in the revision removal, the label is present).
-        if event.secret.label is None:
-            logger.debug("Secret with no label cannot be removed")
-            return
-        logger.debug(f"Removing secret with label {event.secret.label} revision {event.revision}")
-        event.remove_revision()
 
     def _on_get_primary(self, event: ActionEvent) -> None:
         """Get primary instance."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1893,15 +1893,3 @@ def test_get_ldap_parameters(harness):
         harness.charm.get_ldap_parameters()
         _get_relation_data.assert_called_once()
         _get_relation_data.reset_mock()
-
-
-def test_on_secret_remove(harness):
-    event = Mock()
-    harness.charm._on_secret_remove(event)
-    event.remove_revision.assert_called_once_with()
-    event.reset_mock()
-
-    # No secret
-    event.secret.label = None
-    harness.charm._on_secret_remove(event)
-    assert not event.remove_revision.called


### PR DESCRIPTION
This reverts commit a7e8af0778d9cf2caab3e03eb928b3263da3f794 to avoid issues until we can properly test the charm on Juju 3.6.11.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
