### PR TITLE
[DPE-3565] fix: error state on missing headless service

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -613,6 +613,8 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             logger.debug("on_peer_relation_changed early exit: Backup restore check failed")
             return
 
+        self._check_headless_service()
+
         # Validate the status of the member before setting an ActiveStatus.
         if not self._patroni.member_started:
             logger.debug("Deferring on_peer_relation_changed: Waiting for member to start")
@@ -1128,6 +1130,29 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             obj=patch,
         )
 
+    def _check_headless_service(self) -> None:
+        """Raise if the headless endpoint service is missing.
+
+        Puts the unit into error state so the operator can recreate the
+        service and run ``juju resolve``.
+
+        See https://github.com/canonical/postgresql-k8s-operator/issues/392
+        """
+        client = Client()
+        svc_name = f"{self.app.name}-endpoints"
+        try:
+            client.get(Service, name=svc_name, namespace=self.model.name)
+        except ApiError as e:
+            if e.status.code == 404:
+                logger.error(
+                    "error: headless service %r is missing - recreate it and run "
+                    "'juju resolve' on each unit. See "
+                    "https://github.com/canonical/postgresql-k8s-operator/issues/392",
+                    svc_name,
+                )
+                raise RuntimeError from None
+            raise
+
     def _create_services(self) -> None:
         """Create kubernetes services for primary and replicas endpoints."""
         client = Client()
@@ -1513,6 +1538,8 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         container = self.unit.get_container("postgresql")
         if not self._on_update_status_early_exit_checks(container):
             return
+
+        self._check_headless_service()
 
         services = container.pebble.get_services(names=[self.postgresql_service])
         if len(services) == 0:

--- a/tests/integration/test_headless_service.py
+++ b/tests/integration/test_headless_service.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+
+import pytest
+from lightkube.core.client import Client
+from lightkube.core.exceptions import ApiError
+from lightkube.models.core_v1 import ServiceSpec
+from lightkube.models.meta_v1 import ObjectMeta
+from lightkube.resources.core_v1 import Service
+from pytest_operator.plugin import OpsTest
+
+from .helpers import DATABASE_APP_NAME, build_and_deploy
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.abort_on_fail
+async def test_deploy(ops_test: OpsTest, charm):
+    """Deploy the charm and wait for active/idle."""
+    await build_and_deploy(ops_test, charm, num_units=3)
+
+
+async def test_headless_service_error_and_recovery(ops_test: OpsTest):
+    """Delete headless service, verify error state, recreate, and recover."""
+    model_name = ops_test.model.info.name
+    svc_name = f"{DATABASE_APP_NAME}-endpoints"
+
+    # Verify the headless service exists.
+    client = Client(namespace=model_name)
+    svc = client.get(Service, name=svc_name)
+    assert svc.spec.clusterIP == "None"
+
+    # Delete the headless service.
+    logger.info("Deleting headless service %s", svc_name)
+    client.delete(Service, name=svc_name)
+
+    # Verify it's gone.
+    with pytest.raises(ApiError, match="not found"):
+        client.get(Service, name=svc_name)
+
+    # Speed up update-status so the charm detects the missing service.
+    async with ops_test.fast_forward():
+        # Wait for at least one unit to go into error state.
+        await ops_test.model.block_until(
+            lambda: any(
+                unit.workload_status == "error"
+                for unit in ops_test.model.applications[DATABASE_APP_NAME].units
+            ),
+            timeout=600,
+        )
+        logger.info("Unit(s) entered error state as expected")
+
+    # Recreate the headless service (simulating the operator's manual fix).
+    logger.info("Recreating headless service %s", svc_name)
+    client.apply(
+        Service(
+            metadata=ObjectMeta(
+                name=svc_name,
+                namespace=model_name,
+                labels={
+                    "app.kubernetes.io/name": DATABASE_APP_NAME,
+                    "app.kubernetes.io/managed-by": "juju",
+                },
+            ),
+            spec=ServiceSpec(
+                clusterIP="None",
+                publishNotReadyAddresses=True,
+                selector={"app.kubernetes.io/name": DATABASE_APP_NAME},
+            ),
+        ),
+        field_manager="integration-test",
+        force=True,
+    )
+
+    # Verify it's back.
+    svc = client.get(Service, name=svc_name)
+    assert svc.spec.clusterIP == "None"
+    logger.info("Headless service recreated")
+
+    # Resolve all units in error state.
+    for unit in ops_test.model.applications[DATABASE_APP_NAME].units:
+        if unit.workload_status == "error":
+            logger.info("Resolving %s", unit.name)
+            await unit.resolved(retry=False)
+
+    # Wait for units to settle back to active/idle.
+    await ops_test.model.wait_for_idle(
+        apps=[DATABASE_APP_NAME],
+        status="active",
+        raise_on_error=False,
+        timeout=600,
+    )

--- a/tests/spread/test_headless_service.py/task.yaml
+++ b/tests/spread/test_headless_service.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_headless_service.py
+environment:
+  TEST_MODULE: test_headless_service.py
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -10,7 +10,7 @@ import psycopg2
 import pytest
 from charms.postgresql_k8s.v0.postgresql import PostgreSQLUpdateUserPasswordError
 from lightkube import ApiError
-from lightkube.resources.core_v1 import Endpoints, Pod
+from lightkube.resources.core_v1 import Endpoints, Pod, Service
 from ops import JujuVersion
 from ops.model import (
     ActiveStatus,
@@ -880,6 +880,30 @@ def test_create_services(harness):
                 res=Pod, name="postgresql-k8s-0", namespace=harness.charm.model.name
             )
             tc.assertEqual(_client.return_value.apply.call_count, 2)
+
+
+def test_check_headless_service(harness):
+    with patch("charm.Client") as _client:
+        # Test when the service exists — no exception.
+        _client.return_value.get.return_value = MagicMock()
+        harness.charm._check_headless_service()
+        _client.return_value.get.assert_called_once_with(
+            Service,
+            name=f"{harness.charm.app.name}-endpoints",
+            namespace=harness.charm.model.name,
+        )
+
+        # Test when the service is missing (404) — RuntimeError.
+        _client.reset_mock()
+        _client.return_value.get.side_effect = _FakeApiError(404)
+        with tc.assertRaises(RuntimeError, msg="Headless service"):
+            harness.charm._check_headless_service()
+
+        # Test when get raises a non-404 error — propagates ApiError.
+        _client.reset_mock()
+        _client.return_value.get.side_effect = _FakeApiError(403)
+        with tc.assertRaises(_FakeApiError):
+            harness.charm._check_headless_service()
 
 
 def test_patch_pod_labels(harness):


### PR DESCRIPTION
## Issue

The Juju-managed headless Service `{app-name}-endpoints` can be deleted manually or accidentally.
When that happens, Patroni/PostgreSQL communication breaks, and the charm should stop reconciliation
until the operator fixes the Service, instead of trying to recreate it itself (to avoid having a different service specification if Juju changes it in a future version).

## Solution

- Added `_check_headless_service()` in `src/charm.py` to verify `{app-name}-endpoints` exists.
- Call this check from `_on_peer_relation_changed` and `_on_update_status`.
- When the Service is missing (`404`), log an actionable error and raise `RuntimeError` to put units in `error` state.
  Recovery path is: recreate the Service manually, then run `juju resolve` on affected units.
- Added unit coverage in `tests/unit/test_charm.py` for service present, missing service (`404`), and non-404 API error propagation.
- Added integration test `tests/integration/test_headless_service.py` covering delete -> error state -> recreate -> resolve -> active.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.

Fixes https://github.com/canonical/postgresql-k8s-operator/issues/392.