### PR TITLE
[DPE-9256] Endpoints cleanup

### DIFF
--- a/.github/workflows/approve_renovate_pr.yaml
+++ b/.github/workflows/approve_renovate_pr.yaml
@@ -10,6 +10,6 @@ on:
 jobs:
   approve-pr:
     name: Approve Renovate pull request
-    uses: canonical/data-platform-workflows/.github/workflows/approve_renovate_pr.yaml@v41.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/approve_renovate_pr.yaml@v41.1.0
     permissions:
       pull-requests: write  # Needed to approve PR

--- a/.github/workflows/check_pr.yaml
+++ b/.github/workflows/check_pr.yaml
@@ -16,4 +16,4 @@ on:
 jobs:
   check-pr:
     name: Check pull request
-    uses: canonical/data-platform-workflows/.github/workflows/check_charm_pr.yaml@v41.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/check_charm_pr.yaml@v41.1.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ on:
 jobs:
   lint:
     name: Lint
-    uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v41.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v41.1.0
 
   unit-test:
     name: Unit test charm
@@ -50,7 +50,7 @@ jobs:
 
   build:
     name: Build charm
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v41.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v41.1.0
 
   integration-test:
     name: Integration test charm

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -25,7 +25,7 @@ on:
 jobs:
   promote:
     name: Promote charms
-    uses: canonical/data-platform-workflows/.github/workflows/_promote_charms.yaml@v41.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/_promote_charms.yaml@v41.1.0
     with:
       track: '16'
       from-risk: ${{ inputs.from-risk }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ on:
 jobs:
   tag:
     name: Create charm refresh compatibility version git tag
-    uses: canonical/data-platform-workflows/.github/workflows/tag_charm_edge.yaml@v41.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/tag_charm_edge.yaml@v41.1.0
     with:
       track: '16'
     permissions:
@@ -38,7 +38,7 @@ jobs:
     needs:
       - tag
       - ci-tests
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v41.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v41.1.0
     with:
       track: ${{ needs.tag.outputs.track }}
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}

--- a/src/charm.py
+++ b/src/charm.py
@@ -1658,11 +1658,29 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             # Get the k8s resources created by the charm and Patroni.
             resources_to_patch = []
             for kind in [Endpoints, Service]:
+                # Get resources with Juju's created-by label
                 resources_to_patch.extend(
                     client.list(
                         kind,
                         namespace=self._namespace,
                         labels={"app.juju.is/created-by": f"{self._name}"},
+                    )
+                )
+
+                # Since Juju 3.6.13 (commit aa38cff0b1), the mutating webhook no longer
+                # processes Endpoints - they were removed from the webhook's resource allowlist.
+                # Patroni creates its own Endpoints with these labels:
+                # - application: patroni
+                # - cluster-name: patroni-{application}
+                # These resources never get Juju labels, so we must query for them separately.
+                resources_to_patch.extend(
+                    client.list(
+                        kind,
+                        namespace=self._namespace,
+                        labels={
+                            "application": "patroni",
+                            "cluster-name": f"patroni-{self._name}",
+                        },
                     )
                 )
         except ApiError:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -430,12 +430,29 @@ def get_existing_k8s_resources(namespace: str, application: str) -> set:
     # Retrieve the resources created by the charm and Patroni.
     resources = set()
     for kind in [Endpoints, Service]:
