### PR TITLE
[DPE-9568] fix(tests): avoid race in test_no_prefix_dbs and retry CLI errors in test_symlinks

### DIFF
--- a/tests/integration/test_symlinks.py
+++ b/tests/integration/test_symlinks.py
@@ -14,6 +14,7 @@ from .helpers import (
     DATABASE_APP_NAME,
     METADATA,
 )
+from .jubilant_helpers import retry_if_cli_error
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +50,7 @@ def test_build_and_deploy(juju: jubilant.Juju, charm):
                 return False
         return True
 
-    juju.wait(_all_active_idle, timeout=1500)
+    retry_if_cli_error(lambda: juju.wait(_all_active_idle, timeout=1500))
     status = juju.status()
     for unit_id in UNIT_IDS:
         unit_name = f"{APP_NAME}/{unit_id}"

--- a/tests/integration/test_username_prefix.py
+++ b/tests/integration/test_username_prefix.py
@@ -168,7 +168,11 @@ def test_readd_db_from_prefix(juju: jubilant.Juju) -> None:
 def test_no_prefix_dbs(juju: jubilant.Juju) -> None:
     db_ip = get_unit_ip(juju, DATABASE_APP_NAME, get_app_leader(juju, DATABASE_APP_NAME))
 
+    # Remove relations one at a time, waiting for idle after each.
+    # Removing both then waiting once is racy: Juju fires hooks sequentially
+    # and all_agents_idle can return in the gap between them.
     juju.remove_relation(f"{DATABASE_APP_NAME}", "di1")
+    juju.wait(jubilant.all_agents_idle, timeout=5 * MINUTE_SECS)
     juju.remove_relation(f"{DATABASE_APP_NAME}", "di2")
     juju.wait(jubilant.all_agents_idle, timeout=5 * MINUTE_SECS)
 


### PR DESCRIPTION
## Issue
Two integration test flakes identified from [Allure report run 5430](https://canonical.github.io/postgresql-k8s-operator/16_edge/5430/ ).

### Issue 1: test_no_prefix_dbs race condition

`test_no_prefix_dbs` removes two relations (di1 and di2) then calls `wait(all_agents_idle)` once. Juju processes the resulting hooks (relation-departed, relation-broken) sequentially, and the unit briefly appears idle between dispatches. The poll returns in that gap before all hooks complete, so `prefix-databases` is still present in the relation databag.

### Issue 2: test_symlinks CLIError

`test_build_and_deploy` in `test_symlinks.py` fails intermittently with `jubilant.CLIError: connection is shut down` during `juju.wait()`. Other tests in the codebase already handle this with `retry_if_cli_error`.

The remaining two issues still need investigation.

## Solution
Wait for idle after each relation removal instead of removing both, then waiting once — Juju briefly appears idle between sequential hook dispatches.

Wrap `juju.wait()` with `retry_if_cli_error` — the same pattern already used in other integration tests.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
