### PR TITLE
[DPE-9969] feat: add `/var/log/patroni` and `/var/log/pgbackrest` symlinks

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -124,9 +124,11 @@ from constants import (
     MONITORING_PASSWORD_KEY,
     MONITORING_USER,
     PATRONI_LOGS_PATH,
+    PATRONI_LOGS_SYMLINK_PATH,
     PATRONI_PASSWORD_KEY,
     PEER,
     PGBACKREST_LOGS_PATH,
+    PGBACKREST_LOGS_SYMLINK_PATH,
     PGBACKREST_METRICS_PORT,
     PLUGIN_OVERRIDES,
     POSTGRES_LOG_FILES,
@@ -1178,36 +1180,37 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
 
         self._ensure_pgdata_dirs_and_symlinks(container)
 
-    def _ensure_postgresql_logs_symlink(
+    def _ensure_log_symlink(
         self,
         container: Container,
-        postgresql_logs_path: str,
+        target: str,
+        symlink_path: str,
     ) -> None:
-        """Ensure /var/log/postgresql points to the logs storage path."""
-        path_info = self._get_container_path_info(container, POSTGRESQL_LOGS_SYMLINK_PATH)
+        """Ensure symlink_path points to target in the logs storage."""
+        path_info = self._get_container_path_info(container, symlink_path)
         if path_info is not None:
             if path_info.type == FileType.DIRECTORY:
-                self._remove_empty_postgresql_logs_directory(container)
+                self._remove_empty_log_directory(container, symlink_path)
             elif path_info.type != FileType.SYMLINK:
                 logger.error(
                     "error: %s exists but is neither a symlink nor a directory and cannot"
                     " be replaced with a symlink to the logs storage - remove it manually"
                     " and run 'juju resolve' on each unit to recover.",
-                    POSTGRESQL_LOGS_SYMLINK_PATH,
+                    symlink_path,
                 )
                 raise RuntimeError from None
 
         container.exec([
             "ln",
             "-sfn",
-            postgresql_logs_path,
-            POSTGRESQL_LOGS_SYMLINK_PATH,
+            target,
+            symlink_path,
         ]).wait()
         container.exec([
             "chown",
             "-h",
             f"{WORKLOAD_OS_USER}:{WORKLOAD_OS_GROUP}",
-            POSTGRESQL_LOGS_SYMLINK_PATH,
+            symlink_path,
         ]).wait()
 
     def _get_container_path_info(self, container: Container, path: str) -> FileInfo | None:
@@ -1218,18 +1221,18 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             return None
         return path_infos[0]
 
-    def _remove_empty_postgresql_logs_directory(self, container: Container) -> None:
-        """Remove /var/log/postgresql only when it is an empty directory."""
-        if container.list_files(POSTGRESQL_LOGS_SYMLINK_PATH):
+    def _remove_empty_log_directory(self, container: Container, symlink_path: str) -> None:
+        """Remove a log directory at symlink_path only when it is empty."""
+        if container.list_files(symlink_path):
             logger.error(
                 "error: %s is a non-empty directory and cannot be replaced with a"
                 " symlink to the logs storage - move or remove its contents manually"
                 " and run 'juju resolve' on each unit to recover.",
-                POSTGRESQL_LOGS_SYMLINK_PATH,
+                symlink_path,
             )
             raise RuntimeError from None
 
-        container.remove_path(POSTGRESQL_LOGS_SYMLINK_PATH)
+        container.remove_path(symlink_path)
 
     def _ensure_pgdata_dirs_and_symlinks(self, container: Container):
         """Create storage directories and symlinks for PostgreSQL data paths."""
@@ -1311,10 +1314,9 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             f"{WORKLOAD_OS_USER}:{WORKLOAD_OS_GROUP}",
             "/var/lib/postgresql/16",
         ]).wait()
