### PR TITLE
[MISC] Sync renovate config changes

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,15 +6,18 @@
   reviewers: [
     'team:data-postgresql',
   ],
-  "baseBranches": ["main", "/^*\\/edge$/"],
+  baseBranchPatterns: [
+    'main',
+    '/^*\\/edge$/',
+  ],
   packageRules: [
     {
       matchPackageNames: [
         'pydantic',
       ],
+      "matchBaseBranches": ["main"],
       allowedVersions: '<2.0.0',
     },
   ],
-  customManagers: [
-  ],
+  customManagers: [],
 }


### PR DESCRIPTION
Only the default branch is used by renovate but syncing configs to reduce confusion.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
