### PR TITLE
[DPE-7891] test: re-enable discourse integration test

### DIFF
--- a/tests/integration/new_relations/test_new_relations_2.py
+++ b/tests/integration/new_relations/test_new_relations_2.py
@@ -64,7 +64,6 @@ async def test_database_deploy_clientapps(ops_test: OpsTest, charm):
 
 @markers.amd64_only  # discourse-k8s charm not available for arm64
 async def test_discourse(ops_test: OpsTest):
-    pytest.skip("Second migration doesn't complete")
     # Deploy Discourse and Redis.
     await gather(
         ops_test.model.deploy(DISCOURSE_APP_NAME, application_name=DISCOURSE_APP_NAME),


### PR DESCRIPTION
## Issue

The Discourse integration test (`test_discourse`) was disabled with `pytest.skip("Second migration doesn't complete")`. The skip was carried over from the `main` branch, where a `PrematureDataAccessError` in `update_tls_flag` caused the test to fail. The `16/edge` branch is not affected by this bug — its `update_connection_info` method already guards against uninitialized relations with `if not database or not password: continue`.

## Solution

Re-enable the Discourse integration test by removing the `pytest.skip`. The test passes since the code path that caused the failure on `main` does not exist on this branch.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.