-        self._ensure_postgresql_logs_symlink(
-            container,
-            POSTGRESQL_LOGS_PATH,
-        )
+        self._ensure_log_symlink(container, POSTGRESQL_LOGS_PATH, POSTGRESQL_LOGS_SYMLINK_PATH)
+        self._ensure_log_symlink(container, PATRONI_LOGS_PATH, PATRONI_LOGS_SYMLINK_PATH)
+        self._ensure_log_symlink(container, PGBACKREST_LOGS_PATH, PGBACKREST_LOGS_SYMLINK_PATH)
         # Also, fix the permissions from the parent directory.
         container.exec([
             "chown",

--- a/src/constants.py
+++ b/src/constants.py
@@ -19,6 +19,8 @@ WORKLOAD_OS_GROUP = "postgres"
 WORKLOAD_OS_USER = "postgres"
 METRICS_PORT = "9187"
 PGBACKREST_METRICS_PORT = "9854"
+PATRONI_LOGS_SYMLINK_PATH = "/var/log/patroni"
+PGBACKREST_LOGS_SYMLINK_PATH = "/var/log/pgbackrest"
 POSTGRESQL_LOGS_SYMLINK_PATH = "/var/log/postgresql"
 
 # Storage mount paths (must match metadata.yaml storage locations).

--- a/tests/integration/test_filesystem_layout.py
+++ b/tests/integration/test_filesystem_layout.py
@@ -122,3 +122,37 @@ def test_postgresql_log_path(juju: jubilant.Juju, unit_id: int):
         f"Expected {POSTGRESQL_LOGS_PATH} to point to {POSTGRESQL_LOGS_TARGET_PATH}, "
         f"got {target.strip()}"
     )
+
+
+@pytest.mark.parametrize("unit_id", UNIT_IDS)
+def test_patroni_log_symlink(juju: jubilant.Juju, unit_id: int):
+    """Test that /var/log/patroni is a symlink pointing to the patroni_logs directory."""
+    unit_name = f"{APP_NAME}/{unit_id}"
+    symlink_path = "/var/log/patroni"
+    path_type = juju.ssh(
+        unit_name, "stat", "-c", "%F", symlink_path, container="postgresql"
+    ).strip()
+    assert path_type == "symbolic link", (
+        f"Expected {symlink_path} to be a symbolic link, got: {path_type}"
+    )
+    target = juju.ssh(unit_name, "readlink", "-f", symlink_path, container="postgresql")
+    assert target.strip() == PATRONI_LOGS_PATH, (
+        f"Expected {symlink_path} to point to {PATRONI_LOGS_PATH}, got {target.strip()}"
+    )
+
+
+@pytest.mark.parametrize("unit_id", UNIT_IDS)
+def test_pgbackrest_log_symlink(juju: jubilant.Juju, unit_id: int):
+    """Test that /var/log/pgbackrest is a symlink pointing to the pgbackrest_logs directory."""
+    unit_name = f"{APP_NAME}/{unit_id}"
+    symlink_path = "/var/log/pgbackrest"
+    path_type = juju.ssh(
+        unit_name, "stat", "-c", "%F", symlink_path, container="postgresql"
+    ).strip()
+    assert path_type == "symbolic link", (
+        f"Expected {symlink_path} to be a symbolic link, got: {path_type}"
+    )
+    target = juju.ssh(unit_name, "readlink", "-f", symlink_path, container="postgresql")
+    assert target.strip() == PGBACKREST_LOGS_PATH, (
+        f"Expected {symlink_path} to point to {PGBACKREST_LOGS_PATH}, got {target.strip()}"
+    )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1629,6 +1629,16 @@ def test_create_pgdata(harness):
             call(["chown", "postgres:postgres", "/var/lib/pg/logs/16/main/pgbackrest_logs"]),
             call(["ln", "-sfn", "/var/lib/pg/data/16", "/var/lib/postgresql/16"]),
             call(["ln", "-sfn", "/var/lib/pg/logs/16/main/pg_logs", "/var/log/postgresql"]),
+            call(["chown", "-h", "postgres:postgres", "/var/log/postgresql"]),
+            call(["ln", "-sfn", "/var/lib/pg/logs/16/main/patroni_logs", "/var/log/patroni"]),
+            call(["chown", "-h", "postgres:postgres", "/var/log/patroni"]),
+            call([
+                "ln",
+                "-sfn",
+                "/var/lib/pg/logs/16/main/pgbackrest_logs",
+                "/var/log/pgbackrest",
+            ]),
+            call(["chown", "-h", "postgres:postgres", "/var/log/pgbackrest"]),
         ],
         any_order=True,
     )
@@ -1642,11 +1652,20 @@ def test_create_pgdata(harness):
     # When directories exist, none should be created
     container.make_dir.assert_not_called()
     container.list_files.assert_any_call("/var/log", pattern="postgresql")
+    container.list_files.assert_any_call("/var/log", pattern="patroni")
+    container.list_files.assert_any_call("/var/log", pattern="pgbackrest")
     container.remove_path.assert_not_called()
     container.exec.assert_has_calls(
         [
             call(["ln", "-sfn", "/var/lib/pg/data/16", "/var/lib/postgresql/16"]),
             call(["ln", "-sfn", "/var/lib/pg/logs/16/main/pg_logs", "/var/log/postgresql"]),
+            call(["ln", "-sfn", "/var/lib/pg/logs/16/main/patroni_logs", "/var/log/patroni"]),
+            call([
+                "ln",
+                "-sfn",
+                "/var/lib/pg/logs/16/main/pgbackrest_logs",
+                "/var/log/pgbackrest",
+            ]),
         ],
         any_order=True,
     )
@@ -1661,8 +1680,12 @@ def test_create_pgdata_replaces_existing_directory_with_symlink(harness):
 
     def _list_files(path, *, pattern=None, itself=False):
         assert not itself
