### PR TITLE
[DPE-8932] Expose PG stats configuration (16/edge)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -453,6 +453,38 @@ options:
       Allowed values are: from 0 to 1.80E+308.
     type: float
     default: 0.1
+  optimizer-pg-stat-statements-track:
+    description: |
+      Controls which statements are counted by the pg_stat_statements.
+      Allowed values are: none, top, all.
+    type: string
+    default: top
+  optimizer-pg-stat-statements-track-utility:
+    description: |
+      Controls whether utility commands are tracked by pg_stat_statements.
+    type: boolean
+    default: True
+  optimizer-pg-stat-statements-save:
+    description: |
+      Specifies whether to save statement statistics across server shutdowns.
+    type: boolean
+    default: False
+  optimizer-track-io-timing:
+    description: |
+      Enables timing of database I/O calls.
+    type: boolean
+    default: False
+  optimizer-track-wal-io-timing:
+    description: |
+      Enables timing of WAL I/O calls.
+    type: boolean
+    default: False
+  optimizer-track-functions:
+    description: |
+      Enables tracking of function call counts and time used.
+      Allowed values are: pl, all, none.
+    type: string
+    default: "none"
   pause-after-unit-refresh:
     description: |
       Wait for manual confirmation to resume refresh after these units refresh
@@ -588,6 +620,10 @@ options:
     default: false
     type: boolean
     description: Enable pgstattuple extension
+  plugin-pg-stat-statements-enable:
+    type: boolean
+    description: Enable pg_stat_statements extension
+    default: False
   plugin-plperl-enable:
     default: false
     type: boolean

--- a/src/charm.py
+++ b/src/charm.py
@@ -2621,7 +2621,6 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             pg_parameters = dict(worker_configs)
             pg_parameters["wal_compression"] = cpu_wal_compression
             logger.debug(f"pg_parameters set to worker_configs = {pg_parameters}")
-        pg_parameters.pop("maximum_lag_on_failover", None)
 
         return pg_parameters
 

--- a/src/config.py
+++ b/src/config.py
@@ -122,6 +122,12 @@ class CharmConfig(BaseConfigModel):
     optimizer_min_parallel_table_scan_size: int | None = Field(ge=0, le=715827882, default=None)
     optimizer_parallel_setup_cost: float | None = Field(ge=0, le=1.80e308, default=None)
     optimizer_parallel_tuple_cost: float | None = Field(ge=0, le=1.80e308, default=None)
+    optimizer_pg_stat_statements_track: Literal["none", "top", "all"]
+    optimizer_pg_stat_statements_track_utility: bool
+    optimizer_pg_stat_statements_save: bool
+    optimizer_track_io_timing: bool
+    optimizer_track_wal_io_timing: bool
+    optimizer_track_functions: Literal["none", "pl", "all"]
     profile: Literal["testing", "production"]
     profile_limit_memory: int | None = Field(ge=128, le=9999999, default=None)
     plugin_address_standardizer_data_us_enable: bool
@@ -156,6 +162,7 @@ class CharmConfig(BaseConfigModel):
     plugin_pg_visibility_enable: bool
     plugin_pgrowlocks_enable: bool
     plugin_pgstattuple_enable: bool
+    plugin_pg_stat_statements_enable: bool
     plugin_plperl_enable: bool
     plugin_plpython3u_enable: bool
     plugin_pltcl_enable: bool

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -48,7 +48,7 @@ bootstrap:
         log_truncate_on_rotation: 'on'
         logging_collector: 'on'
         wal_level: logical
-        shared_preload_libraries: 'timescaledb,pgaudit,set_user'
+        shared_preload_libraries: 'timescaledb,pgaudit,set_user,pg_stat_statements'
         session_preload_libraries: 'login_hook'
         set_user.block_log_statement: 'on'
         set_user.exit_on_error: 'on'
@@ -124,7 +124,7 @@ postgresql:
   bin_dir: /usr/lib/postgresql/{{ version }}/bin
   listen: 0.0.0.0:5432
   parameters:
-    shared_preload_libraries: 'timescaledb,pgaudit,set_user'
+    shared_preload_libraries: 'timescaledb,pgaudit,set_user,pg_stat_statements'
     session_preload_libraries: 'login_hook'
     set_user.block_log_statement: 'on'
     set_user.exit_on_error: 'on'
@@ -141,6 +141,7 @@ postgresql:
     ssl_key_file: {{ storage_path }}/key.pem
     {%- endif %}
     temp_tablespaces: temp
+    pg_stat_statements.max: 10000
     {%- if pg_parameters %}
     {%- for key, value in pg_parameters.items() %}
     {{key}}: {{value}}

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -112,6 +112,8 @@ async def test_config_parameters(ops_test: OpsTest, charm) -> None:
         {
             "optimizer-parallel-tuple-cost": ["-1", "0.1"]
         },  # config option is between 0 and 1.80E+308
+        {"optimizer-pg-stat-statements-track": [test_string, "top"]},
+        {"optimizer-track-functions": [test_string, "all"]},
         {"profile": [test_string, "testing"]},  # config option is one of `testing` or `production`
         {"profile-limit-memory": ["127", "128"]},  # config option is between 128 and 9999999
         {

--- a/tests/integration/test_plugins.py
+++ b/tests/integration/test_plugins.py
@@ -88,6 +88,9 @@ VECTOR_EXTENSION_STATEMENT = (
     "CREATE TABLE vector_test (id bigserial PRIMARY KEY, embedding vector(3));"
 )
 TIMESCALEDB_EXTENSION_STATEMENT = "CREATE TABLE test_timescaledb (time TIMESTAMPTZ NOT NULL); SELECT create_hypertable('test_timescaledb', 'time');"
+PG_STAT_STATEMENTS_STATEMENT = (
+    "SELECT query, calls, total_exec_time, rows FROM pg_stat_statements LIMIT 5;"
+)
 
 
 @pytest.mark.abort_on_fail
@@ -155,6 +158,7 @@ async def test_plugins(ops_test: OpsTest, charm) -> None:
         "plugin-postgis-topology-enable": POSTGIS_TOPOLOGY_EXTENSION_STATEMENT,
         "plugin-vector-enable": VECTOR_EXTENSION_STATEMENT,
         "plugin-timescaledb-enable": TIMESCALEDB_EXTENSION_STATEMENT,
+        "plugin-pg-stat-statements-enable": PG_STAT_STATEMENTS_STATEMENT,
     }
 
     def enable_disable_config(enabled: False):


### PR DESCRIPTION
Port of https://github.com/canonical/postgresql-operator/pull/1420

Expose config parameters for pg_stat_statements.

Specification is DA249.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
