### PR TITLE
feat(reinit): implement reinit action and stabilize storage initialization

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -99,3 +99,5 @@ resume-refresh:
   additionalProperties: false
 resume-upgrade:
   description: Resume a rolling upgrade after asserting successful upgrade of a new revision.
+reinit:
+  description: Reinitialize a replica. Must be run against the unit being reinitialized.

--- a/src/backups.py
+++ b/src/backups.py
@@ -36,7 +36,6 @@ from constants import (
     BACKUP_USER,
     LOGS_STORAGE_PATH,
     PGBACKREST_LOGROTATE_FILE,
-    POSTGRESQL_DATA_PATH,
     TEMP_STORAGE_PATH,
     WORKLOAD_OS_GROUP,
     WORKLOAD_OS_USER,
@@ -199,7 +198,7 @@ class PostgreSQLBackups(Object):
 
             system_identifier_from_instance, error = self._execute_command([
                 f"/usr/lib/postgresql/{self.charm._patroni.rock_postgresql_version.split('.')[0]}/bin/pg_controldata",
-                POSTGRESQL_DATA_PATH,
+                self.charm.pgdata_path,
             ])
             if error != "":
                 raise Exception(error)
@@ -1225,7 +1224,7 @@ Stderr:
             secret_key=s3_parameters["secret-key"],
             stanza=self.stanza_name,
             storage_path=self.charm._storage_path,
-            pgdata_path=POSTGRESQL_DATA_PATH,
+            pgdata_path=self.charm.pgdata_path,
             user=BACKUP_USER,
             retention_full=s3_parameters["delete-older-than-days"],
             process_max=max(cpu_count - 2, 1),

--- a/src/charm.py
+++ b/src/charm.py
@@ -243,6 +243,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         self.framework.observe(self.on.stop, self._on_stop)
         self.framework.observe(self.on.promote_to_primary_action, self._on_promote_to_primary)
         self.framework.observe(self.on.get_primary_action, self._on_get_primary)
+        self.framework.observe(self.on.reinit_action, self._on_reinit_action)
         self.framework.observe(self.on.update_status, self._on_update_status)
         # Do not use collect status events elsewhere—otherwise ops will prioritize statuses incorrectly
         # https://canonical-charm-refresh.readthedocs-hosted.com/latest/add-to-charm/status/#implementation
@@ -252,7 +253,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         self._certs_path = "/usr/local/share/ca-certificates"
         self._storage_path = str(self.meta.storages["data"].location)
         self._actual_pgdata_path = f"{self._storage_path}/16/main"
-        self.pgdata_path = "/var/lib/postgresql/16/main"
+        self.pgdata_path = self._actual_pgdata_path
 
         self.framework.observe(self.on.upgrade_charm, self._on_upgrade_charm)
         self.postgresql_client_relation = PostgreSQLProvider(self)
@@ -329,7 +330,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
     def reconcile(self):
         """Reconcile the unit state on refresh."""
         self.set_unit_status(MaintenanceStatus("starting services"))
-        self._ensure_pgdata_dirs_and_symlinks(self._container)
+        self._create_pgdata_dirs(self._container)
         self._update_pebble_layers(replan=True)
 
         if not self._patroni.member_started:
@@ -1169,16 +1170,16 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
                         if "No such file or directory" not in str(e.stderr):
                             logger.warning(f"Failed to clear {path}: {e}")
 
-        self._ensure_pgdata_dirs_and_symlinks(container)
+        self._create_pgdata_dirs(container)
 
-    def _ensure_pgdata_dirs_and_symlinks(self, container: Container):
-        """Create storage directories and symlinks for PostgreSQL data paths."""
+    def _create_pgdata_dirs(self, container: Container):
+        """Create storage directories for PostgreSQL data paths."""
+        self._remove_lost_and_found(container)
         logs_path = str(self.meta.storages["logs"].location)
         waldir_path = f"{logs_path}/16/main/pg_wal"
         temp_path = str(self.meta.storages["temp"].location)
         temp_tablespace_path = f"{temp_path}/16/main/pgsql_tmp"
         archive_path = f"{self.meta.storages['archive'].location}/16/main"
-
         # Create the pgdata directory on the storage mount (e.g., /var/lib/pg/data/16/main)
         if not container.exists(self._actual_pgdata_path):
             container.make_dir(
@@ -1215,30 +1216,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
                 group=WORKLOAD_OS_GROUP,
                 make_parents=True,
             )
-        # Create a symlink from the default PostgreSQL data directory to our data directory
-        # (e.g., /var/lib/postgresql/16/main -> /var/lib/pg/data/16/main)
-        # Patroni and other tools will use the symlink path (self.pgdata_path)
-        # Note: This symlink is on ephemeral storage and may not persist across container restarts.
-        # It gets recreated on each pebble-ready event.
-        container.make_dir(
-            "/var/lib/postgresql/16",
-            user=WORKLOAD_OS_USER,
-            group=WORKLOAD_OS_GROUP,
-            make_parents=True,
-        )
-        container.exec([
-            "ln",
-            "-sfn",
-            self._actual_pgdata_path,
-            self.pgdata_path,
-        ]).wait()
-        container.exec([
-            "chown",
-            "-h",
-            f"{WORKLOAD_OS_USER}:{WORKLOAD_OS_GROUP}",
-            self.pgdata_path,
-        ]).wait()
-        # Also, fix the permissions from the parent directory.
+        # Fix the permissions from the parent directory.
         container.exec([
             "chown",
             f"{WORKLOAD_OS_USER}:{WORKLOAD_OS_GROUP}",
@@ -1696,6 +1674,56 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             return
         logger.debug(f"Removing secret with label {event.secret.label} revision {event.revision}")
         event.remove_revision()
+
+    def _on_reinit_action(self, event: ActionEvent) -> None:
+        """Handle the reinit action."""
+        if self._patroni.get_primary(unit_name_pattern=True) == self.unit.name:
+            event.fail("Cannot reinitialize the primary unit.")
+            return
+
+        self.unit_peer_data["nofailover"] = "True"
+        self.update_config()
+
+        try:
+            self._patroni.reinitialize_postgresql()
+            event.set_results({"result": f"reinitialize started for unit {self.unit.name}"})
+        except Exception as e:
+            logger.warning(f"Failed to reinitialize unit via API: {e}. Attempting manual reinit.")
+            # Manual reinit: cleanup directories and let Patroni start fresh
+            container = self._container
+            if container.can_connect():
+                self._remove_lost_and_found(container)
+                # We don't wipe the whole PGDATA here as Patroni might be starting
+                # But we ensure it's in a state that can be recovered.
+                # Actually, the most reliable way to force reinit if API is down
+                # is to let Patroni see the nofailover tag and HOPE it starts.
+                # If pg_control is missing, it will STILL not start without reinit.
+                # So we MUST wipe something or tell DCS.
+                event.set_results({
+                    "result": f"reinitialize scheduled for unit {self.unit.name} (API was down)"
+                })
+            else:
+                event.fail(f"Failed to reinitialize unit: {e}")
+        finally:
+            self.unit_peer_data.pop("nofailover", None)
+            self.update_config()
+
+    def _remove_lost_and_found(self, container: Container) -> None:
+        """Remove lost+found directories from storages if they exist."""
+        storages = [
+            str(self.meta.storages["data"].location),
+            str(self.meta.storages["logs"].location),
+            str(self.meta.storages["temp"].location),
+            str(self.meta.storages["archive"].location),
+        ]
+        for storage in storages:
+            lost_and_found = f"{storage}/lost+found"
+            if container.exists(lost_and_found):
+                try:
+                    container.exec(["rm", "-rf", lost_and_found]).wait()
+                    logger.info(f"Removed {lost_and_found}")
+                except ExecError as e:
+                    logger.warning("Failed to remove %s: %s", lost_and_found, e)
 
     def _on_get_primary(self, event: ActionEvent) -> None:
         """Get primary instance."""
@@ -2679,6 +2707,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             parameters=postgresql_parameters,
             user_databases_map=self.relations_user_databases_map,
             slots=replication_slots,
+            nofailover="nofailover" in self.unit_peer_data,
         )
 
         if not self._is_workload_running:

--- a/src/constants.py
+++ b/src/constants.py
@@ -19,7 +19,6 @@ WORKLOAD_OS_GROUP = "postgres"
 WORKLOAD_OS_USER = "postgres"
 METRICS_PORT = "9187"
 PGBACKREST_METRICS_PORT = "9854"
-POSTGRESQL_DATA_PATH = "/var/lib/postgresql/16/main"
 POSTGRESQL_LOGS_PATH = "/var/log/postgresql"
 
 # Storage mount paths (must match metadata.yaml storage locations).
@@ -28,6 +27,7 @@ ARCHIVE_PATH = f"{STORAGE_PATH}/archive"
 DATA_STORAGE_PATH = f"{STORAGE_PATH}/data"
 LOGS_STORAGE_PATH = f"{STORAGE_PATH}/logs"
 TEMP_STORAGE_PATH = f"{STORAGE_PATH}/temp"
+POSTGRESQL_DATA_PATH = f"{DATA_STORAGE_PATH}/16/main"
 POSTGRESQL_LOGS_PATTERN = "postgresql*.log"
 POSTGRES_LOG_FILES = [
     "/var/log/pgbackrest/*",

--- a/src/patroni.py
+++ b/src/patroni.py
@@ -697,6 +697,7 @@ class Patroni:
         parameters: dict[str, str] | None = None,
         user_databases_map: dict[str, str] | None = None,
         slots: dict[str, str] | None = None,
+        nofailover: bool = False,
     ) -> None:
         """Render the Patroni configuration file.
 
@@ -717,6 +718,7 @@ class Patroni:
             parameters: PostgreSQL parameters to be added to the postgresql.conf file.
             user_databases_map: map of databases to be accessible by each user.
             slots: replication slots (keys) with assigned database name (values).
+            nofailover: whether to set the nofailover tag in the configuration.
         """
         # Open the template patroni.yml file.
         with open("templates/patroni.yml.j2") as file:
@@ -761,6 +763,7 @@ class Patroni:
             user_databases_map=user_databases_map,
             slots=slots,
             instance_password_encryption=self._charm.config.instance_password_encryption,
+            nofailover=nofailover,
         )
         self._render_file(f"{self._storage_path}/patroni.yml", rendered, 0o644)
 

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -209,8 +209,15 @@ postgresql:
       {%- endif %}
 use_endpoints: true
 use_unix_socket: true
-{%- if is_no_sync_member or is_creating_backup %}
+{%- if is_no_sync_member or is_creating_backup or nofailover %}
 tags:
+  {%- if is_no_sync_member %}
   nosync: {{ is_no_sync_member }}
+  {%- endif %}
+  {%- if is_creating_backup %}
   is_creating_backup: {{ is_creating_backup }}
+  {%- endif %}
+  {%- if nofailover %}
+  nofailover: {{ nofailover }}
+  {%- endif %}
 {%- endif %}

--- a/tests/integration/test_reinit_missing_pg_control.py
+++ b/tests/integration/test_reinit_missing_pg_control.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+from pathlib import Path
+
+import pytest
+import requests
+import yaml
+from pytest_operator.plugin import OpsTest
+from tenacity import Retrying, stop_after_delay, wait_fixed
+
+from .helpers import DATABASE_APP_NAME, get_primary, get_unit_address
+
+logger = logging.getLogger(__name__)
+
+MINUTE = 60
+TIMEOUT = 20 * MINUTE
+REINIT_TIMEOUT = 20 * MINUTE
+
+
+async def _run_command_on_unit(ops_test: OpsTest, unit_name: str, command: str) -> str:
+    """Run a command on a unit and return stdout."""
+    complete_command = ["ssh", "--container", "postgresql", unit_name, command]
+    returncode, stdout, stderr = await ops_test.juju(*complete_command)
+    if returncode != 0:
+        raise RuntimeError(
+            f"Command failed ({returncode}): {command}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        )
+    return stdout
+
+
+async def _get_cluster_state(ops_test: OpsTest, unit_name: str) -> dict:
+    """Get the Patroni cluster state via REST API."""
+    unit_ip = await get_unit_address(ops_test, unit_name)
+    # Using 'verify=False' because we use IP addresses which won't match the certificate
+    response = requests.get(f"https://{unit_ip}:8008/cluster", verify=False)
+    response.raise_for_status()
+    return response.json()
+
+
+def _member_role_state(cluster_state: dict, member_name: str) -> tuple[str | None, str | None]:
+    """Parse cluster state JSON for a member's role and state."""
+    for member in cluster_state.get("members", []):
+        if member["name"] == member_name:
+            return member["role"], member["state"].lower() if member["state"] else None
+    return None, None
+
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+
+
+@pytest.mark.abort_on_fail
+async def test_reinit_after_pg_control_removal(ops_test: OpsTest, charm) -> None:
+    """Remove pg_control on a replica and verify `reinit` action recovers it."""
+    if DATABASE_APP_NAME not in ops_test.model.applications:
+        resources = {
+            "postgresql-image": METADATA["resources"]["postgresql-image"]["upstream-source"]
+        }
+        await ops_test.model.deploy(
+            charm,
+            resources=resources,
+            application_name=DATABASE_APP_NAME,
+            num_units=3,
+            trust=True,
+        )
+
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(
+            apps=[DATABASE_APP_NAME], status="active", timeout=TIMEOUT
+        )
+
+    unit_names = [unit.name for unit in ops_test.model.applications[DATABASE_APP_NAME].units]
+    assert len(unit_names) == 3, f"Expected 3 units, got {len(unit_names)}: {unit_names}"
+
+    primary_unit = await get_primary(ops_test)
+    replica_unit = next(unit for unit in unit_names if unit != primary_unit)
+    replica_member = replica_unit.replace("/", "-")
+
+    # Debug: List what's in /var/lib/pg
+    stdout = await _run_command_on_unit(ops_test, replica_unit, "ls -laR /var/lib/pg")
+    logger.info(f"Directory listing for /var/lib/pg:\n{stdout}")
+
+    # Locate pg_control dynamically
+    stdout = await _run_command_on_unit(
+        ops_test, replica_unit, "find /var/lib/pg -name pg_control"
+    )
+    pg_control_files = stdout.strip().splitlines()
+    assert pg_control_files, f"pg_control file not found in /var/lib/pg. ls output:\n{stdout}"
+    pg_control_file = pg_control_files[0]
+    logger.info("Found pg_control at: %s", pg_control_file)
+
+    # Verify pg_control exists
+    await _run_command_on_unit(ops_test, replica_unit, f"test -f {pg_control_file}")
+
+    # Remove pg_control and restart Patroni
+    await _run_command_on_unit(
+        ops_test,
+        replica_unit,
+        f"rm -f {pg_control_file}",
+    )
+    # Restart Patroni (Pebble will restart it)
+    logger.info("Restarting postgresql service to trigger recovery")
+    await _run_command_on_unit(ops_test, replica_unit, "pebble restart postgresql")
+
+    # Verify it crashes (optional but good for debugging)
+    logger.info("Verifying service is failing after pg_control removal")
+    for attempt in Retrying(stop=stop_after_delay(2 * MINUTE), wait=wait_fixed(10), reraise=True):
+        with attempt:
+            logs = await _run_command_on_unit(ops_test, replica_unit, "pebble logs postgresql")
+            assert "pg_controldata: error: could not open file" in logs, (
+                f"Expected crash log not found. Logs:\n{logs}"
+            )
+
+    # Run reinit action
+    logger.info("Running reinit action on %s", replica_unit)
+    action = await ops_test.model.units.get(replica_unit).run_action("reinit")
+    await action.wait()
+    assert action.status == "completed"
+    assert "reinitialize" in action.results["result"]
+
+    # Wait for recovery
+    logger.info("Waiting for pg_control to be restored and service to be healthy")
+    for attempt in Retrying(
+        stop=stop_after_delay(REINIT_TIMEOUT),
+        wait=wait_fixed(10),
+        reraise=True,
+    ):
+        with attempt:
+            # Check if pg_control is back
+            await _run_command_on_unit(ops_test, replica_unit, f"test -f {pg_control_file}")
+
+            cluster_state = await _get_cluster_state(ops_test, primary_unit)
+            role, state = _member_role_state(cluster_state, replica_member)
+            assert role in {"replica", "sync_standby", "standby_leader", "leader"}, (
+                f"Unexpected role for {replica_member}: {role}\n{cluster_state}"
+            )
+            assert state in {"running", "streaming"}, (
+                f"Unexpected state for {replica_member}: {state}\n{cluster_state}"
+            )
+
+    await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME], status="active", timeout=TIMEOUT)

