### PR TITLE
feat: multiple Patroni primaries alert

### DIFF
--- a/docs/reference/alert-rules.md
+++ b/docs/reference/alert-rules.md
@@ -47,6 +47,7 @@ This page contains a markdown version of the alert rules described in the `postg
 |------|----------|-------|
 | `PatroniPostgresqlDown` | ![critical] | Patroni PostgreSQL instance is down.<br>Check for errors in the Loki logs. |
 | `PatroniMultipleLeaders` | ![critical] | Patroni cluster has multiple leader nodes.<br>More than one leader node (primary or standby) is detected inside a cluster.<br>This may indicate split-brain; check Patroni/Loki logs and network/quorum state. |
+| `PatroniPrimaryAndStandbyLeader` | ![critical] | Patroni cluster has both primary and standby leaders.<br>A primary leader and a standby leader are simultaneously detected inside a cluster.<br>Check for errors in the Loki logs. |
 | `PatroniHasNoLeader` | ![critical] | Patroni instance has no leader node.<br>A leader node (neither primary nor standby) cannot be found inside a cluster.<br>Check for errors in the Loki logs. |
 
 ## `PgbackrestExporterK8s`

--- a/docs/reference/alert-rules.md
+++ b/docs/reference/alert-rules.md
@@ -45,8 +45,9 @@ This page contains a markdown version of the alert rules described in the `postg
 
 | Alert | Severity | Notes |
 |------|----------|-------|
-| PatroniPostgresqlDown | ![critical] | Patroni PostgreSQL instance is down.<br>Check for errors in the Loki logs. |
-| PatroniHasNoLeader | ![critical] | Patroni instance has no leader node.<br>A leader node (neither primary nor standby) cannot be found inside a cluster.<br>Check for errors in the Loki logs. |
+| `PatroniPostgresqlDown` | ![critical] | Patroni PostgreSQL instance is down.<br>Check for errors in the Loki logs. |
+| `PatroniMultipleLeaders` | ![critical] | Patroni cluster has multiple leader nodes.<br>More than one leader node (primary or standby) is detected inside a cluster.<br>This may indicate split-brain; check Patroni/Loki logs and network/quorum state. |
+| `PatroniHasNoLeader` | ![critical] | Patroni instance has no leader node.<br>A leader node (neither primary nor standby) cannot be found inside a cluster.<br>Check for errors in the Loki logs. |
 
 ## `PgbackrestExporterK8s`
 

--- a/src/prometheus_alert_rules/patroni_rules.yaml
+++ b/src/prometheus_alert_rules/patroni_rules.yaml
@@ -29,6 +29,18 @@ groups:
           Check for errors in the Loki logs.
           LABELS = {{ $labels }}
 
+    - alert: PatroniPrimaryAndStandbyLeader
+      expr: 'sum by (scope) (patroni_master) == 1 and sum by (scope) (patroni_standby_leader) == 1'
+      for: 0m
+      labels:
+        severity: critical
+      annotations:
+        summary: Patroni cluster {{ $labels.scope }} has both primary and standby leaders.
+        description: |
+          A primary leader and a standby leader are simultaneously detected inside the cluster {{ $labels.scope }}.
+          Check for errors in the Loki logs.
+          LABELS = {{ $labels }}
+
     # 2.4.1
     - alert: PatroniHasNoLeader
       expr: '(max by (scope) (patroni_master) < 1) and (max by (scope) (patroni_standby_leader) < 1)'

--- a/src/prometheus_alert_rules/patroni_rules.yaml
+++ b/src/prometheus_alert_rules/patroni_rules.yaml
@@ -18,7 +18,7 @@ groups:
           LABELS = {{ $labels }}
 
     - alert: PatroniMultipleLeaders
-      expr: 'sum by (scope) (patroni_master) > 1 or sum by (scope) (patroni_standby_leader) > 1'
+      expr: 'sum by (juju_model,juju_application,juju_model_uuid,scope) (patroni_master) > 1 or sum by (juju_model,juju_application,juju_model_uuid,scope) (patroni_standby_leader) > 1'
       for: 0m
       labels:
         severity: critical
@@ -30,7 +30,7 @@ groups:
           LABELS = {{ $labels }}
 
     - alert: PatroniPrimaryAndStandbyLeader
