### PR TITLE
fix: recreate headless service if deleted externally

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -764,6 +764,12 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             logger.debug("on_peer_relation_changed early exit: Backup restore check failed")
             return
 
+        # Ensure headless service exists before checking Patroni health.
+        try:
+            self._ensure_headless_service()
+        except ApiError:
+            logger.exception("failed to check/recreate headless service")
+
         # Validate the status of the member before setting an ActiveStatus.
         if not self._patroni.member_started:
             logger.debug("Deferring on_peer_relation_changed: Waiting for member to start")
@@ -1488,6 +1494,39 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             obj=patch,
         )
 
+    def _ensure_headless_service(self) -> bool:
+        """Ensure the headless endpoint service exists, recreating if needed.
+
+        Returns True if the service was recreated.
+        """
+        client = Client()
+        svc_name = f"{self.app.name}-endpoints"
+        try:
+            client.get(Service, name=svc_name, namespace=self.model.name)
+            return False
+        except ApiError as e:
+            if e.status.code != 404:
+                raise
+        logger.warning("Headless service %s not found, recreating", svc_name)
+        service = Service(
+            metadata=ObjectMeta(
+                name=svc_name,
+                namespace=self.model.name,
+                labels={"app.kubernetes.io/name": self.app.name},
+                annotations={
+                    "service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
+                },
+            ),
+            spec=ServiceSpec(
+                clusterIP="None",
+                publishNotReadyAddresses=True,
+                selector={"app.kubernetes.io/name": self.app.name},
+            ),
+        )
+        client.create(service)
+        logger.info("Recreated headless service %s", svc_name)
+        return True
+
     def _create_services(self) -> None:
         """Create kubernetes services for primary and replicas endpoints."""
         client = Client()
@@ -1826,6 +1865,13 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             return False
 
         self._check_pgdata_storage_size()
+
+        # Check if headless service is missing (could explain waiting status).
+        try:
+            if self._ensure_headless_service():
+                return True
+        except ApiError:
+            logger.exception("failed to check/recreate headless service")
 
         if (
             self._has_blocked_status and self.unit.status not in S3_BLOCK_MESSAGES

--- a/src/charm.py
+++ b/src/charm.py
@@ -1497,6 +1497,9 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
     def _ensure_headless_service(self) -> bool:
         """Ensure the headless endpoint service exists, recreating if needed.
 
+        Workaround for https://github.com/canonical/postgresql-k8s-operator/issues/392
+        Can be removed once Juju properly reconciles deleted headless services.
+
         Returns True if the service was recreated.
         """
         client = Client()
@@ -1512,7 +1515,10 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             metadata=ObjectMeta(
                 name=svc_name,
                 namespace=self.model.name,
-                labels={"app.kubernetes.io/name": self.app.name},
+                labels={
+                    "app.kubernetes.io/name": self.app.name,
+                    "app.kubernetes.io/managed-by": "juju",
+                },
                 annotations={
                     "service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
                 },
@@ -1523,7 +1529,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
                 selector={"app.kubernetes.io/name": self.app.name},
             ),
         )
-        client.create(service)
+        client.apply(service, field_manager=self.app.name, force=True)
         logger.info("Recreated headless service %s", svc_name)
         return True
 
@@ -1867,9 +1873,10 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         self._check_pgdata_storage_size()
 
         # Check if headless service is missing (could explain waiting status).
+        # If recreated, defer to next update-status cycle to let it stabilize.
         try:
             if self._ensure_headless_service():
-                return True
+                return False
         except ApiError:
             logger.exception("failed to check/recreate headless service")
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -111,11 +111,14 @@ def juju(request: pytest.FixtureRequest):
     model = request.config.getoption("--model")
     keep_models = bool(request.config.getoption("--keep-models"))
 
+    cloud = request.config.getoption("--cloud", default=None)
+    controller = request.config.getoption("--controller", default=None)
+
     if model:
         juju = jubilant.Juju(model=model)
         yield juju
     else:
