### PR TITLE
Add optional flags to provides endpoints for PG16 K8s

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -63,8 +63,10 @@ provides:
     interface: postgresql_client
   metrics-endpoint:
     interface: prometheus_scrape
+    optional: true
   grafana-dashboard:
     interface: grafana_dashboard
+    optional: true
 
 requires:
   replication:


### PR DESCRIPTION
Backport of https://github.com/canonical/postgresql-k8s-operator/pull/1018

## Issue

SolQA is issues with automated testing due to mandatory relation declaration for COS.

## Solution

Mark those relations as optional.

## Checklist
- [X] I have added or updated any relevant documentation.
- [X] I have cleaned any remaining cloud resources from my accounts.
