### PR TITLE
[DPE-9935] fix: fix log file bloat by removing `--log-level-file=debug` from backup command

### DIFF
--- a/src/backups.py
+++ b/src/backups.py
@@ -836,7 +836,6 @@ Juju Version: {juju_version!s}
                 "pgbackrest",
                 f"--stanza={self.stanza_name}",
                 "--log-level-console=debug",
-                "--log-level-file=debug",
                 "--log-subprocess",
                 f"--type={BACKUP_TYPE_OVERRIDES[backup_type]}",
                 "backup",


### PR DESCRIPTION
## Issue

The `--log-level-file=debug` flag in the backup command causes significant log file bloat (DPE-9935): each backup generates 5.5M+ pgbackrest log files filled with verbose DEBUG entries.

## Solution

Remove the `--log-level-file=debug` flag from the backup command. The flag was originally added in PR #1115 to diagnose a GCP PITR test failure (a SIGTERM appeared in the logs), but that diagnostic purpose is already served by `--log-level-console=debug`, which captures output via stdout/stderr. The flag is also redundant since SIGTERM is logged at info level by pgbackrest (`cfgLogLevelDefault`).

`--log-subprocess` is intentionally kept: it enables file logging for pgbackrest subprocesses, which now falls back to the default info level and remains useful for troubleshooting without causing log bloat.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.