### PR TITLE
[DPE-8932] Expose PG stats configuration (14/edge)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -439,6 +439,38 @@ options:
       Allowed values are: from 0 to 1.80E+308.
     type: float
     default: 0.1
+  optimizer_pg_stat_statements_track:
+    description: |
+      Controls which statements are counted by the pg_stat_statements.
+      Allowed values are: none, top, all.
+    type: string
+    default: top
+  optimizer_pg_stat_statements_track_utility:
+    description: |
+      Controls whether utility commands are tracked by pg_stat_statements.
+    type: boolean
+    default: True
+  optimizer_pg_stat_statements_save:
+    description: |
+      Specifies whether to save statement statistics across server shutdowns.
+    type: boolean
+    default: False
+  optimizer_track_io_timing:
+    description: |
+      Enables timing of database I/O calls.
+    type: boolean
+    default: False
+  optimizer_track_wal_io_timing:
+    description: |
+      Enables timing of WAL I/O calls.
+    type: boolean
+    default: False
+  optimizer_track_functions:
+    description: |
+      Enables tracking of function call counts and time used.
+      Allowed values are: pl, all, none.
+    type: string
+    default: "none"
   plugin_address_standardizer_data_us_enable:
     default: false
     type: boolean
@@ -567,6 +599,10 @@ options:
     default: false
     type: boolean
     description: Enable pgstattuple extension
+  plugin_pg_stat_statements_enable:
+    type: boolean
+    description: Enable pg_stat_statements extension
+    default: False
   plugin_plperl_enable:
     default: false
     type: boolean

--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -35,7 +35,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 56
+LIBPATCH = 57
 
 # Groups to distinguish HBA access
 ACCESS_GROUP_IDENTITY = "identity_access"