-        if path == "/var/log" and pattern == "postgresql":
-            return [MagicMock(type=FileType.DIRECTORY)]
+        if path == "/var/log":
+            if pattern == "postgresql":
+                return [MagicMock(type=FileType.DIRECTORY)]
+            # patroni and pgbackrest paths are already symlinks — no replacement needed
+            return [MagicMock(type=FileType.SYMLINK)]
+        # list_files(symlink_path) is called to check whether the directory is empty
         assert path == "/var/log/postgresql"
         assert pattern is None
         return []
@@ -1671,10 +1694,8 @@ def test_create_pgdata_replaces_existing_directory_with_symlink(harness):
 
     harness.charm._create_pgdata(container)
 
-    container.list_files.assert_has_calls([
-        call("/var/log", pattern="postgresql"),
-        call("/var/log/postgresql"),
-    ])
+    container.list_files.assert_any_call("/var/log", pattern="postgresql")
+    container.list_files.assert_any_call("/var/log/postgresql")
     container.remove_path.assert_called_once_with("/var/log/postgresql")
     assert call(["ln", "-sfn", "/var/lib/pg/logs/16/main/pg_logs", "/var/log/postgresql"]) in (
         container.exec.call_args_list
@@ -1697,7 +1718,70 @@ def test_create_pgdata_raises_for_existing_non_directory(harness):
     )
 
 
-def test_get_plugins(harness):
+@pytest.mark.parametrize(
+    "symlink_path,target",
+    [
+        ("/var/log/patroni", "/var/lib/pg/logs/16/main/patroni_logs"),
+        ("/var/log/pgbackrest", "/var/lib/pg/logs/16/main/pgbackrest_logs"),
+    ],
+)
+def test_create_pgdata_replaces_existing_directory_for_extra_log_symlinks(
+    harness, symlink_path, target
+):
+    """Existing empty directories at patroni/pgbackrest symlink paths are replaced."""
+    container = MagicMock()
+    container.exists.return_value = True
+    container.exec.return_value.wait_output.return_value = ("755:postgres:postgres", "")
+    parent = "/var/log"
+    name = symlink_path.rsplit("/", 1)[-1]
+
+    def _list_files(path, *, pattern=None, itself=False):
+        assert not itself
+        if path == parent:
+            if pattern == name:
+                return [MagicMock(type=FileType.DIRECTORY)]
+            return [MagicMock(type=FileType.SYMLINK)]
+        # empty-directory check
+        if path == symlink_path:
+            assert pattern is None
+            return []
+        return [MagicMock(type=FileType.SYMLINK)]
+
+    container.list_files.side_effect = _list_files
+
+    harness.charm._create_pgdata(container)
+
+    container.remove_path.assert_called_once_with(symlink_path)
+    assert call(["ln", "-sfn", target, symlink_path]) in container.exec.call_args_list
+
+
+@pytest.mark.parametrize(
+    "symlink_path",
+    ["/var/log/patroni", "/var/log/pgbackrest"],
+)
+def test_create_pgdata_raises_for_existing_non_directory_extra_log_symlinks(harness, symlink_path):
+    """A non-symlink, non-directory file at patroni/pgbackrest paths causes RuntimeError."""
+    container = MagicMock()
+    container.exists.return_value = True
+    container.exec.return_value.wait_output.return_value = ("755:postgres:postgres", "")
+    parent = "/var/log"
+    name = symlink_path.rsplit("/", 1)[-1]
+
+    def _list_files(path, *, pattern=None, itself=False):
+        assert not itself
+        if path == parent:
+            if pattern == name:
+                return [MagicMock(type=FileType.FILE)]
+            return [MagicMock(type=FileType.SYMLINK)]
+        return []
+
+    container.list_files.side_effect = _list_files
+
+    with pytest.raises(RuntimeError):
+        harness.charm._create_pgdata(container)
+
+    container.remove_path.assert_not_called()
+
     with patch("charm.PostgresqlOperatorCharm._on_config_changed"):
         # Test when the charm has no plugins enabled.
         assert harness.charm.get_plugins() == ["pgaudit"]


### PR DESCRIPTION
## Issue

The PostgreSQL logs are accessible via a convenience symlink at `/var/log/postgresql`, but Patroni and pgBackRest logs have no equivalent — they can only be found by navigating directly to their paths under the logs storage (`/var/lib/pg/logs/16/main/`). This makes log access inconsistent and less discoverable.

## Solution

Add symlinks in `/var/log` for Patroni and pgBackRest logs, mirroring the existing `/var/log/postgresql` symlink. The two new symlinks point to the log directories on the logs storage:
```
/var/log/patroni    -> /var/lib/pg/logs/16/main/patroni_logs
/var/log/pgbackrest -> /var/lib/pg/logs/16/main/pgbackrest_logs
```

The private helpers `_ensure_postgresql_logs_symlink` and `_remove_empty_postgresql_logs_directory` are generalised into `_ensure_log_symlink` and `_remove_empty_log_directory`, accepting the symlink and target paths as parameters. The same error-handling logic applies: a non-empty directory or unexpected file type at the symlink path raises RuntimeError and requires manual intervention.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.