### PR TITLE
[DPE-9920] Fix 10th+ cluster<>cluster promotion

### DIFF
--- a/src/relations/async_replication.py
+++ b/src/relations/async_replication.py
@@ -229,7 +229,7 @@ class PostgreSQLAsyncReplication(Object):
             }.items():
                 databag = relation_data[app]
                 relation_promoted_cluster_counter = databag.get("promoted-cluster-counter", "0")
-                if relation_promoted_cluster_counter > promoted_cluster_counter:
+                if int(relation_promoted_cluster_counter) > int(promoted_cluster_counter):
                     promoted_cluster_counter = relation_promoted_cluster_counter
                     primary_cluster = app
         return primary_cluster


### PR DESCRIPTION
## Issue

The  _get_primary_cluster() determines which cluster is the primary in an async replication setup by finding the app with the highest promoted-cluster-counter. The counter is stored as a string in Juju relation databags (e.g., "1", "2", ..., "10").

The comparison uses Python's > operator on strings, which compares lexicographically: "9" > "10" is True because "9" > "1".

## Solution

The propose changes adopts it equal to  _get_highest_promoted_cluster_counter_value().