### PR TITLE
[DPE-9580] fix: set up pgdata symlinks in reconcile, add CLI retry, and re-enable upgrade tests

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -328,7 +328,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
     def reconcile(self):
         """Reconcile the unit state on refresh."""
         self.set_unit_status(MaintenanceStatus("starting services"))
-        self._create_pgdata(self._container)
+        self._ensure_pgdata_dirs_and_symlinks(self._container)
         self._update_pebble_layers(replan=True)
 
         if not self._patroni.member_started:
@@ -1128,12 +1128,11 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         return True
 
     def _create_pgdata(self, container: Container):
-        """Create the PostgreSQL data directories."""
+        """Create the PostgreSQL data directories, clearing stale data if needed."""
         logs_path = str(self.meta.storages["logs"].location)
         waldir_path = f"{logs_path}/16/main/pg_wal"
         temp_path = str(self.meta.storages["temp"].location)
         temp_tablespace_path = f"{temp_path}/16/main/pgsql_tmp"
-        archive_path = f"{self.meta.storages['archive'].location}/16/main"
 
         # Clear stale storage directories when a replica joins an initialized cluster.
         # This is needed because PersistentVolumes may retain data from previous pods,
@@ -1152,6 +1151,16 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
                     except ExecError as e:
                         if "No such file or directory" not in str(e.stderr):
                             logger.warning(f"Failed to clear {path}: {e}")
+
+        self._ensure_pgdata_dirs_and_symlinks(container)
+
+    def _ensure_pgdata_dirs_and_symlinks(self, container: Container):
+        """Create storage directories and symlinks for PostgreSQL data paths."""
+        logs_path = str(self.meta.storages["logs"].location)
+        waldir_path = f"{logs_path}/16/main/pg_wal"
+        temp_path = str(self.meta.storages["temp"].location)
+        temp_tablespace_path = f"{temp_path}/16/main/pgsql_tmp"
+        archive_path = f"{self.meta.storages['archive'].location}/16/main"
 
         # Create the pgdata directory on the storage mount (e.g., /var/lib/pg/data/16/main)
         if not container.exists(self._actual_pgdata_path):

--- a/src/charm.py
+++ b/src/charm.py
@@ -328,6 +328,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
     def reconcile(self):
         """Reconcile the unit state on refresh."""
         self.set_unit_status(MaintenanceStatus("starting services"))
+        self._create_pgdata(self._container)
         self._update_pebble_layers(replan=True)
 
         if not self._patroni.member_started:

--- a/tests/integration/high_availability/test_async_replication_upgrade.py
+++ b/tests/integration/high_availability/test_async_replication_upgrade.py
@@ -12,7 +12,6 @@ from jubilant import Juju
 from tenacity import Retrying, stop_after_attempt
 
 from .. import architecture
