### PR TITLE
DPE-8975 Move PG16 K8s TLS tests to 1/stable

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -886,7 +886,10 @@ async def backup_operations(
     await ops_test.model.deploy(s3_integrator_app_name, base=CHARM_BASE)
     if use_tls:
         await ops_test.model.deploy(
-            tls_certificates_app_name, config=tls_config, channel=tls_channel, base=CHARM_BASE
+            tls_certificates_app_name,
+            config=tls_config,
+            channel=tls_channel,
+            base=CHARM_BASE_NOBLE,
         )
     # Deploy and relate PostgreSQL to S3 integrator (one database app for each cloud for now
     # as archivo_mode is disabled after restoring the backup) and to TLS Certificates Operator

--- a/tests/integration/test_backups_aws.py
+++ b/tests/integration/test_backups_aws.py
@@ -26,7 +26,7 @@ FAILED_TO_ACCESS_CREATE_BUCKET_ERROR_MESSAGE = (
 FAILED_TO_INITIALIZE_STANZA_ERROR_MESSAGE = "failed to initialize stanza, check your S3 settings"
 S3_INTEGRATOR_APP_NAME = "s3-integrator"
 tls_certificates_app_name = "self-signed-certificates"
-tls_channel = "latest/stable"
+tls_channel = "1/stable"
 tls_config = {"ca-common-name": "Test CA"}
 
 logger = logging.getLogger(__name__)

--- a/tests/integration/test_backups_gcp.py
+++ b/tests/integration/test_backups_gcp.py
@@ -29,7 +29,7 @@ FAILED_TO_ACCESS_CREATE_BUCKET_ERROR_MESSAGE = (
 FAILED_TO_INITIALIZE_STANZA_ERROR_MESSAGE = "failed to initialize stanza, check your S3 settings"
 S3_INTEGRATOR_APP_NAME = "s3-integrator"
 tls_certificates_app_name = "self-signed-certificates"
-tls_channel = "latest/stable"
+tls_channel = "1/stable"
 tls_config = {"ca-common-name": "Test CA"}
 
 logger = logging.getLogger(__name__)

--- a/tests/integration/test_backups_pitr_aws.py
+++ b/tests/integration/test_backups_pitr_aws.py
@@ -21,7 +21,7 @@ from .helpers import (
 CANNOT_RESTORE_PITR = "cannot restore PITR, juju debug-log for details"
 S3_INTEGRATOR_APP_NAME = "s3-integrator"
 tls_certificates_app_name = "self-signed-certificates"
-tls_channel = "latest/stable"
+tls_channel = "1/stable"
 tls_config = {"ca-common-name": "Test CA"}
 
 logger = logging.getLogger(__name__)

--- a/tests/integration/test_backups_pitr_gcp.py
+++ b/tests/integration/test_backups_pitr_gcp.py
@@ -21,7 +21,7 @@ from .helpers import (
 CANNOT_RESTORE_PITR = "cannot restore PITR, juju debug-log for details"
 S3_INTEGRATOR_APP_NAME = "s3-integrator"
 tls_certificates_app_name = "self-signed-certificates"
-tls_channel = "latest/stable"
+tls_channel = "1/stable"
 tls_config = {"ca-common-name": "Test CA"}
 
 logger = logging.getLogger(__name__)

--- a/tests/integration/test_ldap.py
+++ b/tests/integration/test_ldap.py
@@ -48,7 +48,7 @@ async def test_glauth_integration(ops_test: OpsTest):
         ops_test.model.deploy(
             GLAUTH_CERT_APP_NAME,
             application_name=glauth_cert_app_name,
-            channel="latest/stable",
+            channel="1/stable",
             trust=False,
         ),
         ops_test.model.deploy(

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -12,7 +12,7 @@ from .ha_tests.helpers import (
     change_patroni_setting,
 )
 from .helpers import (
-    CHARM_BASE,
+    CHARM_BASE_NOBLE,
     DATABASE_APP_NAME,
     build_and_deploy,
     check_tls,
@@ -30,7 +30,7 @@ from .juju_ import juju_major_version
 logger = logging.getLogger(__name__)
 
 tls_certificates_app_name = "self-signed-certificates"
-tls_channel = "latest/stable"
+tls_channel = "1/stable"
 tls_config = {"ca-common-name": "Test CA"}
 APPLICATION_UNITS = 2
 DATABASE_UNITS = 3
@@ -66,7 +66,10 @@ async def test_tls(ops_test: OpsTest) -> None:
     async with ops_test.fast_forward():
         # Deploy TLS Certificates operator.
         await ops_test.model.deploy(
-            tls_certificates_app_name, config=tls_config, channel=tls_channel, base=CHARM_BASE
+            tls_certificates_app_name,
+            config=tls_config,
+            channel=tls_channel,
+            base=CHARM_BASE_NOBLE,
         )
         # Relate it to the PostgreSQL to enable TLS.
         await ops_test.model.relate(


### PR DESCRIPTION
## Issue

Tests are using legacy and deprecated latest/stable which is going to be closed soon.

## Solution

Migrate tests to up-2-date and supported channel 1/stable.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
