### PR TITLE
[DPE-9578] Check unit's host for restart need (14/edge)

### DIFF
--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -35,7 +35,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 57
+LIBPATCH = 58
 
 # Groups to distinguish HBA access
 ACCESS_GROUP_IDENTITY = "identity_access"
@@ -850,7 +850,9 @@ END; $$;"""
         """Query pg_settings for pending restart."""
         connection = None
         try:
-            with self._connect_to_database() as connection, connection.cursor() as cursor:
+            with self._connect_to_database(
+                database_host=self.current_host
+            ) as connection, connection.cursor() as cursor:
                 cursor.execute("SELECT COUNT(*) FROM pg_settings WHERE pending_restart=True;")
                 return cursor.fetchone()[0] > 0
         except psycopg2.OperationalError:


### PR DESCRIPTION
Check the current node for restart need instead of the primary.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