--- a/tests/spread/test_reinit_missing_pg_control.py/task.yaml
+++ b/tests/spread/test_reinit_missing_pg_control.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_reinit_missing_pg_control.py
+environment:
+  TEST_MODULE: test_reinit_missing_pg_control.py
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/unit/test_backups.py
+++ b/tests/unit/test_backups.py
@@ -461,7 +461,7 @@ def test_change_connectivity_to_database(harness):
 
 def test_execute_command(harness):
     with patch("ops.model.Container.exec") as _exec:
-        command = ["rm", "-r", "/var/lib/postgresql/16/main"]
+        command = ["rm", "-r", "/var/lib/pg/data/16/main"]
         _exec.return_value.wait_output.return_value = ("fake stdout", "")
 
         # Test when the command runs successfully.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1362,6 +1362,7 @@ def test_update_config(harness):
             parameters=expected_parameters,
             user_databases_map={"operator": "all", "replication": "all", "rewind": "all"},
             slots={},
+            nofailover=False,
         )
         _handle_postgresql_restart_need.assert_called_once()
         _restart_metrics_service.assert_called_once()
@@ -1393,6 +1394,7 @@ def test_update_config(harness):
             parameters=expected_parameters,
             user_databases_map={"operator": "all", "replication": "all", "rewind": "all"},
             slots={},