@@ -938,6 +938,10 @@ END; $$;"""
             parameter = "_".join(config.split("_")[1:])
             if parameter in ["date_style", "time_zone"]:
                 parameter = "".join(x.capitalize() for x in parameter.split("_"))
+            elif parameter.startswith("pg_stat_statements"):
+                parameter = "pg_stat_statements." + parameter.removeprefix("pg_stat_statements_")
+            elif parameter == "maximum_lag_on_failover":
+                continue
             parameters[parameter] = value
         shared_buffers_max_value_in_mb = int(available_memory * 0.4 / 10**6)
         shared_buffers_max_value = int(shared_buffers_max_value_in_mb * 10**3 / 8)

--- a/src/charm.py
+++ b/src/charm.py
@@ -2255,7 +2255,6 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             pg_parameters = dict(worker_configs)
             pg_parameters["wal_compression"] = cpu_wal_compression
             logger.debug(f"pg_parameters set to worker_configs = {pg_parameters}")
-        pg_parameters.pop("maximum_lag_on_failover", None)
 
         return pg_parameters
 

--- a/src/config.py
+++ b/src/config.py
@@ -94,6 +94,12 @@ class CharmConfig(BaseConfigModel):
     optimizer_min_parallel_table_scan_size: int | None
     optimizer_parallel_setup_cost: float | None
     optimizer_parallel_tuple_cost: float | None
+    optimizer_pg_stat_statements_track: Literal["none", "top", "all"]
+    optimizer_pg_stat_statements_track_utility: bool
+    optimizer_pg_stat_statements_save: bool
+    optimizer_track_io_timing: bool
+    optimizer_track_wal_io_timing: bool
+    optimizer_track_functions: Literal["none", "pl", "all"]
     plugin_address_standardizer_data_us_enable: bool
     plugin_address_standardizer_enable: bool
     plugin_audit_enable: bool
@@ -126,6 +132,7 @@ class CharmConfig(BaseConfigModel):
     plugin_pg_visibility_enable: bool
     plugin_pgrowlocks_enable: bool
     plugin_pgstattuple_enable: bool
+    plugin_pg_stat_statements_enable: bool
     plugin_plperl_enable: bool
     plugin_plpython3u_enable: bool
     plugin_pltcl_enable: bool

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -48,7 +48,7 @@ bootstrap:
         log_truncate_on_rotation: 'on'
         logging_collector: 'on'
         wal_level: logical
-        shared_preload_libraries: 'timescaledb,pgaudit'
+        shared_preload_libraries: 'timescaledb,pgaudit,pg_stat_statements'
   {%- if restoring_backup %}
   method: pgbackrest
   pgbackrest:
@@ -113,7 +113,7 @@ postgresql:
   bin_dir: /usr/lib/postgresql/{{ version }}/bin
   listen: 0.0.0.0:5432
   parameters:
-    shared_preload_libraries: 'timescaledb,pgaudit'
+    shared_preload_libraries: 'timescaledb,pgaudit,pg_stat_statements'
     {%- if enable_pgbackrest_archiving %}
     archive_command: 'pgbackrest --stanza={{ stanza }} archive-push %p'
     {% else %}
@@ -125,6 +125,7 @@ postgresql:
     ssl_cert_file: {{ storage_path }}/cert.pem
     ssl_key_file: {{ storage_path }}/key.pem
     {%- endif %}
+    pg_stat_statements.max: 10000
     {%- if pg_parameters %}
     {%- for key, value in pg_parameters.items() %}
     {{key}}: {{value}}

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -109,6 +109,8 @@ async def test_config_parameters(ops_test: OpsTest, charm) -> None:
         {
             "optimizer_parallel_tuple_cost": ["-1", "0.1"]
         },  # config option is between 0 and 1.80E+308
+        {"optimizer_pg_stat_statements_track": [test_string, "top"]},
+        {"optimizer_track_functions": [test_string, "all"]},
         {"profile": [test_string, "testing"]},  # config option is one of `testing` or `production`
         {"profile_limit_memory": ["127", "128"]},  # config option is between 128 and 9999999
         {

--- a/tests/integration/test_plugins.py
+++ b/tests/integration/test_plugins.py
@@ -88,6 +88,9 @@ VECTOR_EXTENSION_STATEMENT = (
     "CREATE TABLE vector_test (id bigserial PRIMARY KEY, embedding vector(3));"
 )
 TIMESCALEDB_EXTENSION_STATEMENT = "CREATE TABLE test_timescaledb (time TIMESTAMPTZ NOT NULL); SELECT create_hypertable('test_timescaledb', 'time');"
+PG_STAT_STATEMENTS_STATEMENT = (
+    "SELECT query, calls, total_exec_time, rows FROM pg_stat_statements LIMIT 5;"
+)
 
 
 @pytest.mark.abort_on_fail
@@ -154,6 +157,7 @@ async def test_plugins(ops_test: OpsTest, charm) -> None:
         "plugin_postgis_topology_enable": POSTGIS_TOPOLOGY_EXTENSION_STATEMENT,
         "plugin_vector_enable": VECTOR_EXTENSION_STATEMENT,
         "plugin_timescaledb_enable": TIMESCALEDB_EXTENSION_STATEMENT,
+        "plugin-pg-stat-statements-enable": PG_STAT_STATEMENTS_STATEMENT,
     }
 
     def enable_disable_config(enabled: False):

--- a/tests/integration/test_plugins.py
+++ b/tests/integration/test_plugins.py
@@ -157,7 +157,7 @@ async def test_plugins(ops_test: OpsTest, charm) -> None:
         "plugin_postgis_topology_enable": POSTGIS_TOPOLOGY_EXTENSION_STATEMENT,
         "plugin_vector_enable": VECTOR_EXTENSION_STATEMENT,
         "plugin_timescaledb_enable": TIMESCALEDB_EXTENSION_STATEMENT,
-        "plugin-pg-stat-statements-enable": PG_STAT_STATEMENTS_STATEMENT,
+        "plugin_pg_stat_statements_enable": PG_STAT_STATEMENTS_STATEMENT,
     }
 
     def enable_disable_config(enabled: False):


### PR DESCRIPTION
Port of https://github.com/canonical/postgresql-operator/pull/1420

Expose config parameters for pg_stat_statements.

Specification is DA249.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
