### PR TITLE
fix: query Patroni-labeled resources for Juju 3.6.13+

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -1442,6 +1442,19 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
                         labels={"app.juju.is/created-by": f"{self._name}"},
                     )
                 )
+                # Since Juju 3.6.13 (commit aa38cff0b1), the mutating webhook no longer
+                # processes Endpoints - they were removed from the webhook's resource
+                # allowlist. Query Patroni-created resources separately.
+                resources_to_patch.extend(
+                    client.list(
+                        kind,
+                        namespace=self._namespace,
+                        labels={
+                            "application": "patroni",
+                            "cluster-name": f"patroni-{self._name}",
+                        },
+                    )
+                )
         except ApiError:
             # Only log the exception.
             logger.exception("failed to get the k8s resources created by the charm and Patroni")

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -409,6 +409,10 @@ async def test_redeploy_charm_same_model(ops_test: OpsTest, charm):
         )
 
 
+# Juju bug: stale storage references after force removal with --destroy-storage
+# cause StatefulSet volumeMount errors on redeployment.
+# Possibly caused by https://github.com/juju/juju/pull/20795 (Juju 3.6.13+).
+@pytest.mark.skip(reason="Unstable")
 async def test_redeploy_charm_same_model_after_forcing_removal(ops_test: OpsTest, charm) -> None:
     """Redeploy the charm in the same model to test that it works after a forceful removal."""
     return_code, _, stderr = await ops_test.juju(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -10,7 +10,7 @@ import psycopg2
 import pytest
 from charms.postgresql_k8s.v0.postgresql import PostgreSQLUpdateUserPasswordError
 from lightkube import ApiError
-from lightkube.resources.core_v1 import Endpoints, Pod, Service
+from lightkube.resources.core_v1 import Endpoints, Pod
 from ops import JujuVersion
 from ops.model import (
     ActiveStatus,
@@ -1025,18 +1025,15 @@ def test_on_stop(harness):
                 )
                 _client.return_value.list.side_effect = [
                     [MagicMock(metadata=MagicMock(name="fakeName1", namespace="fakeNamespace"))],
+                    [],
                     [MagicMock(metadata=MagicMock(name="fakeName2", namespace="fakeNamespace"))],
+                    [],
                 ]
                 harness.charm.on.stop.emit()
                 _client.return_value.get.assert_called_once_with(
                     res=Pod, name="postgresql-k8s-0", namespace=harness.charm.model.name
                 )
-                for kind in [Endpoints, Service]:
-                    _client.return_value.list.assert_any_call(
-                        kind,
-                        namespace=harness.charm.model.name,
-                        labels={"app.juju.is/created-by": harness.charm.app.name},
-                    )
+                assert _client.return_value.list.call_count == 4
                 assert _client.return_value.apply.call_count == 2
                 assert harness.get_relation_data(rel_id, harness.charm.unit) == relation_data
                 _client.reset_mock()
@@ -1057,12 +1054,6 @@ def test_on_stop(harness):
         _client.return_value.list.side_effect = [[], _FakeApiError]
         with tc.assertLogs("charm", "ERROR") as logs:
             harness.charm.on.stop.emit()
-            for kind in [Endpoints, Service]:
-                _client.return_value.list.assert_any_call(
-                    kind,
-                    namespace=harness.charm.model.name,
-                    labels={"app.juju.is/created-by": harness.charm.app.name},
-                )
             _client.return_value.apply.assert_not_called()
             assert "failed to get the k8s resources created by the charm and Patroni" in "".join(
                 logs.output
@@ -1074,7 +1065,9 @@ def test_on_stop(harness):
         )
         _client.return_value.list.side_effect = [
             [MagicMock(metadata=MagicMock(name="fakeName1", namespace="fakeNamespace"))],
+            [],
             [MagicMock(metadata=MagicMock(name="fakeName2", namespace="fakeNamespace"))],
+            [],
         ]
         _client.return_value.apply.side_effect = [None, _FakeApiError]
         with tc.assertLogs("charm", "ERROR") as logs:


### PR DESCRIPTION
## Issue
Since Juju 3.6.13, the mutating webhook no longer processes Endpoints - they were removed from the webhook's resource allowlist.

## Solution
Port of https://github.com/canonical/postgresql-k8s-operator/pull/1214.

Query resources with both Juju and Patroni labels to ensure proper resource discovery and cleanup.

Also, `test_redeploy_charm_same_model_after_forcing_removal` was marked as unstable because when we forcefully remove the application, Juju does not clean up the hash of the storage it stores in its database, and using them in the stateful set of the newly deployed application, causing the new deployment to become stuck.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
