### PR TITLE
ci: update spread installation from snapcore to canonical org

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up environment
         run: |
           sudo snap install go --classic
-          go install github.com/snapcore/spread/cmd/spread@latest
+          go install github.com/canonical/spread/cmd/spread@latest
           pipx install tox poetry
       - name: Collect spread jobs
         id: collect-jobs
@@ -103,7 +103,7 @@ jobs:
       # https://github.com/canonical/charmcraft/issues/2130 fixed
       - run: |
           sudo snap install go --classic
-          go install github.com/snapcore/spread/cmd/spread@latest
+          go install github.com/canonical/spread/cmd/spread@latest
       - name: Download packed charm(s)
         timeout-minutes: 5
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## Issue

The `spread` tool repository was moved from `github.com/snapcore/spread` to `github.com/canonical/spread`. This breaks the CI integration test workflow because Go rejects the install when the module's declared path no longer matches the import path.

## Solution

Update the `go install` commands in `.github/workflows/integration_test.yaml` to use the new `github.com/canonical/spread` path.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.