-      expr: 'sum by (scope) (patroni_master) == 1 and sum by (scope) (patroni_standby_leader) == 1'
+      expr: 'sum by (juju_model,juju_application,juju_model_uuid,scope) (patroni_master) == 1 and sum by (juju_model,juju_application,juju_model_uuid,scope) (patroni_standby_leader) == 1'
       for: 0m
       labels:
         severity: critical
@@ -43,7 +43,7 @@ groups:
 
     # 2.4.1
     - alert: PatroniHasNoLeader
-      expr: '(max by (scope) (patroni_master) < 1) and (max by (scope) (patroni_standby_leader) < 1)'
+      expr: '(max by (juju_model,juju_application,juju_model_uuid,scope) (patroni_master) < 1) and (max by (juju_model,juju_application,juju_model_uuid,scope) (patroni_standby_leader) < 1)'
       for: 0m
       labels:
         severity: critical

--- a/src/prometheus_alert_rules/patroni_rules.yaml
+++ b/src/prometheus_alert_rules/patroni_rules.yaml
@@ -17,6 +17,18 @@ groups:
           Check for errors in the Loki logs.
           LABELS = {{ $labels }}
 
+    - alert: PatroniMultipleLeaders
+      expr: 'sum by (scope) (patroni_master) > 1 or sum by (scope) (patroni_standby_leader) > 1'
+      for: 0m
+      labels:
+        severity: critical
+      annotations:
+        summary: Patroni cluster {{ $labels.scope }} has multiple leader nodes.
+        description: |
+          More than one leader node (primary or standby) is detected inside the cluster {{ $labels.scope }}.
+          Check for errors in the Loki logs.
+          LABELS = {{ $labels }}
+
     # 2.4.1
     - alert: PatroniHasNoLeader
       expr: '(max by (scope) (patroni_master) < 1) and (max by (scope) (patroni_standby_leader) < 1)'
@@ -24,7 +36,7 @@ groups:
       labels:
         severity: critical
       annotations:
-        summary: Patroni instance {{ $labels.instance }} has no leader node. 
+        summary: Patroni instance {{ $labels.instance }} has no leader node.
         description: |
           A leader node (neither primary nor standby) cannot be found inside the cluster {{ $labels.scope }}.
           Check for errors in the Loki logs.

--- a/tests/alerts/test_patroni_rules.yaml
+++ b/tests/alerts/test_patroni_rules.yaml
@@ -166,3 +166,37 @@ tests:
                 More than one leader node (primary or standby) is detected inside the cluster cluster1.
                 Check for errors in the Loki logs.
                 LABELS = map[scope:cluster1]
+
+  - name: PatroniPrimaryAndStandbyLeader does not fire if master=1 and standby_leader=0
+    interval: 1m
+    input_series:
+      - series: 'patroni_master{scope="cluster1"}'
+        values: '1'
+      - series: 'patroni_standby_leader{scope="cluster1"}'
+        values: '0'
+    alert_rule_test:
+      - alertname: PatroniPrimaryAndStandbyLeader
+        eval_time: 1m
+        exp_alerts: []
+
+  - name: PatroniPrimaryAndStandbyLeader fires if master=1 and standby_leader=1
+    interval: 1m
+    input_series:
+      - series: 'patroni_master{scope="cluster1"}'
+        values: '1'
+      - series: 'patroni_standby_leader{scope="cluster1"}'
+        values: '1'
+    alert_rule_test:
+      - alertname: PatroniPrimaryAndStandbyLeader
+        eval_time: 0m
+        exp_alerts:
+          - exp_labels:
+              alertname: PatroniPrimaryAndStandbyLeader
+              severity: critical
+              scope: cluster1
+            exp_annotations:
+              summary: Patroni cluster cluster1 has both primary and standby leaders.
+              description: |
+                A primary leader and a standby leader are simultaneously detected inside the cluster cluster1.
+                Check for errors in the Loki logs.
+                LABELS = map[scope:cluster1]

--- a/tests/alerts/test_patroni_rules.yaml
+++ b/tests/alerts/test_patroni_rules.yaml
@@ -78,3 +78,91 @@ tests:
       - alertname: PatroniHasNoLeader
         eval_time: 1m
         exp_alerts: []
