### PR TITLE
[DPE-9555] fix(test): add explicit relation endpoints for GLAuth-PostgreSQL integration

### DIFF
--- a/tests/integration/test_ldap.py
+++ b/tests/integration/test_ldap.py
@@ -69,7 +69,9 @@ async def test_glauth_integration(ops_test: OpsTest):
         # Add both relations to GLAuth (PostgreSQL and self-signed-certificates)
         logger.info("Adding relations to GLAuth")
         await asyncio.gather(
-            ops_test.model.add_relation(GLAUTH_APP_NAME, glauth_psql_app_name),
+            ops_test.model.add_relation(
+                f"{GLAUTH_APP_NAME}:pg-database", f"{glauth_psql_app_name}:database"
+            ),
             ops_test.model.add_relation(GLAUTH_APP_NAME, glauth_cert_app_name),
         )
         await asyncio.gather(


### PR DESCRIPTION
## Issue

The `test_glauth_integration` integration test fails across PRs with:

```
juju.errors.JujuAPIError: ambiguous relation: "glauth-k8s glauth-postgresql-k8s" could refer to
  "glauth-k8s:pg-database glauth-postgresql-k8s:database";
  "glauth-postgresql-k8s:ldap glauth-k8s:ldap";
  "glauth-postgresql-k8s:receive-ca-cert glauth-k8s:send-ca-cert"
```

The test deploys `glauth-postgresql-k8s` (the backing PostgreSQL for GLAuth) from the `14/stable` channel. On March 2, 2026, `postgresql-k8s` rev 774 was published to `14/stable`, which added `ldap` (requires, interface `ldap`) and `receive-ca-cert` (requires, interface `certificate_transfer`) endpoints. These new endpoints match `glauth-k8s`'s existing `ldap` (provides) and `send-ca-cert` (provides) endpoints, creating 3 possible interface pairs between the two charms instead of the previous single one (`pg-database` ↔ `database`). This makes the unqualified `add_relation("glauth-k8s", "glauth-postgresql-k8s")` call ambiguous.

The previous `14/stable` revision (rev 494, from February 2025) did not have `ldap` or `receive-ca-cert` endpoints, so the relation was unambiguous.

## Solution

Specify explicit endpoint names (`glauth-k8s:pg-database` and `glauth-postgresql-k8s:database`) when adding the database relation between GLAuth and its backing PostgreSQL instance.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.