### PR TITLE
DPE-9018 Bump src/dependency.json PG version 14.11->14.20

### DIFF
--- a/src/dependency.json
+++ b/src/dependency.json
@@ -9,6 +9,6 @@
     "dependencies": {},
     "name": "charmed-postgresql",
     "upgrade_supported": "^14",
-    "version": "14.11"
+    "version": "14.20"
   }
 }


### PR DESCRIPTION
## Issue

The PG version in src/dependency.json was outdated 14.11 while the workload is currently 14.20.

## Solution

Bump PG version from 14.11 to 14.20.