+
+  - name: PatroniMultipleLeaders does not fire if master=1 and standby_leader=0
+    interval: 1m
+    input_series:
+      - series: 'patroni_master{scope="cluster1"}'
+        values: '1'
+      - series: 'patroni_standby_leader{scope="cluster1"}'
+        values: '0'
+    alert_rule_test:
+      - alertname: PatroniMultipleLeaders
+        eval_time: 1m
+        exp_alerts: []
+    
+  - name: PatroniMultipleLeaders does not fire if master=0 and standby_leader=1
+    interval: 1m
+    input_series:
+      - series: 'patroni_master{scope="cluster1"}'
+        values: '0'
+      - series: 'patroni_standby_leader{scope="cluster1"}'
+        values: '1'
+    alert_rule_test:
+      - alertname: PatroniMultipleLeaders
+        eval_time: 1m
+        exp_alerts: []
+    
+  - name: PatroniMultipleLeaders does not fire if master=1 and standby_leader=1
+    interval: 1m
+    input_series:
+      - series: 'patroni_master{scope="cluster1"}'
+        values: '1'
+      - series: 'patroni_standby_leader{scope="cluster1"}'
+        values: '1'
+    alert_rule_test:
+      - alertname: PatroniMultipleLeaders
+        eval_time: 1m
+        exp_alerts: []
+
+  - name: PatroniMultipleLeaders fires if two masters exist in one scope
+    interval: 1m
+    input_series:
+      - series: 'patroni_master{scope="cluster1",instance="pg1"}'
+        values: '1'
+      - series: 'patroni_master{scope="cluster1",instance="pg2"}'
+        values: '1'
+      - series: 'patroni_standby_leader{scope="cluster1",instance="pg1"}'
+        values: '0'
+      - series: 'patroni_standby_leader{scope="cluster1",instance="pg2"}'
+        values: '0'
+    alert_rule_test:
+      - alertname: PatroniMultipleLeaders
+        eval_time: 0m
+        exp_alerts:
+          - exp_labels:
+              alertname: PatroniMultipleLeaders
+              severity: critical
+              scope: cluster1
+            exp_annotations:
+              summary: Patroni cluster cluster1 has multiple leader nodes.
+              description: |
+                More than one leader node (primary or standby) is detected inside the cluster cluster1.
+                Check for errors in the Loki logs.
+                LABELS = map[scope:cluster1]
+
+  - name: PatroniMultipleLeaders fires if two standby leaders exist in one scope
+    interval: 1m
+    input_series:
+      - series: 'patroni_master{scope="cluster1",instance="pg1"}'
+        values: '0'
+      - series: 'patroni_master{scope="cluster1",instance="pg2"}'
+        values: '0'
+      - series: 'patroni_standby_leader{scope="cluster1",instance="pg1"}'
+        values: '1'
+      - series: 'patroni_standby_leader{scope="cluster1",instance="pg2"}'
+        values: '1'
+    alert_rule_test:
+      - alertname: PatroniMultipleLeaders
+        eval_time: 0m
+        exp_alerts:
+          - exp_labels:
+              alertname: PatroniMultipleLeaders
+              severity: critical
+              scope: cluster1
+            exp_annotations:
+              summary: Patroni cluster cluster1 has multiple leader nodes.
+              description: |
+                More than one leader node (primary or standby) is detected inside the cluster cluster1.
+                Check for errors in the Loki logs.
+                LABELS = map[scope:cluster1]


### PR DESCRIPTION
## Issue

There is no alert that would check for multiple leaders. This explicit alert will help detect a split-brain occurrence.

## Solution

1. `PatroniMultipleLeaders` - fires if multiple leaders are detected.

<img width="3789" height="639" alt="image" src="https://github.com/user-attachments/assets/791a00f6-e09d-4eca-ae3a-4b67d94baf4c" />

2. `PatroniPrimaryAndStandbyLeader` -fires if the cluster has both primary and standby leaders at the same time

## Checklist
- [X] I have added or updated any relevant documentation.
- [X] I have cleaned any remaining cloud resources from my accounts.

Closes: https://github.com/canonical/postgresql-operator/issues/1151