### PR TITLE
expose pg16 config options

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -20,9 +20,60 @@ options:
       Allowed values are: from 0 to 2147483647.
     type: int
     default: 0
+  cpu_max_logical_replication_workers:
+    description: |
+      Sets the maximum number of logical replication workers. Should be either "auto"
+      or a positive integer value. Restart is required when changed.
+      auto = max_worker_processes.
+    type: string
+    default: "auto"
+  cpu_max_parallel_apply_workers_per_subscription:
+    description: |
+      Sets the maximum number of parallel apply workers per subscription.
+      Should be either "auto" or a positive integer value.
+      auto = max_worker_processes.
+    type: string
+    default: "auto"
+  cpu_max_parallel_maintenance_workers:
+    description: |
+      Sets the maximum number of workers that can be used for parallel maintenance operations
+      like CREATE INDEX. Should be either "auto" or a positive integer value.
+      Cannot exceed max_parallel_workers.
+      auto = max_worker_processes.
+    type: string
+    default: "auto"
+  cpu_max_parallel_workers:
+    description: |
+      Sets the maximum number of workers that can be used for parallel operations.
+      Should be either "auto" or a positive integer value. Cannot exceed max_worker_processes.
+      auto = max_worker_processes.
+    type: string
+    default: "auto"
+  cpu_max_sync_workers_per_subscription:
+    description: |
+      Sets the maximum number of synchronization workers per subscription.
+      Should be either "auto" or a positive integer value.
+      auto = max_worker_processes.
+    type: string
+    default: "auto"
+  cpu_max_worker_processes:
+    description: |
+      Sets the maximum number of background processes that the system can support.
+      Should be either "auto" or a positive integer value.
+      auto = minimum(8, 2 * vCores). Value will be capped at 10 * vCores if exceeded.
+      Restart is required when changed.
+    type: string
+    default: "auto"
   cpu_parallel_leader_participation:
     description: |
       Controls whether Gather and Gather Merge also run subplans.
+    type: boolean
+    default: true
+  cpu_wal_compression:
+    description: |
+      Enable compression of full-page writes written in WAL. Compression reduces
+      the I/O needed for local storage and replication.
+      Default is on (true).
     type: boolean
     default: true
   durability_synchronous_commit:

--- a/src/charm.py
+++ b/src/charm.py
@@ -2023,13 +2023,244 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             return False
         return True
 