-        extra_resources = client.list(
+        # Get resources with Juju's created-by label
+        juju_resources = client.list(
             kind,
             namespace=namespace,
             labels={"app.juju.is/created-by": application},
         )
-        resources.update({f"{kind.__name__}/{x.metadata.name}" for x in extra_resources})
+        resources.update({f"{kind.__name__}/{x.metadata.name}" for x in juju_resources})
+
+        # Since Juju 3.6.13 (commit aa38cff0b1), the mutating webhook no longer
+        # processes Endpoints - they were removed from the webhook's resource allowlist.
+        # Patroni creates its own Endpoints with these labels:
+        # - application: patroni
+        # - cluster-name: patroni-{application}
+        # These resources never get Juju labels, so we must query for them separately.
+        patroni_resources = client.list(
+            kind,
+            namespace=namespace,
+            labels={
+                "application": "patroni",
+                "cluster-name": f"patroni-{application}",
+            },
+        )
+        resources.update({f"{kind.__name__}/{x.metadata.name}" for x in patroni_resources})
 
     return resources
 

--- a/tests/integration/high_availability/test_async_replication.py
+++ b/tests/integration/high_availability/test_async_replication.py
@@ -13,6 +13,7 @@ from tenacity import Retrying, stop_after_attempt, wait_fixed
 
 from .. import architecture
 from ..helpers import METADATA
+from ..jubilant_helpers import retry_if_cli_error
 from .high_availability_helpers_new import (
     get_app_leader,
     get_app_units,
@@ -136,13 +137,17 @@ def test_deploy(first_model: str, second_model: str, charm: str) -> None:
     model_2.integrate(f"{DB_TEST_APP_2}:database", f"{DB_APP_2}:database")
 
     logging.info("Waiting for the applications to settle")
-    model_1.wait(
-        ready=wait_for_apps_status(jubilant.all_active, DB_APP_1, DB_TEST_APP_1),
-        timeout=20 * MINUTE_SECS,
+    retry_if_cli_error(
+        lambda: model_1.wait(
+            ready=wait_for_apps_status(jubilant.all_active, DB_APP_1, DB_TEST_APP_1),
+            timeout=20 * MINUTE_SECS,
+        )
     )
-    model_2.wait(
-        ready=wait_for_apps_status(jubilant.all_active, DB_APP_2, DB_TEST_APP_2),
-        timeout=20 * MINUTE_SECS,
+    retry_if_cli_error(
+        lambda: model_2.wait(
+            ready=wait_for_apps_status(jubilant.all_active, DB_APP_2, DB_TEST_APP_2),
+            timeout=20 * MINUTE_SECS,
+        )
     )
 
 
@@ -150,23 +155,29 @@ def test_async_relate(first_model: str, second_model: str) -> None:
     """Relate the two PostgreSQL clusters."""
     logging.info("Creating offers in first model")
     model_1 = Juju(model=first_model)
-    model_1.offer(f"{first_model}.{DB_APP_1}", endpoint="replication-offer")
+    retry_if_cli_error(
+        lambda: model_1.offer(f"{first_model}.{DB_APP_1}", endpoint="replication-offer")
+    )
 
     logging.info("Consuming offer in second model")
     model_2 = Juju(model=second_model)
-    model_2.consume(f"{first_model}.{DB_APP_1}")
+    retry_if_cli_error(lambda: model_2.consume(f"{first_model}.{DB_APP_1}"))
 
     logging.info("Relating the two postgresql clusters")
-    model_2.integrate(f"{DB_APP_1}", f"{DB_APP_2}:replication")
+    retry_if_cli_error(lambda: model_2.integrate(f"{DB_APP_1}", f"{DB_APP_2}:replication"))
 
     logging.info("Waiting for the applications to settle")
-    model_1.wait(
-        ready=wait_for_apps_status(jubilant.any_active, DB_APP_1),
-        timeout=10 * MINUTE_SECS,
+    retry_if_cli_error(
+        lambda: model_1.wait(
+            ready=wait_for_apps_status(jubilant.any_active, DB_APP_1),
+            timeout=10 * MINUTE_SECS,
+        )
     )
-    model_2.wait(
-        ready=wait_for_apps_status(jubilant.any_active, DB_APP_2),
-        timeout=10 * MINUTE_SECS,
+    retry_if_cli_error(
+        lambda: model_2.wait(
+            ready=wait_for_apps_status(jubilant.any_active, DB_APP_2),
+            timeout=10 * MINUTE_SECS,
+        )
     )
 
 
@@ -176,16 +187,24 @@ def test_create_replication(first_model: str, second_model: str) -> None:
     model_2 = Juju(model=second_model)
 
     logging.info("Running create replication action")
-    model_1.run(
-        unit=get_app_leader(model_1, DB_APP_1), action="create-replication", wait=5 * MINUTE_SECS
-    ).raise_on_failure()
+    retry_if_cli_error(
+        lambda: model_1.run(
+            unit=get_app_leader(model_1, DB_APP_1),
+            action="create-replication",
+            wait=5 * MINUTE_SECS,
+        ).raise_on_failure()
+    )
 
     logging.info("Waiting for the applications to settle")
-    model_1.wait(
-        ready=wait_for_apps_status(jubilant.all_active, DB_APP_1), timeout=20 * MINUTE_SECS
+    retry_if_cli_error(
+        lambda: model_1.wait(
+            ready=wait_for_apps_status(jubilant.all_active, DB_APP_1), timeout=20 * MINUTE_SECS
+        )
     )
-    model_2.wait(
-        ready=wait_for_apps_status(jubilant.all_active, DB_APP_2), timeout=20 * MINUTE_SECS
+    retry_if_cli_error(
+        lambda: model_2.wait(
+            ready=wait_for_apps_status(jubilant.all_active, DB_APP_2), timeout=20 * MINUTE_SECS
+        )
     )
 
 
@@ -226,39 +245,59 @@ def test_unrelate_and_relate(first_model: str, second_model: str) -> None:
     model_2 = Juju(model=second_model)
 
     logging.info("Remove async relation")
-    model_2.remove_relation(f"{DB_APP_1}", f"{DB_APP_2}:replication")
+    retry_if_cli_error(lambda: model_2.remove_relation(f"{DB_APP_1}", f"{DB_APP_2}:replication"))
 
     logging.info("Waiting for the applications to settle")
-    model_1.wait(
-        ready=wait_for_apps_status(jubilant.all_agents_idle, DB_APP_1), timeout=10 * MINUTE_SECS
+    retry_if_cli_error(
+        lambda: model_1.wait(
+            ready=wait_for_apps_status(jubilant.all_agents_idle, DB_APP_1),
+            timeout=10 * MINUTE_SECS,
+        )
     )
-    model_2.wait(
-        ready=wait_for_apps_status(jubilant.all_agents_idle, DB_APP_2), timeout=10 * MINUTE_SECS
+    retry_if_cli_error(
+        lambda: model_2.wait(
+            ready=wait_for_apps_status(jubilant.all_agents_idle, DB_APP_2),
+            timeout=10 * MINUTE_SECS,
+        )
     )
 
     logging.info("Re-relating the two postgresql clusters")
-    model_2.integrate(f"{DB_APP_1}", f"{DB_APP_2}:replication")
+    retry_if_cli_error(lambda: model_2.integrate(f"{DB_APP_1}", f"{DB_APP_2}:replication"))
 
-    model_1.wait(
-        ready=wait_for_apps_status(jubilant.all_agents_idle, DB_APP_1), timeout=10 * MINUTE_SECS
+    retry_if_cli_error(
+        lambda: model_1.wait(
+            ready=wait_for_apps_status(jubilant.all_agents_idle, DB_APP_1),
+            timeout=10 * MINUTE_SECS,
+        )
     )
-    model_2.wait(
-        ready=wait_for_apps_status(jubilant.all_agents_idle, DB_APP_2), timeout=10 * MINUTE_SECS
+    retry_if_cli_error(
+        lambda: model_2.wait(
+            ready=wait_for_apps_status(jubilant.all_agents_idle, DB_APP_2),
+            timeout=10 * MINUTE_SECS,
+        )
     )
 
     logging.info("Running create replication action")
-    model_1.run(
-        unit=get_app_leader(model_1, DB_APP_1), action="create-replication", wait=5 * MINUTE_SECS
-    ).raise_on_failure()
+    retry_if_cli_error(
+        lambda: model_1.run(
+            unit=get_app_leader(model_1, DB_APP_1),
+            action="create-replication",
+            wait=5 * MINUTE_SECS,
+        ).raise_on_failure()
+    )
 
     rerelate_test_app(model_1, DB_APP_1, DB_TEST_APP_1)
 
     logging.info("Waiting for the applications to settle")
-    model_1.wait(
-        ready=wait_for_apps_status(jubilant.all_active, DB_APP_1), timeout=20 * MINUTE_SECS
+    retry_if_cli_error(
+        lambda: model_1.wait(
+            ready=wait_for_apps_status(jubilant.all_active, DB_APP_1), timeout=20 * MINUTE_SECS
+        )
     )
-    model_2.wait(
-        ready=wait_for_apps_status(jubilant.all_active, DB_APP_2), timeout=20 * MINUTE_SECS
+    retry_if_cli_error(
+        lambda: model_2.wait(
+            ready=wait_for_apps_status(jubilant.all_active, DB_APP_2), timeout=20 * MINUTE_SECS
+        )
     )
 
     results = get_db_max_written_values(first_model, second_model, first_model, DB_TEST_APP_1)
@@ -274,12 +313,16 @@ def test_failover_in_main_cluster(first_model: str, second_model: str) -> None:
 
     rerelate_test_app(model_1, DB_APP_1, DB_TEST_APP_1)
 
-    model_1.remove_unit(DB_APP_1, num_units=1)
-    model_1.wait(
-        ready=wait_for_apps_status(jubilant.all_active, DB_APP_1), timeout=10 * MINUTE_SECS
+    retry_if_cli_error(lambda: model_1.remove_unit(DB_APP_1, num_units=1))
+    retry_if_cli_error(
+        lambda: model_1.wait(
+            ready=wait_for_apps_status(jubilant.all_active, DB_APP_1), timeout=10 * MINUTE_SECS
+        )
     )
-    model_2.wait(
-        ready=wait_for_apps_status(jubilant.all_active, DB_APP_2), timeout=10 * MINUTE_SECS
+    retry_if_cli_error(
+        lambda: model_2.wait(
+            ready=wait_for_apps_status(jubilant.all_active, DB_APP_2), timeout=10 * MINUTE_SECS
+        )
     )
 
     for attempt in Retrying(stop=stop_after_attempt(10), wait=wait_fixed(3), reraise=True):
@@ -301,13 +344,17 @@ def test_failover_in_standby_cluster(first_model: str, second_model: str) -> Non
 
     rerelate_test_app(model_1, DB_APP_1, DB_TEST_APP_1)
 
-    model_2.remove_unit(DB_APP_2, num_units=1)
+    retry_if_cli_error(lambda: model_2.remove_unit(DB_APP_2, num_units=1))
 
-    model_2.wait(
-        ready=lambda status: len(status.apps[DB_APP_2].units) == 2, timeout=2 * MINUTE_SECS
+    retry_if_cli_error(
+        lambda: model_2.wait(
+            ready=lambda status: len(status.apps[DB_APP_2].units) == 2, timeout=2 * MINUTE_SECS
+        )
     )
-    model_2.wait(
-        ready=wait_for_apps_status(jubilant.all_active, DB_APP_2), timeout=10 * MINUTE_SECS
+    retry_if_cli_error(
+        lambda: model_2.wait(
+            ready=wait_for_apps_status(jubilant.all_active, DB_APP_2), timeout=10 * MINUTE_SECS
+        )
     )
 
     for attempt in Retrying(stop=stop_after_attempt(10), wait=wait_fixed(3), reraise=True):
@@ -327,15 +374,19 @@ def test_scale_up(first_model: str, second_model: str) -> None:
     model_2 = Juju(model=second_model)
 
     rerelate_test_app(model_1, DB_APP_1, DB_TEST_APP_1)
-    model_1.add_unit(DB_APP_1)
-    model_2.add_unit(DB_APP_2)
+    retry_if_cli_error(lambda: model_1.add_unit(DB_APP_1))
+    retry_if_cli_error(lambda: model_2.add_unit(DB_APP_2))
 
     logging.info("Waiting for the applications to settle")
-    model_1.wait(
-        ready=wait_for_apps_status(jubilant.all_active, DB_APP_1), timeout=20 * MINUTE_SECS
+    retry_if_cli_error(
+        lambda: model_1.wait(
+            ready=wait_for_apps_status(jubilant.all_active, DB_APP_1), timeout=20 * MINUTE_SECS
+        )
     )
-    model_2.wait(
-        ready=wait_for_apps_status(jubilant.all_active, DB_APP_2), timeout=20 * MINUTE_SECS
+    retry_if_cli_error(
+        lambda: model_2.wait(
+            ready=wait_for_apps_status(jubilant.all_active, DB_APP_2), timeout=20 * MINUTE_SECS
+        )
     )
 
     results = get_db_max_written_values(first_model, second_model, first_model, DB_TEST_APP_1)
@@ -377,27 +428,37 @@ def get_db_max_written_values(
 
 def rerelate_test_app(juju: Juju, db_name: str, test_app_name: str) -> None:
     logging.info(f"Reintegrating {db_name} and {test_app_name}")
-    juju.remove_relation(db_name, f"{test_app_name}:database")
-    juju.wait(
-        ready=wait_for_apps_status(jubilant.all_blocked, test_app_name)
-        and wait_for_apps_status(jubilant.all_active, db_name),
-        timeout=10 * MINUTE_SECS,
+    retry_if_cli_error(lambda: juju.remove_relation(db_name, f"{test_app_name}:database"))
+    retry_if_cli_error(
+        lambda: juju.wait(
+            ready=wait_for_apps_status(jubilant.all_blocked, test_app_name)
+            and wait_for_apps_status(jubilant.all_active, db_name),
+            timeout=10 * MINUTE_SECS,
+        )
     )
 
-    juju.integrate(f"{db_name}:database", f"{test_app_name}:database")
-    juju.wait(
-        ready=wait_for_apps_status(jubilant.all_active, test_app_name, db_name),
-        timeout=10 * MINUTE_SECS,
+    retry_if_cli_error(lambda: juju.integrate(f"{db_name}:database", f"{test_app_name}:database"))
+    retry_if_cli_error(
+        lambda: juju.wait(
+            ready=wait_for_apps_status(jubilant.all_active, test_app_name, db_name),
+            timeout=10 * MINUTE_SECS,
+        )
     )
 
     logging.info("Clearing continuous writes")
     application_unit = get_app_leader(juju, test_app_name)
-    juju.run(unit=application_unit, action="clear-continuous-writes", wait=120).raise_on_failure()
+    retry_if_cli_error(
+        lambda: juju.run(
+            unit=application_unit, action="clear-continuous-writes", wait=120
+        ).raise_on_failure()
+    )
 
     logging.info("Starting continuous writes")
     for attempt in Retrying(stop=stop_after_attempt(10), reraise=True):
         with attempt:
-            result = juju.run(unit=application_unit, action="start-continuous-writes")
+            result = retry_if_cli_error(
+                lambda: juju.run(unit=application_unit, action="start-continuous-writes")
+            )
             result.raise_on_failure()
 
             assert result.results["result"] == "True"


### PR DESCRIPTION
## Issue
Juju 3.6.13 no longer applies labels to Patroni-created Endpoints.

## Solution
Query resources with both Juju and Patroni labels to ensure proper resource discovery and cleanup.

Note: this PR includes changes from https://github.com/canonical/postgresql-k8s-operator/pull/1209 because I was testing on top of it due to the errors that led to the current PR: https://github.com/canonical/postgresql-k8s-operator/actions/runs/21170093807/job/60884999558?pr=1209#step:6:2593
```
FAILED tests/integration/test_charm.py::test_application_created_required_resources - AssertionError: assert {'Endpoints/p...k8s-replicas'} == {'Endpoints/p...-config', ...}
  
  Extra items in the right set:
  'Endpoints/patroni-postgresql-k8s-config'
  'Endpoints/patroni-postgresql-k8s-sync'
  'Endpoints/patroni-postgresql-k8s'
  
  Full diff:
    {
  -     'Endpoints/patroni-postgresql-k8s',
  -     'Endpoints/patroni-postgresql-k8s-config',
  -     'Endpoints/patroni-postgresql-k8s-sync',
        'Endpoints/postgresql-k8s-primary',
        'Endpoints/postgresql-k8s-replicas',
        'Service/patroni-postgresql-k8s-config',
        'Service/postgresql-k8s-primary',
        'Service/postgresql-k8s-replicas',
    }
```

Also, a retry wrapper was added to the async replication tests calls to Juju, due to https://github.com/canonical/jubilant/issues/241.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
