### PR TITLE
[DPE-9448] Preserve upgrade statuses during rolling restart

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -1951,8 +1951,6 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
                     self.unit.status = BlockedStatus("ready to rollback application")
                 case "failed":
                     self.upgrade.set_unit_failed()
-                case "ready":
-                    self.upgrade.set_unit_ready()
                 case "upgrading":
                     self.unit.status = MaintenanceStatus("upgrading unit")
                 case "completed":

--- a/src/charm.py
+++ b/src/charm.py
@@ -1954,7 +1954,16 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
                 case "upgrading":
                     self.unit.status = MaintenanceStatus("upgrading unit")
                 case "completed":
-                    self.upgrade.set_unit_completed()
+                    if len(self.upgrade.app_units) > 1 and int(
+                        self.unit.name.split("/")[1]
+                    ) == max(int(unit.name.split("/")[1]) for unit in self.upgrade.app_units):
+                        # If the last unit resets the status, make sure to inform the user to
+                        # continue the upgrade
+                        self.unit.status = MaintenanceStatus(
+                            "upgrade completed, run resume-upgrade to proceed"
+                        )
+                    else:
+                        self.upgrade.set_unit_completed()
 
     def _restart(self, event: RunWithLock) -> None:
         """Restart PostgreSQL."""


### PR DESCRIPTION
## Issue
Rolling ops charm lib will overwrite the current status of a unit by default, potentially hiding if a refresh did not complete successfully.

## Solution
* Reset the upgrade status in the restart callback, so that rolling ops doesn't overwrite
* Set a reminder on the last unit to notify the user that `resume-refresh` still needs to be run

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
