### PR TITLE
[DPE-9361] Strict mode configuration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,12 @@ options:
       either "all", "majority" or a positive integer value.
     type: string
     default: "all"
+  synchronous_mode_strict:
+    description: |
+      Enforce transactions to be committed on Primary and at least one more synchronous node.
+      Default is true.
+    type: boolean
+    default: true
   connection_authentication_timeout:
     description: |
       Sets the maximum allowed time to complete client authentication.
@@ -69,6 +75,12 @@ options:
       Default is on (true).
     type: boolean
     default: true
+  durability_maximum_lag_on_failover:
+    description: |
+      The amount of transactions that can be lost in bytes to consider failover is safe.
+      Default is 1048576.
+    type: int
+    default: 1048576
   durability_synchronous_commit:
     description: |
       Sets the current transactions synchronization level. This charm allows only the
@@ -811,6 +823,14 @@ options:
       Allowed values are: from 64 to 2147483647.
     type: int
     default: 4096
+  storage_hot_standby_feedback:
+    description: |
+      Send feedback to the primary or upstream standby about queries currently executing on
+      the standby.
+      Warning: enabling can cause database bloat on the Primary for some workloads.
+      Default is false.
+    type: boolean
+    default: false
   storage_old_snapshot_threshold:
     description: |
       Time before a snapshot is too old to read pages changed after the snapshot was taken.

--- a/src/config.py
+++ b/src/config.py
@@ -8,18 +8,19 @@ import logging
 from typing import Annotated, Literal
 
 from charms.data_platform_libs.v0.data_models import BaseConfigModel
-from pydantic import PositiveInt, conint, validator
+from pydantic import Field, NonNegativeInt, PositiveInt, validator
 
 logger = logging.getLogger(__name__)
 
 # Type for worker process parameters that must be >= 2
-WorkerProcessInt = Annotated[int, conint(ge=2)]
+WorkerProcessInt = Annotated[int, Field(ge=2)]
 
 
 class CharmConfig(BaseConfigModel):
     """Manager for the structured configuration."""
 
     synchronous_node_count: Literal["all", "majority"] | PositiveInt
+    synchronous_mode_strict: bool = Field(default=True)
     connection_authentication_timeout: int | None
     connection_statement_timeout: int | None
     cpu_max_logical_replication_workers: Literal["auto"] | WorkerProcessInt | None
@@ -29,6 +30,7 @@ class CharmConfig(BaseConfigModel):
     cpu_max_worker_processes: Literal["auto"] | WorkerProcessInt | None
     cpu_parallel_leader_participation: bool | None
     cpu_wal_compression: bool | None
+    durability_maximum_lag_on_failover: NonNegativeInt | None = Field(default=None)
     durability_synchronous_commit: str | None
     durability_wal_keep_size: int | None
     experimental_max_connections: int | None
@@ -173,6 +175,7 @@ class CharmConfig(BaseConfigModel):
     storage_bgwriter_lru_multiplier: float | None
     storage_default_table_access_method: str | None
     storage_gin_pending_list_limit: int | None
+    storage_hot_standby_feedback: bool | None = Field(default=None)
     storage_old_snapshot_threshold: int | None
     vacuum_autovacuum_analyze_scale_factor: float | None
     vacuum_autovacuum_analyze_threshold: int | None

--- a/src/patroni.py
+++ b/src/patroni.py
@@ -242,6 +242,17 @@ class Patroni:
             else planned_units - 1
         )
 
+    @cached_property
+    def synchronous_configuration(self) -> dict[str, Any]:
+        """Synchronous mode configuration."""
+        # Try to update synchronous_node_count.
+        return {
+            "synchronous_node_count": self._synchronous_node_count,
+            "synchronous_mode_strict": self._members_count > 1
+            and self._charm.config.synchronous_mode_strict
+            and self._synchronous_node_count > 0,
+        }
+
     def update_synchronous_node_count(self) -> None:
         """Update synchronous_node_count."""
         # Try to update synchronous_node_count.