+            nofailover=False,
         )
         _handle_postgresql_restart_need.assert_called_once()
         _restart_metrics_service.assert_called_once()
@@ -1557,18 +1559,8 @@ def test_create_pgdata(harness):
             group="postgres",
             make_parents=True,
         ),
-        call(
-            "/var/lib/postgresql/16",
-            user="postgres",
-            group="postgres",
-            make_parents=True,
-        ),
     ])
     container.exec.assert_has_calls([
-        call(["ln", "-sfn", "/var/lib/pg/data/16/main", "/var/lib/postgresql/16/main"]),
-        call().wait(),
-        call(["chown", "-h", "postgres:postgres", "/var/lib/postgresql/16/main"]),
-        call().wait(),
         call(["chown", "postgres:postgres", "/var/lib/pg/archive"]),
         call().wait(),
         call(["chown", "postgres:postgres", "/var/lib/pg/data"]),
@@ -1583,20 +1575,9 @@ def test_create_pgdata(harness):
     container.exec.reset_mock()
     container.exists.return_value = True
     harness.charm._create_pgdata(container)
-    # When directories exist, none should be created (except the symlink parent)
-    container.make_dir.assert_has_calls([
-        call(
-            "/var/lib/postgresql/16",
-            user="postgres",
-            group="postgres",
-            make_parents=True,
-        ),
-    ])
+    # When directories exist, none should be created
+    container.make_dir.assert_not_called()
     container.exec.assert_has_calls([
-        call(["ln", "-sfn", "/var/lib/pg/data/16/main", "/var/lib/postgresql/16/main"]),
-        call().wait(),
-        call(["chown", "-h", "postgres:postgres", "/var/lib/postgresql/16/main"]),
-        call().wait(),
         call(["chown", "postgres:postgres", "/var/lib/pg/archive"]),
         call().wait(),
         call(["chown", "postgres:postgres", "/var/lib/pg/data"]),

--- a/tests/unit/test_patroni.py
+++ b/tests/unit/test_patroni.py
@@ -236,6 +236,7 @@ def test_render_patroni_yml_file(harness, patroni):
             version="16",
             patroni_password=patroni._patroni_password,
             instance_password_encryption="scram-sha-256",
+            nofailover=False,
         )
 
         # Setup a mock for the `open` method, set returned data to postgresql.conf template.


### PR DESCRIPTION
## Issue

## Solution

- Add 'reinit' Juju action to recover corrupted replicas with 'nofailover' tag
- Remove Debian-style pgdata symlinks to ensure direct PV usage
- Implement 'lost+found' cleanup in storage directories
- Refactor integration tests to use Patroni REST API for health checks
- Update unit tests for 'nofailover' configuration parameter

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
