### PR TITLE
[DPE-9705] Limit max_timelines_history to 50 (PG14)

### DIFF
--- a/src/patroni.py
+++ b/src/patroni.py
@@ -544,6 +544,16 @@ class Patroni:
             timeout=PATRONI_TIMEOUT,
         )
 
+    def set_max_timelines_history(self) -> None:
+        """Patch the DCS with max_timelines_history limit."""
+        requests.patch(
+            f"{self._patroni_url}/config",
+            verify=self._verify,
+            json={"max_timelines_history": 50},
+            auth=self._patroni_auth,
+            timeout=PATRONI_TIMEOUT,
+        )
+
     @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=2, max=10))
     def reinitialize_postgresql(self) -> None:
         """Reinitialize PostgreSQL."""

--- a/src/upgrade.py
+++ b/src/upgrade.py
@@ -124,6 +124,7 @@ class PostgreSQLUpgrade(DataUpgrade):
             self._set_up_new_credentials_for_legacy()
             self._set_up_new_access_roles_for_legacy()
             self._patch_failsafe_mode()
+            self._patch_max_timelines_history()
 
         try:
             for attempt in Retrying(stop=stop_after_attempt(6), wait=wait_fixed(10)):
@@ -303,6 +304,12 @@ class PostgreSQLUpgrade(DataUpgrade):
             self.charm._patroni.set_failsafe_mode()
         except Exception:
             logger.warning("Unable to patch in failsafe mode")
+
+    def _patch_max_timelines_history(self):
+        try:
+            self.charm._patroni.set_max_timelines_history()
+        except Exception:
+            logger.warning("Unable to patch in max_timelines_history")
 
     @property
     def unit_upgrade_data(self) -> RelationDataContent:

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -5,6 +5,7 @@ bootstrap:
     maximum_lag_on_failover: {{ maximum_lag_on_failover }}
     synchronous_mode: true
     synchronous_mode_strict: false
+    max_timelines_history: 50
     postgresql:
       use_pg_rewind: true
       remove_data_directory_on_rewind_failure: false

--- a/tests/integration/ha_tests/test_upgrade_from_stable.py
+++ b/tests/integration/ha_tests/test_upgrade_from_stable.py
@@ -149,3 +149,4 @@ async def test_upgrade_from_stable(ops_test: OpsTest, charm, continuous_writes):
             "Number of switchovers is greater than 2"
         )
         assert await get_patroni_setting(ops_test, "failsafe_mode")
+        assert await get_patroni_setting(ops_test, "max_timelines_history") == 50

--- a/tests/unit/test_patroni.py
+++ b/tests/unit/test_patroni.py
@@ -499,6 +499,21 @@ def test_set_failsafe_mode(harness, patroni):
         )
 
 
+def test_set_max_timelines_history(harness, patroni):
+    with (
+        patch("requests.patch") as _patch,
+    ):
+        patroni.set_max_timelines_history()
+
+        _patch.assert_called_once_with(
+            f"{patroni._patroni_url}/config",
+            json={"max_timelines_history": 50},
+            verify=True,
+            auth=patroni._patroni_auth,
+            timeout=10,
+        )
+
+
 def test_reload_patroni_configuration(harness, patroni):
     with (
         patch("ops.model.Container.send_signal") as _send_signal,


### PR DESCRIPTION
## Issue

The 'history' part of patroni config K8s enpoint grows without limits.

## Solution

Backporting one-line Patroni config from 16/edge (4b61edee),
plus a runtime PATCH /config on refresh, so existing Charmed
PostgreSQL 14 deployments pick up the value.
Pattern mirrors fa528991 (failsafe mode).

Assisted-by: Claude:claude-4.6-opus

Fixes https://github.com/canonical/postgresql-k8s-operator/issues/1388