-        with jubilant.temp_model(keep=keep_models) as juju:
+        with jubilant.temp_model(keep=keep_models, cloud=cloud, controller=controller) as juju:
             yield juju
 
 

--- a/tests/integration/test_headless_service.py
+++ b/tests/integration/test_headless_service.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 
 import logging
-import time
 
 import jubilant
 import pytest
@@ -11,6 +10,7 @@ from jubilant import Juju
 from lightkube.core.client import Client
 from lightkube.core.exceptions import ApiError
 from lightkube.resources.core_v1 import Service
+from tenacity import RetryError, Retrying, retry_if_exception, stop_after_delay, wait_fixed
 
 from .helpers import CHARM_BASE_NOBLE, METADATA
 
@@ -61,19 +61,24 @@ def test_headless_service_recreated(juju: Juju):
 
     # Poll for the service to be recreated (avoids issues from the headless
     # service deletion disrupting K8s networking for Juju connections).
-    deadline = time.time() + 600
-    recreated = False
-    while time.time() < deadline:
-        try:
-            svc = client.get(Service, name=svc_name)
-            if svc.spec.clusterIP == "None":
-                recreated = True
-                break
-        except ApiError:
-            pass
-        time.sleep(10)
-
-    assert recreated, f"Headless service {svc_name} was not recreated within timeout"
+    try:
+        for attempt in Retrying(
+            stop=stop_after_delay(600),
+            wait=wait_fixed(10),
+            retry=retry_if_exception(
+                lambda e: (
+                    isinstance(e, ValueError) or (isinstance(e, ApiError) and e.status.code == 404)
+                )
+            ),
+        ):
+            with attempt:
+                svc = client.get(Service, name=svc_name)
+                if svc.spec.clusterIP != "None":
+                    raise ValueError("service exists but is not headless yet")
+    except RetryError as e:
+        raise AssertionError(
+            f"Headless service {svc_name} was not recreated within timeout"
+        ) from e
     logger.info("Headless service %s was recreated", svc_name)
 
     # Wait for units to settle back to active/idle.

--- a/tests/integration/test_headless_service.py
+++ b/tests/integration/test_headless_service.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+import time
+
+import jubilant
+import pytest
+from jubilant import Juju
+from lightkube.core.client import Client
+from lightkube.core.exceptions import ApiError
+from lightkube.resources.core_v1 import Service
+
+from .helpers import CHARM_BASE_NOBLE, METADATA
+
+logger = logging.getLogger(__name__)
+
+DB_APP_NAME = METADATA["name"]
+MINUTE_SECS = 60
+
+
+def test_deploy(juju: Juju, charm: str):
+    """Deploy the charm and wait for active/idle."""
+    resources = {
+        "postgresql-image": METADATA["resources"]["postgresql-image"]["upstream-source"],
+    }
+    juju.deploy(
+        charm=charm,
+        app=DB_APP_NAME,
+        base=CHARM_BASE_NOBLE,
+        resources=resources,
+        config={"profile": "testing"},
+        num_units=3,
+        trust=True,
+    )
+    juju.wait(jubilant.all_active, timeout=20 * MINUTE_SECS)
+
+
+def test_headless_service_recreated(juju: Juju):
+    """Delete the headless endpoints service and verify the charm recreates it."""
+    # juju.model may include "controller:" prefix; K8s namespace is just the model name.
+    model_name = juju.model.split(":")[-1]
+    svc_name = f"{DB_APP_NAME}-endpoints"
+
+    # Verify the headless service exists.
+    client = Client(namespace=model_name)
+    svc = client.get(Service, name=svc_name)
+    assert svc.spec.clusterIP == "None"
+
+    # Delete the headless service.
+    logger.info("Deleting headless service %s", svc_name)
+    client.delete(Service, name=svc_name)
+
+    # Verify it's gone.
+    with pytest.raises(ApiError, match="not found"):
+        client.get(Service, name=svc_name)
+
+    # Speed up update-status.
+    juju.cli("model-config", "update-status-hook-interval=1m")
+
+    # Poll for the service to be recreated (avoids issues from the headless
+    # service deletion disrupting K8s networking for Juju connections).
+    deadline = time.time() + 600
+    recreated = False
+    while time.time() < deadline:
+        try:
+            svc = client.get(Service, name=svc_name)
+            if svc.spec.clusterIP == "None":
+                recreated = True
+                break
+        except ApiError:
+            pass
+        time.sleep(10)
+
+    assert recreated, f"Headless service {svc_name} was not recreated within timeout"
+    logger.info("Headless service %s was recreated", svc_name)
+
+    # Wait for units to settle back to active/idle.
+    juju.wait(jubilant.all_active, timeout=5 * MINUTE_SECS)
+
+    # Restore default interval.
+    juju.cli("model-config", "update-status-hook-interval=5m")

