### PR TITLE
[DPE-9561] Create archive directory

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -1132,6 +1132,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         waldir_path = f"{logs_path}/16/main/pg_wal"
         temp_path = str(self.meta.storages["temp"].location)
         temp_tablespace_path = f"{temp_path}/16/main/pgsql_tmp"
+        archive_path = f"{self.meta.storages['archive'].location}/16/main"
 
         # Clear stale storage directories when a replica joins an initialized cluster.
         # This is needed because PersistentVolumes may retain data from previous pods,
@@ -1173,6 +1174,15 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         if not container.exists(temp_tablespace_path):
             container.make_dir(
                 temp_tablespace_path,
+                permissions=0o700,
+                user=WORKLOAD_OS_USER,
+                group=WORKLOAD_OS_GROUP,
+                make_parents=True,
+            )
+        # Create the archive directory (e.g., /var/lib/pg/archive/16/main)
+        if not container.exists(archive_path):
+            container.make_dir(
+                archive_path,
                 permissions=0o700,
                 user=WORKLOAD_OS_USER,
                 group=WORKLOAD_OS_GROUP,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1527,7 +1527,7 @@ def test_create_pgdata(harness):
     container = MagicMock()
     container.exists.return_value = False
     harness.charm._create_pgdata(container)
-    # When directories don't exist, all three should be created
+    # When directories don't exist, all four should be created
     container.make_dir.assert_has_calls([
         call(
             "/var/lib/pg/data/16/main",
@@ -1545,6 +1545,13 @@ def test_create_pgdata(harness):
         ),
         call(
             "/var/lib/pg/temp/16/main/pgsql_tmp",
+            permissions=448,
+            user="postgres",
+            group="postgres",
+            make_parents=True,
+        ),
+        call(
+            "/var/lib/pg/archive/16/main",
             permissions=448,
             user="postgres",
             group="postgres",


### PR DESCRIPTION
## Issue

PR [#1186](https://github.com/canonical/postgresql-k8s-operator/pull/1186) updated PostgreSQL mount paths to use `/var/lib/pg/*` with a `16/main` subdirectory structure. However, as noted in the [review](https://github.com/canonical/postgresql-k8s-operator/pull/1186#pullrequestreview-3879533579), the archive storage mount (`/var/lib/pg/archive`) was missing the `16/main` subdirectory — unlike data, logs, and temp which all create it.

## Solution

Create the `16/main` subdirectory under the archive storage mount during `_create_pgdata`, following the same pattern used for the other storage directories. This ensures the archive path matches the structure documented in PR #1186's description (`/var/lib/pg/archive/16/main`).

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.