### PR TITLE
DPE-9018 Bump PG version 16.10->16.11

### DIFF
--- a/refresh_versions.toml
+++ b/refresh_versions.toml
@@ -1,4 +1,4 @@
 # https://canonical-charm-refresh.readthedocs-hosted.com/latest/refresh-versions-toml/
 
 charm_major = 1
-workload = "16.10"
+workload = "16.11"

--- a/tests/integration/high_availability/test_upgrade.py
+++ b/tests/integration/high_availability/test_upgrade.py
@@ -164,7 +164,7 @@ def inject_dependency_fault(juju: Juju, app_name: str, charm_file: str | Path) -
         versions = tomli.load(file)
 
     versions["charm"] = "16/0.0.0"
-    versions["workload"] = "16.10"
+    versions["workload"] = "16.11"
 
     # Overwrite refresh_versions.toml with incompatible version.
     with zipfile.ZipFile(charm_file, mode="a") as charm_zip:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -34,7 +34,7 @@ def mock_refresh():
     # Mock the _RefreshVersions class to avoid KeyError when charm key is missing
     versions_mock = Mock()
     versions_mock.charm = "v1/16.0.0"
-    versions_mock.workload = "16.10"
+    versions_mock.workload = "16.11"
 
     with (
         patch("charm_refresh.Kubernetes", Mock(return_value=refresh_mock)),


### PR DESCRIPTION
## Issue

The PG version was outdated 16.10 while the workload is currently 16.11.

## Solution

Bump PG version from 16.10 to 16.11.