### PR TITLE
[DPE-7891] test: re-enable discourse integration test

### DIFF
--- a/tests/integration/new_relations/test_new_relations_2.py
+++ b/tests/integration/new_relations/test_new_relations_2.py
@@ -64,7 +64,6 @@ async def test_database_deploy_clientapps(ops_test: OpsTest, charm):
 
 @markers.amd64_only  # discourse-k8s charm not available for arm64
 async def test_discourse(ops_test: OpsTest):
-    pytest.skip("Second migration doesn't complete")
     # Deploy Discourse and Redis.
     await gather(
         ops_test.model.deploy(DISCOURSE_APP_NAME, application_name=DISCOURSE_APP_NAME),


### PR DESCRIPTION
## Issue

The Discourse integration test (`test_discourse`) was disabled with `pytest.skip("Second migration doesn't complete")`. The root cause was a `PrematureDataAccessError` in `update_tls_flag`, which iterated all relations and attempted to set TLS data on uninitialized relations (where the `database` field was not yet set by the requirer). This was fixed in PR #933 (commit `bebd8b9a5`), but the test was never re-enabled.

## Solution

Re-enable the Discourse integration test by removing the `pytest.skip`. The test passes with the guard check already present in `update_tls_flag`, which skips relations where `fetch_relation_field(relation.id, "database")` returns `None`.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.

Fixes https://github.com/canonical/postgresql-k8s-operator/issues/1053.