@@ -249,7 +260,7 @@ class Patroni:
             with attempt:
                 r = requests.patch(
                     f"{self._patroni_url}/config",
-                    json={"synchronous_node_count": self._synchronous_node_count},
+                    json=self.synchronous_configuration,
                     verify=self._verify,
                     auth=self._patroni_auth,
                     timeout=PATRONI_TIMEOUT,
@@ -621,6 +632,7 @@ class Patroni:
             stanza=stanza,
             restore_stanza=restore_stanza,
             synchronous_node_count=self._synchronous_node_count,
+            maximum_lag_on_failover=self._charm.config.durability_maximum_lag_on_failover,
             version=self.rock_postgresql_version.split(".")[0],
             pg_parameters=parameters,
             primary_cluster_endpoint=self._charm.async_replication.get_primary_cluster_endpoint(),

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -1,8 +1,10 @@
 bootstrap:
   dcs:
-    synchronous_mode: true
     failsafe_mode: true
     synchronous_node_count: {{ synchronous_node_count }}
+    maximum_lag_on_failover: {{ maximum_lag_on_failover }}
+    synchronous_mode: true
+    synchronous_mode_strict: false
     postgresql:
       use_pg_rewind: true
       remove_data_directory_on_rewind_failure: false

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -38,6 +38,7 @@ async def test_config_parameters(ops_test: OpsTest, charm) -> None:
         },  # config option is one of `all`, `minority` or `majority`
         {"connection_authentication_timeout": ["0", "60"]},  # config option is from 1 and 600
         {"connection_statement_timeout": ["-1", "0"]},  # config option is from 0 to 2147483647
+        {"durability_maximum_lag_on_failover": ["-1", "1024"]},  # config option is integer
         {
             "durability_synchronous_commit": [test_string, "on"]
         },  # config option is one of `on`, `remote_apply` or `remote_write`

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -293,9 +293,6 @@ def test_on_config_changed(harness):
             "charm.PostgreSQLUpgrade.idle", return_value=False, new_callable=PropertyMock
         ) as _idle,
         patch("charm.PostgresqlOperatorCharm.update_config") as _update_config,
-        patch(
-            "charm.PostgresqlOperatorCharm.updated_synchronous_node_count", return_value=True
-        ) as _updated_synchronous_node_count,
         patch("charm.Patroni.member_started", return_value=True, new_callable=PropertyMock),
         patch("charm.Patroni.get_primary"),
         patch(
@@ -338,14 +335,6 @@ def test_on_config_changed(harness):
         harness.charm._on_config_changed(mock_event)
         assert isinstance(harness.charm.unit.status, ActiveStatus)
         assert not _enable_disable_extensions.called
-        _updated_synchronous_node_count.assert_called_once_with()
-
-        # Deferst on update sync nodes failure
-        _updated_synchronous_node_count.return_value = False
-        harness.charm._on_config_changed(mock_event)
-        mock_event.defer.assert_called_once_with()
-        mock_event.defer.reset_mock()
-        _updated_synchronous_node_count.return_value = True
 
         # Leader enables extensions
         with harness.hooks_disabled():

--- a/tests/unit/test_patroni.py
+++ b/tests/unit/test_patroni.py
@@ -224,6 +224,7 @@ def test_render_patroni_yml_file(harness, patroni):
             rewind_user=REWIND_USER,
             rewind_password=patroni._rewind_password,
             synchronous_node_count=0,
+            maximum_lag_on_failover=1048576,
             version="14",
             patroni_password=patroni._patroni_password,
         )
@@ -259,6 +260,7 @@ def test_render_patroni_yml_file(harness, patroni):
             rewind_user=REWIND_USER,
             rewind_password=patroni._rewind_password,
             synchronous_node_count=0,
+            maximum_lag_on_failover=1048576,
             version="14",
             patroni_password=patroni._patroni_password,
         )
@@ -469,7 +471,7 @@ def test_update_synchronous_node_count(harness, patroni):
 
         _patch.assert_called_once_with(
             "http://postgresql-k8s-0:8008/config",
-            json={"synchronous_node_count": 0},
+            json={"synchronous_node_count": 0, "synchronous_mode_strict": False},
             verify=True,
             auth=patroni._patroni_auth,
             timeout=10,


### PR DESCRIPTION
Port of https://github.com/canonical/postgresql-operator/pull/1389

Adds synchronous_mode_strict, storage_hot_standby_feedback and durability_maximum_lag_on_failover config options.

Spec is DA237.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
