### PR TITLE
[DPE-9361] Strict mode configuration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,12 @@ options:
       either "all", "majority" or a positive integer value.
     type: string
     default: "all"
+  synchronous-mode-strict:
+    description: |
+      Enforce transactions to be committed on Primary and at least one more synchronous node.
+      Default is true.
+    type: boolean
+    default: true
   connection-authentication-timeout:
     description: |
       Sets the maximum allowed time to complete client authentication.
@@ -76,6 +82,12 @@ options:
       Default is on (true).
     type: boolean
     default: true
+  durability-maximum-lag-on-failover:
+    description: |
+      The amount of transactions that can be lost in bytes to consider failover is safe.
+      Default is 1048576.
+    type: int
+    default: 1048576
   durability-synchronous-commit:
     description: |
       Sets the current transactions synchronization level. This charm allows only the
@@ -832,6 +844,14 @@ options:
       Allowed values are: from 64 to 2147483647.
     type: int
     default: 4096
+  storage-hot-standby-feedback:
+    description: |
+      Send feedback to the primary or upstream standby about queries currently executing on
+      the standby.
+      Warning: enabling can cause database bloat on the Primary for some workloads.
+      Default is false.
+    type: boolean
+    default: false
   storage-old-snapshot-threshold:
     description: |
       Time before a snapshot is too old to read pages changed after the snapshot was taken.

--- a/src/config.py
+++ b/src/config.py
@@ -8,7 +8,7 @@ import logging
 from typing import Annotated, Literal
 
 from charms.data_platform_libs.v1.data_models import BaseConfigModel
-from pydantic import Field, PositiveInt, conint
+from pydantic import Field, NonNegativeInt, PositiveInt
 
 from locales import ROCK_LOCALES
 
@@ -16,13 +16,14 @@ logger = logging.getLogger(__name__)
 
 
 # Type for worker process parameters that must be >= 2
-WorkerProcessInt = Annotated[int, conint(ge=2)]
+WorkerProcessInt = Annotated[int, Field(ge=2)]
 
 
 class CharmConfig(BaseConfigModel):
     """Manager for the structured configuration."""
 
     synchronous_node_count: Literal["all", "majority"] | PositiveInt = Field(default="all")
+    synchronous_mode_strict: bool = Field(default=True)
     connection_authentication_timeout: int | None = Field(ge=1, le=600, default=None)
     connection_statement_timeout: int | None = Field(ge=0, le=2147483647, default=None)
     cpu_max_logical_replication_workers: Literal["auto"] | WorkerProcessInt | None = Field(
@@ -41,6 +42,7 @@ class CharmConfig(BaseConfigModel):
     cpu_max_worker_processes: Literal["auto"] | WorkerProcessInt | None = Field(default="auto")
     cpu_parallel_leader_participation: bool | None = Field(default=None)
     cpu_wal_compression: bool | None = Field(default=None)
+    durability_maximum_lag_on_failover: NonNegativeInt | None = Field(default=None)
     durability_synchronous_commit: Literal["on", "remote_apply", "remote_write"] | None = Field(
         default=None
     )
@@ -208,6 +210,7 @@ class CharmConfig(BaseConfigModel):
         | None
     ) = Field(default=None)
     storage_gin_pending_list_limit: int | None = Field(ge=64, le=2147483647, default=None)
+    storage_hot_standby_feedback: bool | None = Field(default=None)
     storage_old_snapshot_threshold: int | None = Field(ge=-1, le=86400, default=None)
     system_users: str | None = Field(default=None)
     vacuum_autovacuum_analyze_scale_factor: float | None = Field(ge=0, le=100, default=None)

--- a/src/patroni.py
+++ b/src/patroni.py
@@ -243,7 +243,8 @@ class Patroni:
         # Try to update synchronous_node_count.
         return {
             "synchronous_node_count": self._synchronous_node_count,
-            "synchronous_mode_strict": self._charm.config.synchronous_mode_strict
+            "synchronous_mode_strict": self._members_count > 1
+            and self._charm.config.synchronous_mode_strict
             and self._synchronous_node_count > 0,
         }
 

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -1,7 +1,9 @@
 bootstrap:
   dcs:
