### PR TITLE
feat: update juju terraform provider to v1

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,27 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# Lock file (optional - remove this line if you want to commit the lock file)
+.terraform.lock.hcl

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,55 @@
+# Terraform module for PostgreSQL K8s Operator
+
+This is a Terraform module facilitating the deployment of the postgresql-k8s charm using
+the [Juju Terraform provider](https://github.com/juju/terraform-provider-juju).
+For more information, refer to the
+[documentation](https://registry.terraform.io/providers/juju/juju/latest/docs)
+for the Juju Terraform provider.
+
+## Requirements
+
+This module requires a Juju model to be available. Refer to the [usage](#usage)
+section for more details.
+
+## API
+
+### Inputs
+
+This module offers the following configurable units:
+
+| Name                 | Type        | Description                              | Default          | Required |
+|----------------------|-------------|------------------------------------------|------------------|:--------:|
+| `app_name`           | string      | Application name                         | postgresql-k8s   |          |
+| `base`               | string      | Base version to use for deployed charm   | ubuntu@22.04     |          |
+| `channel`            | string      | Channel that charm is deployed from      | 14/stable        |          |
+| `config`             | map(string) | Application configuration                | {}               |          |
+| `constraints`        | string      | Juju constraints to apply                | ""               |          |
+| `model_uuid`         | string      | UUID of the model to deploy the charm to |                  |    Y     |
+| `revision`           | number      | Revision number of charm to deploy       | null             |          |
+| `storage_directives` | map(string) | Storage directives                       | { pgdata = 10G } |          |
+| `units`              | number      | Number of units to deploy                | 1                |          |
+
+### Outputs
+
+After applying, the module exports the following outputs:
+
+| Name              | Description                  |
+|-------------------|------------------------------|
+| `app_name`        | Application name             |
+| `provides`        | Map of `provides` endpoints  |
+| `requires`        | Map of `requires` endpoints  |
+
+## Usage
+
+Users should ensure that Terraform is aware of the Juju model dependency of the
+charm module.
+
+To deploy this module with its required dependency, you can run
+the following command:
+
+```shell
+terraform apply -var="model_uuid=<MODEL_UUID>" -auto-approve
+```
+
+For more configuration options, refer to the [CharmHub documentation](https://charmhub.io/postgresql-k8s/configurations).
+

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,7 +1,7 @@
 resource "juju_application" "k8s_postgresql" {
-  name  = var.app_name
-  model = var.juju_model_name
-  trust = true
+  name       = var.app_name
+  model_uuid = var.model_uuid
+  trust      = true
 
   charm {
     name     = "postgresql-k8s"
@@ -10,9 +10,7 @@ resource "juju_application" "k8s_postgresql" {
     base     = var.base
   }
 
-  storage_directives = {
-    pgdata = var.storage_size
-  }
+  storage_directives = var.storage_directives
 
   units       = var.units
   constraints = var.constraints

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,7 +1,6 @@
-output "application_name" {
+output "app_name" {
   value = juju_application.k8s_postgresql.name
 }
-
 
 output "provides" {
   value = {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,5 +1,5 @@
-variable "juju_model_name" {
-  description = "Juju model name"
+variable "model_uuid" {
+  description = "Juju model UUID"
   type        = string
 }
 
@@ -36,13 +36,15 @@ variable "units" {
 variable "constraints" {
   description = "Juju constraints to apply for this application."
   type        = string
-  default     = "arch=amd64"
+  default     = ""
 }
 
-variable "storage_size" {
-  description = "Storage size"
-  type        = string
-  default     = "10G"
+variable "storage_directives" {
+  description = "Storage directives"
+  type        = map(string)
+  default = {
+    pgdata = "10G"
+  }
 }
 
 variable "config" {

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.14.0"
+      version = "~> 1.0"
     }
   }
 }


### PR DESCRIPTION
## Issue

The postgresql-k8s Terraform module is incompatible with version `>=1.0` of the Juju Terraform provider since the provider now uses the model UUID instead of the model name: https://search.opentofu.org/provider/juju/juju/latest/docs/resources/application

## Solution

I updated the postgresql-k8s Terraform module to v1 of the Juju Terraform provider. I set a pessimistic version constraint so that the module only uses v1 of the Juju Terraform provider. I also added a README and .gitignore for the module so that Terraform data files are not accidentally committed.

Another thing is that I updated to module to be "more compliant" with CC006 - e.g. `application_name` -> `app_name` and parts of CC008, but both specs haven't been accepted yet, so I can be convinced to leave the outputs alone if general consensus is to not change it.

Please let me know if you have any question :smile: 

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