+    def _calculate_max_worker_processes(self, cpu_cores: int) -> str | None:
+        """Calculate cpu_max_worker_processes configuration value."""
+        if self.config.cpu_max_worker_processes == "auto":
+            # auto = minimum(8, 2 * vCores)
+            return str(min(8, 2 * cpu_cores))
+        elif self.config.cpu_max_worker_processes is not None:
+            value = self.config.cpu_max_worker_processes
+            if value < 2:
+                from pydantic import ValidationError
+                from pydantic_core import InitErrorDetails
+
+                raise ValidationError.from_exception_data(
+                    "ValidationError",
+                    [
+                        InitErrorDetails(
+                            type="greater_than_equal",
+                            ctx={"ge": 2},
+                            input=value,
+                            loc=("cpu_max_worker_processes",),
+                        )
+                    ],
+                )
+            cap = 10 * cpu_cores
+            if value > cap:
+                raise ValueError(
+                    f"cpu_max_worker_processes value {value} exceeds maximum allowed "
+                    f"of {cap} (10 * vCores). Please set a value <= {cap}."
+                )
+            return str(value)
+        return None
+
+    def _validate_worker_config_value(self, param_name: str, value: int, cpu_cores: int) -> str:
+        """Shared validation logic for worker process parameters.
+
+        Args:
+            param_name: The configuration parameter name (for error messages)
+            value: The integer value to validate
+            cpu_cores: The number of available CPU cores
+
+        Returns:
+            String representation of the validated value
+
+        Raises:
+            ValidationError: If value is less than 2
+            ValueError: If value exceeds 10 * vCores
+        """
+        if value < 2:
+            from pydantic import ValidationError
+            from pydantic_core import InitErrorDetails
+
+            raise ValidationError.from_exception_data(
+                "ValidationError",
+                [
+                    InitErrorDetails(
+                        type="greater_than_equal",
+                        ctx={"ge": 2},
+                        input=value,
+                        loc=(param_name,),
+                    )
+                ],
+            )
+        cap = 10 * cpu_cores
+        if value > cap:
+            raise ValueError(
+                f"{param_name} value {value} exceeds maximum allowed "
+                f"of {cap} (10 * vCores). Please set a value <= {cap}."
+            )
+        return str(value)
+
+    def _calculate_max_parallel_workers(self, base_max_workers: int, cpu_cores: int) -> str | None:
+        """Calculate cpu_max_parallel_workers configuration value."""
+        if self.config.cpu_max_parallel_workers == "auto":
+            return str(base_max_workers)
+        elif self.config.cpu_max_parallel_workers is not None:
+            # Validate the value first
+            validated_value_str = self._validate_worker_config_value(
+                "cpu_max_parallel_workers", self.config.cpu_max_parallel_workers, cpu_cores
+            )
+            # Apply the min constraint with base_max_workers
+            return str(min(int(validated_value_str), base_max_workers))
+        return None
+
+    def _calculate_max_parallel_maintenance_workers(
+        self, base_max_workers: int, cpu_cores: int
+    ) -> str | None:
+        """Calculate cpu_max_parallel_maintenance_workers configuration value."""
+        if self.config.cpu_max_parallel_maintenance_workers == "auto":
+            return str(base_max_workers)
+        elif self.config.cpu_max_parallel_maintenance_workers is not None:
+            return self._validate_worker_config_value(
+                "cpu_max_parallel_maintenance_workers",
+                self.config.cpu_max_parallel_maintenance_workers,
+                cpu_cores,
+            )
+        return None
+
+    def _calculate_max_logical_replication_workers(
+        self, base_max_workers: int, cpu_cores: int
+    ) -> str | None:
+        """Calculate cpu_max_logical_replication_workers configuration value."""
+        if self.config.cpu_max_logical_replication_workers == "auto":
+            return str(base_max_workers)
+        elif self.config.cpu_max_logical_replication_workers is not None:
+            return self._validate_worker_config_value(
+                "cpu_max_logical_replication_workers",
+                self.config.cpu_max_logical_replication_workers,
+                cpu_cores,
+            )
+        return None
+
+    def _calculate_max_sync_workers_per_subscription(
+        self, base_max_workers: int, cpu_cores: int
+    ) -> str | None:
+        """Calculate cpu_max_sync_workers_per_subscription configuration value."""
+        if self.config.cpu_max_sync_workers_per_subscription == "auto":
+            return str(base_max_workers)
+        elif self.config.cpu_max_sync_workers_per_subscription is not None:
+            return self._validate_worker_config_value(
+                "cpu_max_sync_workers_per_subscription",
+                self.config.cpu_max_sync_workers_per_subscription,
+                cpu_cores,
+            )
+        return None
+
+    def _calculate_max_parallel_apply_workers_per_subscription(
+        self, base_max_workers: int, cpu_cores: int
+    ) -> str | None:
+        """Calculate cpu_max_parallel_apply_workers_per_subscription configuration value."""
+        if self.config.cpu_max_parallel_apply_workers_per_subscription == "auto":
+            return str(base_max_workers)
+        elif self.config.cpu_max_parallel_apply_workers_per_subscription is not None:
+            return self._validate_worker_config_value(
+                "cpu_max_parallel_apply_workers_per_subscription",
+                self.config.cpu_max_parallel_apply_workers_per_subscription,
+                cpu_cores,
+            )
+        return None
+
+    def _calculate_worker_process_config(self, cpu_cores: int) -> dict[str, str]:
+        """Calculate worker process configuration values.
+
+        Handles 'auto' values and capping logic for worker process parameters.
+        Returns a dictionary with the calculated values ready for PostgreSQL.
+        """
+        result: dict[str, str] = {}
+
+        # Calculate cpu_max_worker_processes (baseline for other worker configs)
+        cpu_max_worker_processes_value = self._calculate_max_worker_processes(cpu_cores)
+        if cpu_max_worker_processes_value is not None:
+            result["max_worker_processes"] = cpu_max_worker_processes_value
+
+        # Get the effective cpu_max_worker_processes for dependent configs
+        # Use the calculated value, or fall back to PostgreSQL default (8)
+        base_max_workers = int(result.get("max_worker_processes", "8"))
+
+        # Calculate other worker parameters
+        cpu_max_parallel_workers_value = self._calculate_max_parallel_workers(
+            base_max_workers, cpu_cores
+        )
+        if cpu_max_parallel_workers_value is not None:
+            result["max_parallel_workers"] = cpu_max_parallel_workers_value
+
+        cpu_max_parallel_maintenance_workers_value = (
+            self._calculate_max_parallel_maintenance_workers(base_max_workers, cpu_cores)
+        )
+        if cpu_max_parallel_maintenance_workers_value is not None:
+            result["max_parallel_maintenance_workers"] = cpu_max_parallel_maintenance_workers_value
+
+        cpu_max_logical_replication_workers_value = (
+            self._calculate_max_logical_replication_workers(base_max_workers, cpu_cores)
+        )
+        if cpu_max_logical_replication_workers_value is not None:
+            result["max_logical_replication_workers"] = cpu_max_logical_replication_workers_value
+
+        cpu_max_sync_workers_per_subscription_value = (
+            self._calculate_max_sync_workers_per_subscription(base_max_workers, cpu_cores)
+        )
+        if cpu_max_sync_workers_per_subscription_value is not None:
+            result["max_sync_workers_per_subscription"] = (
+                cpu_max_sync_workers_per_subscription_value
+            )
+
+        cpu_max_parallel_apply_workers_per_subscription_value = (
+            self._calculate_max_parallel_apply_workers_per_subscription(
+                base_max_workers, cpu_cores
+            )
+        )
+        if cpu_max_parallel_apply_workers_per_subscription_value is not None:
+            result["max_parallel_apply_workers_per_subscription"] = (
+                cpu_max_parallel_apply_workers_per_subscription_value
+            )
+
+        return result
+
+    def _build_postgresql_parameters(
+        self, available_cpu_cores: int, available_memory: int
+    ) -> dict | None:
+        """Build PostgreSQL configuration parameters.
+
+        Args:
+            available_cpu_cores: Number of available CPU cores
+            available_memory: Available memory in bytes
+
+        Returns:
+            Dictionary of PostgreSQL parameters or None if base parameters couldn't be built.
+        """
+        limit_memory = None
+        if self.config.profile_limit_memory:
+            limit_memory = self.config.profile_limit_memory * 10**6
+
+        # Build PostgreSQL parameters.
+        pg_parameters = self.postgresql.build_postgresql_parameters(
+            self.model.config, available_memory, limit_memory
+        )
+
+        # Calculate and merge worker process configurations
+        worker_configs = self._calculate_worker_process_config(available_cpu_cores)
+
+        # Add cpu_wal_compression configuration (separate from worker processes)
+        if self.config.cpu_wal_compression is not None:
+            cpu_wal_compression = "on" if self.config.cpu_wal_compression else "off"
+        else:
+            # Use config.yaml default when unset (default: true)
+            cpu_wal_compression = "on"
+
+        if pg_parameters is not None:
+            pg_parameters.update(worker_configs)
+            pg_parameters["wal_compression"] = cpu_wal_compression
+        else:
+            pg_parameters = dict(worker_configs)
+            pg_parameters["wal_compression"] = cpu_wal_compression
+            logger.debug(f"pg_parameters set to worker_configs = {pg_parameters}")
+
+        return pg_parameters
+
     def update_config(self, is_creating_backup: bool = False) -> bool:
         """Updates Patroni config file based on the existence of the TLS files."""
         # Retrieve PostgreSQL parameters.