-    synchronous_mode: true
     failsafe_mode: true
+    maximum_lag_on_failover: {{ maximum_lag_on_failover }}
+    synchronous_mode: true
+    synchronous_mode_strict: false
     synchronous_node_count: {{ synchronous_node_count }}
     postgresql:
       use_pg_rewind: true

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -38,6 +38,7 @@ async def test_config_parameters(ops_test: OpsTest, charm) -> None:
         },  # config option is one of `all`, `minority` or `majority`
         {"connection-authentication-timeout": ["0", "60"]},  # config option is from 1 and 600
         {"connection-statement-timeout": ["-1", "0"]},  # config option is from 0 to 2147483647
+        {"durability-maximum-lag-on-failover": ["-1", "1024"]},  # config option is integer
         {
             "durability-synchronous-commit": [test_string, "on"]
         },  # config option is one of `on`, `remote_apply` or `remote_write`

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -263,9 +263,6 @@ def test_on_config_changed(harness):
             "charm.PostgresqlOperatorCharm._validate_config_options"
         ) as _validate_config_options,
         patch("charm.PostgresqlOperatorCharm.update_config") as _update_config,
-        patch(
-            "charm.PostgresqlOperatorCharm.updated_synchronous_node_count", return_value=True
-        ) as _updated_synchronous_node_count,
         patch("charm.Patroni.member_started", return_value=True, new_callable=PropertyMock),
         patch("charm.Patroni.get_primary"),
         patch(
@@ -303,14 +300,6 @@ def test_on_config_changed(harness):
         harness.charm._on_config_changed(mock_event)
         assert isinstance(harness.charm.unit.status, ActiveStatus)
         assert not _enable_disable_extensions.called
-        _updated_synchronous_node_count.assert_called_once_with()
-
-        # Deferst on update sync nodes failure
-        _updated_synchronous_node_count.return_value = False
-        harness.charm._on_config_changed(mock_event)
-        mock_event.defer.assert_called_once_with()
-        mock_event.defer.reset_mock()
-        _updated_synchronous_node_count.return_value = True
 
         # Leader enables extensions
         with harness.hooks_disabled():

--- a/tests/unit/test_patroni.py
+++ b/tests/unit/test_patroni.py
@@ -228,6 +228,7 @@ def test_render_patroni_yml_file(harness, patroni):
             replication_password=patroni._replication_password,
             rewind_user=REWIND_USER,
             rewind_password=patroni._rewind_password,
+            maximum_lag_on_failover=1048576,
             synchronous_node_count=0,
             version="16",
             patroni_password=patroni._patroni_password,
@@ -265,6 +266,7 @@ def test_render_patroni_yml_file(harness, patroni):
             rewind_user=REWIND_USER,
             rewind_password=patroni._rewind_password,
             synchronous_node_count=0,
+            maximum_lag_on_failover=1048576,
             version="16",
             patroni_password=patroni._patroni_password,
             instance_password_encryption="scram-sha-256",
@@ -513,7 +515,7 @@ def test_update_synchronous_node_count(harness, patroni):
 
         _patch.assert_called_once_with(
             "https://postgresql-k8s-0:8008/config",
-            json={"synchronous_node_count": 0},
+            json={"synchronous_node_count": 0, "synchronous_mode_strict": False},
             verify=patroni._verify,
             auth=patroni._patroni_auth,
             timeout=API_REQUEST_TIMEOUT,


### PR DESCRIPTION
Port of https://github.com/canonical/postgresql-operator/pull/1389

Adds synchronous-mode-strict, storage-hot-standby-feedback and durability-maximum-lag-on-failover config options.

Spec is DA237.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
