### PR TITLE
[DPE-9448] Don't override upgrade status

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -1051,6 +1051,8 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
                     self.app_peer_data["s3-initialization-block-message"]
                 )
                 return
+            if not self.upgrade.idle:
+                return
             if (
                 self._patroni.get_primary(unit_name_pattern=True) == self.unit.name
                 or self.is_standby_leader

--- a/src/ldap.py
+++ b/src/ldap.py
@@ -11,9 +11,7 @@ from charms.glauth_k8s.v0.ldap import (
     LdapRequirer,
     LdapUnavailableEvent,
 )
-from ops import Relation
-from ops.framework import Object
-from ops.model import ActiveStatus
+from ops import Object, Relation
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +42,7 @@ class PostgreSQLLDAP(Object):
             self.charm.app_peer_data.update({"ldap_enabled": "True"})
 
         self.charm.update_config()
-        self.charm.unit.status = ActiveStatus()
+        self.charm._set_active_status()
 
     def _on_ldap_unavailable(self, _: LdapUnavailableEvent) -> None:
         """Handler for the LDAP unavailable event."""

--- a/src/relations/async_replication.py
+++ b/src/relations/async_replication.py
@@ -23,7 +23,6 @@ from lightkube import ApiError, Client
 from lightkube.resources.core_v1 import Endpoints, Service
 from ops import (
     ActionEvent,
-    ActiveStatus,
     Application,
     BlockedStatus,
     MaintenanceStatus,
@@ -128,7 +127,6 @@ class PostgreSQLAsyncReplication(Object):
                             "promoted-cluster-counter": ""
                         })
                         self._set_app_status()
-                        self.charm._set_active_status()
                 except (StandbyClusterAlreadyPromotedError, ClusterNotPromotedError) as e:
                     event.fail(str(e))
                 return False
@@ -408,7 +406,7 @@ class PostgreSQLAsyncReplication(Object):
 
     def handle_read_only_mode(self) -> None:
         """Handle read-only mode (standby cluster that lost the relation with the primary cluster)."""
-        if not self.charm.is_blocked:
+        if not self.charm.is_blocked and not self.charm.unit.is_leader():
             self.charm._set_active_status()
 
         if self.charm.unit.is_leader():
@@ -676,16 +674,7 @@ class PostgreSQLAsyncReplication(Object):
         if self.charm._peers.data[self.charm.app].get("promoted-cluster-counter") == "0":
             self.charm.app.status = BlockedStatus(READ_ONLY_MODE_BLOCKING_MESSAGE)
             return
-        if self._relation is None:
-            self.charm.app.status = ActiveStatus()
-            return
-        primary_cluster = self.get_primary_cluster()
-        if primary_cluster is None:
-            self.charm.app.status = ActiveStatus()
-        else:
-            self.charm.app.status = ActiveStatus(
-                "Primary" if self.charm.app == primary_cluster else "Standby"
-            )
+        self.charm._set_active_status()
 
     def _stop_database(self, event: RelationChangedEvent) -> bool:
         """Stop the database."""

--- a/src/relations/db.py
+++ b/src/relations/db.py
@@ -13,14 +13,17 @@ from charms.postgresql_k8s.v0.postgresql import (
     PostgreSQLDeleteUserError,
     PostgreSQLGetPostgreSQLVersionError,
 )
-from ops.charm import (
+from ops import (
+    ActiveStatus,
+    BlockedStatus,
     CharmBase,
+    Object,
+    Relation,
     RelationBrokenEvent,
     RelationChangedEvent,
     RelationDepartedEvent,
+    Unit,
 )
-from ops.framework import Object
-from ops.model import ActiveStatus, BlockedStatus, Relation, Unit
 from pgconnstr import ConnectionString
 
 from constants import (

--- a/src/relations/postgresql_provider.py
+++ b/src/relations/postgresql_provider.py
@@ -18,9 +18,16 @@ from charms.postgresql_k8s.v0.postgresql import (
     PostgreSQLDeleteUserError,
     PostgreSQLGetPostgreSQLVersionError,
 )
-from ops.charm import CharmBase, RelationBrokenEvent, RelationChangedEvent, RelationDepartedEvent
-from ops.framework import Object
-from ops.model import ActiveStatus, BlockedStatus, Relation
+from ops import (
+    ActiveStatus,
+    BlockedStatus,
+    CharmBase,
+    Object,
+    Relation,
+    RelationBrokenEvent,
+    RelationChangedEvent,
+    RelationDepartedEvent,
+)
 
 from constants import DATABASE_PORT, ENDPOINT_SIMULTANEOUSLY_BLOCKING_MESSAGE
 from utils import new_password

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -615,6 +615,7 @@ def test_enable_disable_extensions(harness):
             return_value=False,
             new_callable=PropertyMock,
         ),
+        patch("charm.PostgreSQLUpgrade.idle", new_callable=PropertyMock, return_value=True),
     ):
         # Early exit if no primary
         harness.charm.enable_disable_extensions()
@@ -1718,6 +1719,7 @@ def test_set_active_status(harness):
             "charm.PostgresqlOperatorCharm.is_standby_leader", new_callable=PropertyMock
         ) as _is_standby_leader,
         patch("charm.Patroni.get_primary") as _get_primary,
+        patch("charm.PostgreSQLUpgrade.idle", new_callable=PropertyMock, return_value=True),
     ):
         for values in itertools.product(
             [


### PR DESCRIPTION
## Issue
Unit status during upgrade gets overwritten, hiding from the user that upgrade did not complete

## Solution
Add a check for upgrade idleness in the helper method

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
