### PR TITLE
DPE-9001 Cache _patroni property

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -1866,7 +1866,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
 
         return True
 
-    @property
+    @cached_property
     def _patroni(self):
         """Returns an instance of the Patroni object."""
         return Patroni(


### PR DESCRIPTION
Ported from VM: https://github.com/canonical/postgresql-operator/issues/1231

## Issue

Juju Controller received the goal-state for each Patroni class initialisation.

## Solution

Decrease the Juju controller goal-state load by caching Patroni class.
See https://github.com/canonical/postgresql-operator/issues/1231 for details.