-from ..helpers import METADATA
 from ..jubilant_helpers import retry_if_cli_error
 from .high_availability_helpers_new import (
     get_app_leader,
@@ -22,6 +21,7 @@ from .high_availability_helpers_new import (
     wait_for_apps_status,
 )
 
+DB_APP_NAME = "postgresql-k8s"
 DB_APP_1 = "db1"
 DB_APP_2 = "db2"
 DB_TEST_APP_NAME = "postgresql-test-app"
@@ -85,29 +85,27 @@ def test_deploy(first_model: str, second_model: str, charm: str) -> None:
     """Simple test to ensure that the PostgreSQL application charms get deployed."""
     configuration = {"profile": "testing"}
     constraints = {"arch": architecture.architecture}
-    resources = {"postgresql-image": METADATA["resources"]["postgresql-image"]["upstream-source"]}
 
-    # TODO Deploy from edge
     logging.info("Deploying postgresql clusters")
     model_1 = Juju(model=first_model)
     model_1.deploy(
-        charm=charm,
+        charm=DB_APP_NAME,
         app=DB_APP_1,
         base="ubuntu@24.04",
+        channel="16/beta",
         config=configuration,
         constraints=constraints,
-        resources=resources,
         num_units=3,
         trust=True,
     )
     model_2 = Juju(model=second_model)
     model_2.deploy(
-        charm=charm,
+        charm=DB_APP_NAME,
         app=DB_APP_2,
         base="ubuntu@24.04",
+        channel="16/beta",
         config=configuration,
         constraints=constraints,
-        resources=resources,
         num_units=3,
         trust=True,
     )

--- a/tests/integration/high_availability/test_upgrade.py
+++ b/tests/integration/high_availability/test_upgrade.py
@@ -36,7 +36,7 @@ def test_deploy_latest(juju: Juju) -> None:
         charm=DB_APP_NAME,
         app=DB_APP_NAME,
         base="ubuntu@24.04",
-        channel="16/edge",
+        channel="16/beta",
         config={"profile": "testing"},
         num_units=3,
         trust=True,

--- a/tests/integration/high_availability/test_upgrade_from_stable.py
+++ b/tests/integration/high_availability/test_upgrade_from_stable.py
@@ -29,8 +29,7 @@ def test_deploy_stable(juju: Juju) -> None:
         charm=DB_APP_NAME,
         app=DB_APP_NAME,
         base="ubuntu@24.04",
-        # TODO Switch channel after stable release
-        channel="16/edge",
+        channel="16/beta",
         config={"profile": "testing"},
         num_units=3,
         trust=True,

--- a/tests/integration/high_availability/test_upgrade_skip_pre_upgrade_check.py
+++ b/tests/integration/high_availability/test_upgrade_skip_pre_upgrade_check.py
@@ -32,8 +32,7 @@ def test_deploy_stable(juju: Juju) -> None:
         charm=DB_APP_NAME,
         app=DB_APP_NAME,
         base="ubuntu@24.04",
-        # TODO Switch channel after stable release
-        channel="16/edge",
+        channel="16/beta",
         config={"profile": "testing"},
         num_units=3,
         trust=True,

--- a/tests/integration/test_invalid_extra_user_roles.py
+++ b/tests/integration/test_invalid_extra_user_roles.py
@@ -13,7 +13,7 @@ from .helpers import (
     DATABASE_APP_NAME,
     METADATA,
 )
-from .jubilant_helpers import relations
+from .jubilant_helpers import relations, retry_if_cli_error
 
 logger = logging.getLogger(__name__)
 
@@ -134,5 +134,7 @@ def test_extra_user_roles(
         juju.remove_relation(f"{DATA_INTEGRATOR_APP_NAME}:{RELATION_ENDPOINT}", DATABASE_APP_NAME)
 
         logger.info("Waiting for the database charm to become active again")
-        juju.wait(lambda status: database_active(status), timeout=TIMEOUT)
+        retry_if_cli_error(
+            lambda: juju.wait(lambda status: database_active(status), timeout=TIMEOUT)
+        )
         juju.wait(lambda status: data_integrator_blocked(status), timeout=TIMEOUT)

--- a/tests/spread/test_async_replication_upgrade.py/task.yaml
+++ b/tests/spread/test_async_replication_upgrade.py/task.yaml
@@ -3,8 +3,5 @@ environment:
   TEST_MODULE: high_availability/test_async_replication_upgrade.py
 execute: |
   tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
-systems:
-  - -ubuntu-24.04
-  - -ubuntu-24.04-arm
 artifacts:
   - allure-results

--- a/tests/spread/test_upgrade.py/task.yaml
+++ b/tests/spread/test_upgrade.py/task.yaml
@@ -3,8 +3,5 @@ environment:
   TEST_MODULE: high_availability/test_upgrade.py
 execute: |
   tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
-systems:
-  - -ubuntu-24.04
-  - -ubuntu-24.04-arm
 artifacts:
   - allure-results

--- a/tests/spread/test_upgrade_from_stable.py/task.yaml
+++ b/tests/spread/test_upgrade_from_stable.py/task.yaml
@@ -3,8 +3,5 @@ environment:
   TEST_MODULE: high_availability/test_upgrade_from_stable.py
 execute: |
   tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
-systems:
-  - -ubuntu-24.04
-  - -ubuntu-24.04-arm
 artifacts:
   - allure-results

--- a/tests/spread/test_upgrade_skip_pre_upgrade_check.py/task.yaml
+++ b/tests/spread/test_upgrade_skip_pre_upgrade_check.py/task.yaml
@@ -3,8 +3,5 @@ environment:
   TEST_MODULE: high_availability/test_upgrade_skip_pre_upgrade_check.py
 execute: |
   tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
-systems:
-  - -ubuntu-24.04
-  - -ubuntu-24.04-arm
 artifacts:
   - allure-results


### PR DESCRIPTION
## Issue

1. `test_extra_user_roles` in `test_invalid_extra_user_roles.py` fails intermittently with `jubilant.CLIError: connection is shut down` during `juju.wait()`, as seen in [Allure report run 5434](https://canonical.github.io/postgresql-k8s-operator/16_edge/5434/).

2. Upgrade tests fail because `reconcile()` restarts Patroni (via `_update_pebble_layers(replan=True)`) without first creating the symlink `/var/lib/postgresql/16/main → /var/lib/pg/data/16/main`. On non-first units during upgrade, `workload_allowed_to_start` is already `True` when the pod restarts, so `reconcile()` fires immediately during `upgrade-charm` — before `pebble-ready` gets a chance to create the symlinks. This causes `pg_basebackup` to fail with `Permission denied` when trying to create `/var/lib/postgresql/16/` (owned by root).

3. Upgrade tests were disabled (excluded via spread `systems`). The initial deploy channel should point to `16/beta` now that it's available.

## Solution

1. Wrap `juju.wait()` with `retry_if_cli_error` — the same pattern already used in other integration tests. We'll most probably need to use a different approach, maybe create some kind of implicit wrapper in the juju object to always retry instead of wrapping each juju object call.

2. Split `_create_pgdata` into two methods: `_create_pgdata` (which conditionally clears stale WAL/temp directories on replicas, then delegates) and `_ensure_pgdata_dirs_and_symlinks` (which idempotently creates storage directories, symlinks, and fixes permissions). Call only `_ensure_pgdata_dirs_and_symlinks` from `reconcile()` to ensure symlinks exist before Patroni starts, without running the destructive stale-directory cleanup during upgrades. The cleanup is safe to skip during upgrades because `PG_VERSION` persists on PV-backed storage. See [DPE-9581](https://warthogs.atlassian.net/browse/DPE-9581) for a follow-up to replace the delete with a move.

3. Re-enable all four upgrade spread tests and set the initial deploy channel to `16/beta`.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.


[DPE-9581]: https://warthogs.atlassian.net/browse/DPE-9581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