### PR TITLE
[DPE-9841] fix: error state on missing headless service

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -764,6 +764,8 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             logger.debug("on_peer_relation_changed early exit: Backup restore check failed")
             return
 
+        self._check_headless_service()
+
         # Validate the status of the member before setting an ActiveStatus.
         if not self._patroni.member_started:
             logger.debug("Deferring on_peer_relation_changed: Waiting for member to start")
@@ -1488,6 +1490,29 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             obj=patch,
         )
 
+    def _check_headless_service(self) -> None:
+        """Raise if the headless endpoint service is missing.
+
+        Puts the unit into error state so the operator can recreate the
+        service and run ``juju resolve``.
+
+        See https://github.com/canonical/postgresql-k8s-operator/issues/392
+        """
+        client = Client()
+        svc_name = f"{self.app.name}-endpoints"
+        try:
+            client.get(Service, name=svc_name, namespace=self.model.name)
+        except ApiError as e:
+            if e.status.code == 404:
+                logger.error(
+                    "error: headless service %r is missing - recreate it and run "
+                    "'juju resolve' on each unit. See "
+                    "https://github.com/canonical/postgresql-k8s-operator/issues/392",
+                    svc_name,
+                )
+                raise RuntimeError from None
+            raise
+
     def _create_services(self) -> None:
         """Create kubernetes services for primary and replicas endpoints."""
         client = Client()
@@ -1867,6 +1892,8 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         """Update the unit status message."""
         if not self._on_update_status_early_exit_checks(self._container):
             return
+
+        self._check_headless_service()
 
         services = self._container.pebble.get_services(names=[self.postgresql_service])
         if len(services) == 0:

--- a/tests/integration/test_headless_service.py
+++ b/tests/integration/test_headless_service.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+
+import jubilant
+import pytest
+from lightkube.core.client import Client
+from lightkube.core.exceptions import ApiError
+from lightkube.models.core_v1 import ServiceSpec
+from lightkube.models.meta_v1 import ObjectMeta
+from lightkube.resources.core_v1 import Service
+
+from .helpers import DATABASE_APP_NAME, METADATA
+
+logger = logging.getLogger(__name__)
+
+TIMEOUT = 20 * 60
+
+
+def database_active_idle(status: jubilant.Status) -> bool:
+    return jubilant.all_active(status, DATABASE_APP_NAME) and jubilant.all_agents_idle(
+        status, DATABASE_APP_NAME
+    )
+
+
+def any_database_unit_error(status: jubilant.Status) -> bool:
+    app = status.apps.get(DATABASE_APP_NAME)
+    if app is None:
+        return False
+
+    return any(unit.workload_status.current == "error" for unit in app.units.values())
+
+
+@pytest.mark.abort_on_fail
+def test_deploy(juju: jubilant.Juju, charm) -> None:
+    """Deploy the charm and wait for active/idle."""
+    if DATABASE_APP_NAME not in juju.status().apps:
+        resources = {
+            "postgresql-image": METADATA["resources"]["postgresql-image"]["upstream-source"]
+        }
+        juju.deploy(
+            charm,
+            config={"profile": "testing"},
+            num_units=3,
+            resources=resources,
+            trust=True,
+        )
+
+    juju.wait(database_active_idle, timeout=TIMEOUT)
+
+
+def test_headless_service_error_and_recovery(juju: jubilant.Juju) -> None:
+    """Delete headless service, verify error state, recreate, and recover."""
+    model_name = juju.model
+    svc_name = f"{DATABASE_APP_NAME}-endpoints"
+
+    # Verify the headless service exists.
+    client = Client(namespace=model_name)
+    svc = client.get(Service, name=svc_name)
+    assert svc.spec.clusterIP == "None"
+
+    # Delete the headless service.
+    logger.info("Deleting headless service %s", svc_name)
+    client.delete(Service, name=svc_name)
+
+    # Verify it's gone.
+    with pytest.raises(ApiError, match="not found"):
+        client.get(Service, name=svc_name)
+
+    # Speed up update-status so the charm detects the missing service.
+    juju.model_config(values={"update-status-hook-interval": "1m"})
+    try:
+        # Wait for at least one unit to go into error state.
+        juju.wait(any_database_unit_error, timeout=TIMEOUT)
+        logger.info("Unit(s) entered error state as expected")
+    finally:
+        juju.model_config(reset=("update-status-hook-interval",))
+
+    # Recreate the headless service (simulating the operator's manual fix).
+    logger.info("Recreating headless service %s", svc_name)
+    client.apply(
+        Service(
+            metadata=ObjectMeta(
+                name=svc_name,
+                namespace=model_name,
+                labels={
+                    "app.kubernetes.io/name": DATABASE_APP_NAME,
+                    "app.kubernetes.io/managed-by": "juju",
+                },
+            ),
+            spec=ServiceSpec(
+                clusterIP="None",
+                publishNotReadyAddresses=True,
+                selector={"app.kubernetes.io/name": DATABASE_APP_NAME},
+            ),
+        ),
+        field_manager="integration-test",
+        force=True,
+    )
+
+    # Verify it's back.
+    svc = client.get(Service, name=svc_name)
+    assert svc.spec.clusterIP == "None"
+    logger.info("Headless service recreated")
+
+    # Resolve all units in error state.
+    for unit_name, unit_status in juju.status().apps[DATABASE_APP_NAME].units.items():
+        if unit_status.workload_status.current == "error":
+            logger.info("Resolving %s", unit_name)
+            juju.cli("resolve", "--no-retry", unit_name)
+
+    # Wait for units to settle back to active/idle.
+    juju.wait(database_active_idle, timeout=TIMEOUT)