-        if self.config.profile_limit_memory:
-            limit_memory = self.config.profile_limit_memory * 10**6
-        else:
-            limit_memory = None
         try:
             available_cpu_cores, available_memory = self.get_available_resources()
         except ApiError as e:
@@ -2038,9 +2269,12 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
                 return
             raise e
 
-        postgresql_parameters = self.postgresql.build_postgresql_parameters(
-            self.model.config, available_memory, limit_memory
+        postgresql_parameters = self._build_postgresql_parameters(
+            available_cpu_cores, available_memory
         )
+
+        # Extract worker configs for later use in Patroni API
+        worker_configs = self._calculate_worker_process_config(available_cpu_cores)
 
         logger.info("Updating Patroni config file")
         # Update and reload configuration based on TLS files availability.
@@ -2082,12 +2316,23 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         else:
             max_connections = max(4 * available_cpu_cores, 100)
 
-        self._patroni.bulk_update_parameters_controller_by_patroni({
+        # Build the config patch with restart-required parameters
+        config_patch = {
             "max_connections": max_connections,
             "max_prepared_transactions": self.config.memory_max_prepared_transactions,
             "shared_buffers": self.config.memory_shared_buffers,
             "wal_keep_size": self.config.durability_wal_keep_size,
-        })
+        }
+
+        # Add restart-required worker process parameters via Patroni API
+        if "max_worker_processes" in worker_configs:
+            config_patch["max_worker_processes"] = worker_configs["max_worker_processes"]
+        if "max_logical_replication_workers" in worker_configs:
+            config_patch["max_logical_replication_workers"] = worker_configs[
+                "max_logical_replication_workers"
+            ]
+
+        self._patroni.bulk_update_parameters_controller_by_patroni(config_patch)
 
         self._handle_postgresql_restart_need(
             self.unit_peer_data.get("config_hash") != self.generate_config_hash

--- a/src/config.py
+++ b/src/config.py
@@ -5,12 +5,15 @@
 """Structured configuration for the PostgreSQL charm."""
 
 import logging
-from typing import Literal
+from typing import Annotated, Literal
 
 from charms.data_platform_libs.v0.data_models import BaseConfigModel
-from pydantic import PositiveInt, validator
+from pydantic import PositiveInt, conint, validator
 
 logger = logging.getLogger(__name__)
+
+# Type for worker process parameters that must be >= 2
+WorkerProcessInt = Annotated[int, conint(ge=2)]
 
 
 class CharmConfig(BaseConfigModel):
@@ -19,7 +22,14 @@ class CharmConfig(BaseConfigModel):
     synchronous_node_count: Literal["all", "majority"] | PositiveInt
     connection_authentication_timeout: int | None
     connection_statement_timeout: int | None
+    cpu_max_logical_replication_workers: Literal["auto"] | WorkerProcessInt | None
+    cpu_max_parallel_apply_workers_per_subscription: Literal["auto"] | WorkerProcessInt | None
+    cpu_max_parallel_maintenance_workers: Literal["auto"] | WorkerProcessInt | None
+    cpu_max_parallel_workers: Literal["auto"] | WorkerProcessInt | None
+    cpu_max_sync_workers_per_subscription: Literal["auto"] | WorkerProcessInt | None
+    cpu_max_worker_processes: Literal["auto"] | WorkerProcessInt | None
     cpu_parallel_leader_participation: bool | None
+    cpu_wal_compression: bool | None
     durability_synchronous_commit: str | None
     durability_wal_keep_size: int | None
     experimental_max_connections: int | None

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1571,6 +1571,7 @@ def test_clean_ca_file_from_workload(harness):
 def test_update_config(harness):
     with (
         patch("ops.model.Container.get_plan") as _get_plan,
+        patch("charm.PostgresqlOperatorCharm.get_available_resources", return_value=(4, 8000000)),
         patch(
             "charm.PostgresqlOperatorCharm._handle_postgresql_restart_need"
         ) as _handle_postgresql_restart_need,
@@ -1607,6 +1608,17 @@ def test_update_config(harness):
             harness.update_relation_data(rel_id, harness.charm.unit.name, {"tls": ""})
         _is_tls_enabled.return_value = False
         harness.charm.update_config()
+        # Expected parameters include base "test": "test" plus worker configs (auto = 8, since min(8, 2*4) = 8)
+        expected_parameters = {
+            "test": "test",
+            "max_worker_processes": "8",
+            "max_parallel_workers": "8",
+            "max_parallel_maintenance_workers": "8",
+            "max_logical_replication_workers": "8",
+            "max_sync_workers_per_subscription": "8",
+            "max_parallel_apply_workers_per_subscription": "8",
+            "wal_compression": "on",
+        }
         _render_patroni_yml_file.assert_called_once_with(
             connectivity=True,
             is_creating_backup=False,
@@ -1619,7 +1631,7 @@ def test_update_config(harness):
             restore_timeline=None,
             pitr_target=None,
             restore_to_latest=False,
-            parameters={"test": "test"},
+            parameters=expected_parameters,
             user_databases_map={"operator": "all", "replication": "all", "rewind": "all"},
         )
         _handle_postgresql_restart_need.assert_called_once()
@@ -1649,7 +1661,7 @@ def test_update_config(harness):
             restore_timeline=None,
             pitr_target=None,
             restore_to_latest=False,
-            parameters={"test": "test"},
+            parameters=expected_parameters,
             user_databases_map={"operator": "all", "replication": "all", "rewind": "all"},
         )
         _handle_postgresql_restart_need.assert_called_once()
@@ -1928,3 +1940,297 @@ def test_on_secret_remove(harness, only_with_juju_secrets):
         event.secret.label = None
         harness.charm._on_secret_remove(event)
         assert not event.remove_revision.called
+
+
+def test_calculate_worker_process_config_auto_values(harness):
+    """Test worker process config calculation with 'auto' values."""
+    with patch.object(
+        PostgresqlOperatorCharm, "get_available_resources", return_value=(2, 8000000)
+    ):
+        with harness.hooks_disabled():
+            harness.update_config({
+                "cpu_max_worker_processes": "auto",
+                "cpu_max_parallel_workers": "auto",
+                "cpu_max_parallel_maintenance_workers": "auto",
+                "cpu_max_logical_replication_workers": "auto",
+                "cpu_max_sync_workers_per_subscription": "auto",
+                "cpu_max_parallel_apply_workers_per_subscription": "auto",
+            })
+
+        result = harness.charm._calculate_worker_process_config(2)
+
+        # All auto values should resolve to 4 (min(8, 2*2))
+        assert result["max_worker_processes"] == "4"
+        assert result["max_parallel_workers"] == "4"
+        assert result["max_parallel_maintenance_workers"] == "4"
+        assert result["max_logical_replication_workers"] == "4"
+        assert result["max_sync_workers_per_subscription"] == "4"
+        assert result["max_parallel_apply_workers_per_subscription"] == "4"
+
+        # Test with 8 vCPUs (auto should be min(8, 2*8) = 8)
+        result = harness.charm._calculate_worker_process_config(8)
+        assert result["max_worker_processes"] == "8"
+        assert result["max_parallel_workers"] == "8"
+
+        # Test with 1 vCPU (auto should be min(8, 2*1) = 2)
+        result = harness.charm._calculate_worker_process_config(1)
+        assert result["max_worker_processes"] == "2"
+
+
+def test_calculate_worker_process_config_numeric_values(harness):
+    """Test worker process config calculation with numeric values."""
+    with harness.hooks_disabled():
+        harness.update_config({
+            "cpu_max_worker_processes": "10",
+            "cpu_max_parallel_workers": "8",
+            "cpu_max_parallel_maintenance_workers": "8",
+        })
+
+    result = harness.charm._calculate_worker_process_config(4)
+
+    assert result["max_worker_processes"] == "10"
+    assert result["max_parallel_workers"] == "8"
+    assert result["max_parallel_maintenance_workers"] == "8"
+
+
+def test_calculate_worker_process_config_all_workers_numeric(harness):
+    """Test all worker configs with numeric values within limits (not capped)."""
+    with harness.hooks_disabled():
+        harness.update_config({
+            "cpu_max_worker_processes": "20",
+            "cpu_max_parallel_workers": "15",
+            "cpu_max_parallel_maintenance_workers": "10",
+            "cpu_max_logical_replication_workers": "12",
+            "cpu_max_sync_workers_per_subscription": "8",
+            "cpu_max_parallel_apply_workers_per_subscription": "8",
+        })
+
+    result = harness.charm._calculate_worker_process_config(4)  # Cap would be 40
+
+    # All values should pass through unchanged (within cap of 40)
+    assert result["max_worker_processes"] == "20"
+    assert result["max_parallel_workers"] == "15"
+    assert result["max_parallel_maintenance_workers"] == "10"
+    assert result["max_logical_replication_workers"] == "12"
+    assert result["max_sync_workers_per_subscription"] == "8"
+    assert result["max_parallel_apply_workers_per_subscription"] == "8"
+
+
+def test_calculate_worker_process_config_validation_blocking_max_worker_processes(harness):
+    """Test worker process config validation blocks max_worker_processes exceeding values instead of capping."""
+    with harness.hooks_disabled():
+        harness.update_config({"cpu_max_worker_processes": "50"})  # Exceeds cap of 20 (2*10)
+
+    with pytest.raises(
+        ValueError, match="cpu_max_worker_processes value 50 exceeds maximum allowed of 20"
+    ):
+        harness.charm._calculate_worker_process_config(2)
+
+
+def test_calculate_worker_process_config_validation_blocking_max_parallel_workers(harness):
+    """Test worker process config validation blocks max_parallel_workers exceeding values instead of capping."""
+    with harness.hooks_disabled():
+        harness.update_config({"cpu_max_parallel_workers": "30"})  # Exceeds cap of 20 (2*10)
+
+    with pytest.raises(
+        ValueError, match="cpu_max_parallel_workers value 30 exceeds maximum allowed of 20"
+    ):
+        harness.charm._calculate_worker_process_config(2)
+
+
+def test_calculate_worker_process_config_validation_blocking_valid_value(harness):
+    """Test worker process config validation accepts valid values within cap."""
+    with harness.hooks_disabled():
+        harness.update_config({"cpu_max_parallel_maintenance_workers": "15"})  # Within cap of 20
+
+    result = harness.charm._calculate_worker_process_config(2)
+    assert result["max_parallel_maintenance_workers"] == "15"  # Should accept valid value
+
+
+def test_calculate_worker_process_config_edge_cases(harness):
+    """Test worker process config edge cases."""
+    # Test with no worker config set (but wal_compression has default)
+    with harness.hooks_disabled():
+        harness.update_config(
+            unset=[
+                "cpu_max_worker_processes",
+                "cpu_max_parallel_workers",
+                "cpu_max_parallel_maintenance_workers",
+                "cpu_max_logical_replication_workers",
+                "cpu_max_sync_workers_per_subscription",
+                "cpu_max_parallel_apply_workers_per_subscription",
+                "cpu_wal_compression",
+            ]
+        )
+
+    result = harness.charm._calculate_worker_process_config(4)
+    # All worker parameters default to auto, so they get calculated
+    expected = {
+        "max_worker_processes": "8",  # min(8, 2 * 4) = 8
+        "max_parallel_workers": "8",
+        "max_parallel_maintenance_workers": "8",
+        "max_logical_replication_workers": "8",
+        "max_sync_workers_per_subscription": "8",
+        "max_parallel_apply_workers_per_subscription": "8",
+    }
+    assert result == expected
+
+    # Test with only one worker config set
+    with harness.hooks_disabled():
+        harness.update_config({"cpu_max_worker_processes": "10"})
+
+    result = harness.charm._calculate_worker_process_config(4)
+    # Other worker parameters still get auto-calculated since they default to "auto"
+    expected = {
+        "max_worker_processes": "10",
+        "max_parallel_workers": "10",  # auto = base_max_workers (10)
+        "max_parallel_maintenance_workers": "10",
+        "max_logical_replication_workers": "10",
+        "max_sync_workers_per_subscription": "10",
+        "max_parallel_apply_workers_per_subscription": "10",
+    }
+    assert result == expected
+
+    # Test with very high vCPU count (reset config to defaults first)
+    with harness.hooks_disabled():
+        harness.update_config(
+            unset=[
+                "cpu_max_worker_processes",
+                "cpu_max_parallel_workers",
+                "cpu_max_parallel_maintenance_workers",
+                "cpu_max_logical_replication_workers",
+                "cpu_max_sync_workers_per_subscription",
+                "cpu_max_parallel_apply_workers_per_subscription",
+            ]
+        )
+
+    result = harness.charm._calculate_worker_process_config(128)
+    # Should be min(8, 2*128) = 8
+    expected = {
+        "max_worker_processes": "8",
+        "max_parallel_workers": "8",
+        "max_parallel_maintenance_workers": "8",
+        "max_logical_replication_workers": "8",
+        "max_sync_workers_per_subscription": "8",
+        "max_parallel_apply_workers_per_subscription": "8",
+    }
+    assert result == expected
+
+
+def test_calculate_worker_process_config_dependencies(harness):
+    """Test that dependent worker configs properly use max_worker_processes as base."""
+    with harness.hooks_disabled():
+        harness.update_config({
+            "cpu_max_worker_processes": "12",
+            "cpu_max_parallel_workers": "auto",
+            "cpu_max_parallel_maintenance_workers": "auto",
+        })
+
+    result = harness.charm._calculate_worker_process_config(4)
+
+    # Auto values should use max_worker_processes (12) as base
+    assert result["max_worker_processes"] == "12"
+    assert result["max_parallel_workers"] == "12"
+    assert result["max_parallel_maintenance_workers"] == "12"
+
+
+def test_calculate_worker_process_config_wal_compression(harness):
+    """Test that wal_compression is NOT included in worker process config."""
+    # Test with wal_compression enabled - should NOT be in worker config result
+    with harness.hooks_disabled():
+        harness.update_config({"cpu_wal_compression": True})
+
+    result = harness.charm._calculate_worker_process_config(4)
+    assert "wal_compression" not in result  # wal_compression is not part of worker configs
+
+    # Test with wal_compression disabled - should NOT be in worker config result
+    with harness.hooks_disabled():
+        harness.update_config({"cpu_wal_compression": False})
+
+    result = harness.charm._calculate_worker_process_config(4)
+    assert "wal_compression" not in result  # wal_compression is not part of worker configs
+
+    # Test with wal_compression not explicitly set - should NOT be in worker config result
+    with harness.hooks_disabled():
+        harness.update_config(unset=["cpu_wal_compression"])
+
+    result = harness.charm._calculate_worker_process_config(4)
+    assert "wal_compression" not in result  # wal_compression is not part of worker configs
+
+
+def test_calculate_worker_process_config_mixed_auto_and_numeric(harness):
+    """Test worker process config with mixed auto and numeric values."""
+    with harness.hooks_disabled():
+        harness.update_config({
+            "cpu_max_worker_processes": "16",
+            "cpu_max_parallel_workers": "auto",  # Should become 16
+            "cpu_max_parallel_maintenance_workers": "8",  # Explicit value
+            "cpu_max_logical_replication_workers": "auto",  # Should become 16
+        })
+
+    result = harness.charm._calculate_worker_process_config(4)
+
+    assert result["max_worker_processes"] == "16"
+    assert result["max_parallel_workers"] == "16"  # Auto resolved to base
+    assert result["max_parallel_maintenance_workers"] == "8"  # Explicit value
+    assert result["max_logical_replication_workers"] == "16"  # Auto resolved to base
+
+
+def test_calculate_worker_process_config_zero_cpu_count(harness):
+    """Test worker process config when cpu_count is 0 (edge case)."""
+    with harness.hooks_disabled():
+        harness.update_config({"cpu_max_worker_processes": "auto"})
+
+    result = harness.charm._calculate_worker_process_config(0)
+
+    # min(8, 2*0) = 0
+    assert result["max_worker_processes"] == "0"
+
+
+def test_calculate_worker_process_config_all_workers_validation_blocking(harness):
+    """Test that worker configs exceeding limits raise ValueError instead of capping."""
+    cpu_cores = 2  # Cap = 20
+
+    # Test each exceeding parameter individually (since first exception stops execution)
+    exceeding_configs = [
+        ("cpu_max_worker_processes", "25"),
+        ("cpu_max_parallel_maintenance_workers", "22"),
+        ("cpu_max_logical_replication_workers", "30"),
+        ("cpu_max_sync_workers_per_subscription", "25"),
+        ("cpu_max_parallel_apply_workers_per_subscription", "100"),
+    ]
+
+    for param_name, invalid_value in exceeding_configs:
+        # Reset all configs to auto first, then set the specific one we want to test
+        reset_config = {
+            "cpu_max_worker_processes": "auto",
+            "cpu_max_parallel_workers": "auto",
+            "cpu_max_parallel_maintenance_workers": "auto",
+            "cpu_max_logical_replication_workers": "auto",
+            "cpu_max_sync_workers_per_subscription": "auto",
+            "cpu_max_parallel_apply_workers_per_subscription": "auto",
+        }
+        reset_config[param_name] = invalid_value
+
+        with harness.hooks_disabled():
+            harness.update_config(reset_config)
+
+        with pytest.raises(
+            ValueError,
+            match=f"{param_name.replace('-', '_')} value {invalid_value} exceeds maximum allowed of 20",
+        ):
+            harness.charm._calculate_worker_process_config(cpu_cores)
+
+    # Test valid value within cap works - need to set max_worker_processes high enough
+    with harness.hooks_disabled():
+        harness.update_config({
+            "cpu_max_worker_processes": "20",  # Set high enough to allow max_parallel_workers = 18
+            "cpu_max_parallel_workers": "18",  # Within both CPU cap (20) and max_worker_processes (20)
+            "cpu_max_parallel_maintenance_workers": "auto",
+            "cpu_max_logical_replication_workers": "auto",
+            "cpu_max_sync_workers_per_subscription": "auto",
+            "cpu_max_parallel_apply_workers_per_subscription": "auto",
+        })
+
+    result = harness.charm._calculate_worker_process_config(cpu_cores)
+    assert result["max_parallel_workers"] == "18"  # Should accept valid value


### PR DESCRIPTION
Added PG-16 worker process and WAL compression configuration options.

6 worker process settings (cpu-max-logical-replication-workers, cpu-max-parallel-apply-workers-per-subscription, cpu-max-parallel-maintenance-workers, cpu-max-parallel-workers, cpu-max-sync-workers-per-subscription, cpu-max-worker-processes)
1 WAL compression setting (cpu-wal-compression)
All options support "auto" values with defaults and include descriptions for PG-16 compatibility.


Similar to [this PR.](https://github.com/canonical/postgresql-operator/pull/1284)