### PR TITLE
[DPE-9578] Check unit's host for restart need (16/edge)

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -3146,7 +3146,9 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         connection = None
         try:
             with (
-                self.postgresql._connect_to_database() as connection,
+                self.postgresql._connect_to_database(
+                    database_host=self.postgresql.current_host
+                ) as connection,
                 connection.cursor() as cursor,
             ):
                 cursor.execute("SELECT COUNT(*) FROM pg_settings WHERE pending_restart=True;")


### PR DESCRIPTION
Check the current node for restart need instead of the primary.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