--- a/tests/spread/test_headless_service.py/task.yaml
+++ b/tests/spread/test_headless_service.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_headless_service.py
+environment:
+  TEST_MODULE: test_headless_service.py
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, Mock, PropertyMock, call, patch, sentinel
 import psycopg2
 import pytest
 from lightkube import ApiError
-from lightkube.resources.core_v1 import Endpoints, Pod
+from lightkube.resources.core_v1 import Endpoints, Pod, Service
 from ops import JujuVersion
 from ops.model import (
     ActiveStatus,
@@ -730,6 +730,30 @@ def test_create_services(harness):
                 res=Pod, name="postgresql-k8s-0", namespace=harness.charm.model.name
             )
             tc.assertEqual(_client.return_value.apply.call_count, 2)
+
+
+def test_check_headless_service(harness):
+    with patch("charm.Client") as _client:
+        # Test when the service exists — no exception.
+        _client.return_value.get.return_value = MagicMock()
+        harness.charm._check_headless_service()
+        _client.return_value.get.assert_called_once_with(
+            Service,
+            name=f"{harness.charm.app.name}-endpoints",
+            namespace=harness.charm.model.name,
+        )
+
+        # Test when the service is missing (404) — RuntimeError.
+        _client.reset_mock()
+        _client.return_value.get.side_effect = _FakeApiError(404)
+        with tc.assertRaises(RuntimeError, msg="Headless service"):
+            harness.charm._check_headless_service()
+
+        # Test when get raises a non-404 error — propagates ApiError.
+        _client.reset_mock()
+        _client.return_value.get.side_effect = _FakeApiError(403)
+        with tc.assertRaises(_FakeApiError):
+            harness.charm._check_headless_service()
 
 
 def test_patch_pod_labels(harness):


### PR DESCRIPTION
## Issue

The Juju-managed headless Service `{app-name}-endpoints` can be deleted manually or accidentally.
When that happens, Patroni/PostgreSQL communication breaks, and the charm should stop reconciliation
until the operator fixes the Service, instead of trying to recreate it itself (to avoid having a different service specification if Juju changes it in a future version).

## Solution

- Added `_check_headless_service()` in `src/charm.py` to verify `{app-name}-endpoints` exists.
- Call this check from `_on_peer_relation_changed` and `_on_update_status`.
- When the Service is missing (`404`), log an actionable error and raise `RuntimeError` to put units in `error` state.
  Recovery path is: recreate the Service manually, then run `juju resolve` on affected units.
- Added jubilant integration test `tests/integration/test_headless_service.py` covering delete -> error state -> recreate -> resolve -> active.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.

Port of https://github.com/canonical/postgresql-k8s-operator/pull/1415.