--- a/tests/spread/test_headless_service.py/task.yaml
+++ b/tests/spread/test_headless_service.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_headless_service.py
+environment:
+  TEST_MODULE: test_headless_service.py
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -732,6 +732,35 @@ def test_create_services(harness):
             tc.assertEqual(_client.return_value.apply.call_count, 2)
 
 
+def test_ensure_headless_service(harness):
+    with patch("charm.Client") as _client:
+        # Test when the service already exists.
+        _client.return_value.get.return_value = MagicMock()
+        result = harness.charm._ensure_headless_service()
+        tc.assertFalse(result)
+        _client.return_value.apply.assert_not_called()
+
+        # Test when the service is missing (404) and gets recreated.
+        _client.reset_mock()
+        _client.return_value.get.side_effect = _FakeApiError(404)
+        result = harness.charm._ensure_headless_service()
+        tc.assertTrue(result)
+        _client.return_value.apply.assert_called_once()
+
+        # Test when get raises a non-404 error (should propagate).
+        _client.reset_mock()
+        _client.return_value.get.side_effect = _FakeApiError(403)
+        with tc.assertRaises(_FakeApiError):
+            harness.charm._ensure_headless_service()
+
+        # Test when apply raises an error (should propagate).
+        _client.reset_mock()
+        _client.return_value.get.side_effect = _FakeApiError(404)
+        _client.return_value.apply.side_effect = _FakeApiError
+        with tc.assertRaises(_FakeApiError):
+            harness.charm._ensure_headless_service()
+
+
 def test_patch_pod_labels(harness):
     with patch("charm.Client") as _client:
         member = harness.charm._unit.replace("/", "-")


### PR DESCRIPTION
## Issue

Fixes https://github.com/canonical/postgresql-k8s-operator/issues/392

When the Kubernetes headless service `<app-name>-endpoints` is deleted externally (e.g. by a user or a controller reconciliation issue), PostgreSQL units lose DNS-based connectivity to each other, Patroni health checks fail, and all units get stuck in `waiting` status permanently. Juju does not reconcile or recreate this service on its own.

## Solution

Port of https://github.com/canonical/postgresql-k8s-operator/pull/1348.

- Add `_ensure_headless_service()` method to `src/charm.py` that checks for the headless endpoints service via the K8s API and recreates it with the correct spec (`clusterIP: "None"`, `publishNotReadyAddresses: True`) if it gets a 404.
- Call this method from `_on_peer_relation_changed` (before checking Patroni health, so DNS is restored first) and from `_on_update_status_early_exit_checks` (returning early after recreation to let things stabilize).
- Use `database_host=self.postgresql.current_host` in `_connect_to_database` for the pending-restart check to avoid connectivity issues during headless service disruption.
- Add unit tests for the new method (service exists, 404 recreation, non-404 propagation, apply error propagation).
- Add integration test that deploys the charm, deletes the headless service, and verifies the charm recreates it and recovers to active/idle.
- Add `--cloud` and `--controller` options to `conftest.py`'s `temp_model` fixture.
- Add spread task for the new integration test.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.