### PR TITLE
Update documentation for stable release (16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Bootstrap a Kubernetes (e.g. [Multipass-based MicroK8s](https://discourse.charmh
 
 ```shell
 juju add-model postgresql-k8s
-juju deploy postgresql-k8s --channel 16/edge --trust
+juju deploy postgresql-k8s --channel 16/stable --trust
 ```
 
 **Note:** the `--trust` flag is required because the charm and Patroni need to create some K8s resources.
@@ -61,7 +61,7 @@ Adding a relation is accomplished with `juju relate` (or `juju integrate` for Ju
 
 ```shell
 # Deploy Charmed PostgreSQL cluster with 3 nodes
-juju deploy postgresql-k8s -n 3 --trust --channel 16/edge
+juju deploy postgresql-k8s -n 3 --trust --channel 16/stable
 
 # Deploy the relevant application charms
 juju deploy mycharm
@@ -86,7 +86,7 @@ juju status --relations
 This charm supports legacy interface `pgsql` from the previous [PostgreSQL charm](https://launchpad.net/postgresql-charm):
 
 ```shell
-juju deploy postgresql-k8s --trust --channel 16/edge
+juju deploy postgresql-k8s --trust --channel 16/stable
 juju deploy finos-waltz-k8s --channel edge
 juju relate postgresql-k8s:db finos-waltz-k8s
 ```

--- a/docs/explanation/connection-pooling.md
+++ b/docs/explanation/connection-pooling.md
@@ -9,7 +9,7 @@ A way to achieve this with Charmed PostgreSQL K8s is by integrating with the [Pg
 
 ## Increasing maximum allowed connections
 
-If using PgBouncer is not enough to handle the connections load of your application, you can increase the amount of connections that PostgreSQL can open via the [`experimental-max-connections` config parameter](https://charmhub.io/postgresql-k8s/configurations?channel=16/edge#experimental-max-connections). 
+If using PgBouncer is not enough to handle the connections load of your application, you can increase the amount of connections that PostgreSQL can open via the [`experimental-max-connections` config parameter](https://charmhub.io/postgresql-k8s/configurations?channel=16/stable#experimental-max-connections). 
 
 ```{caution}
 Each connection opened by PostgreSQL spawns a new process, which is resource-intensive. Use this option as a last resort.

--- a/docs/explanation/interfaces-and-endpoints.md
+++ b/docs/explanation/interfaces-and-endpoints.md
@@ -17,7 +17,7 @@ Adding a relation is accomplished with `juju relate` (or `juju integrate` for Ju
 
 ```text
 # Deploy Charmed PostgreSQL cluster with 3 nodes
-juju deploy postgresql-k8s --channel 16/edge -n 3 --trust
+juju deploy postgresql-k8s --channel 16/stable -n 3 --trust
 
 # Deploy the relevant application charms
 juju deploy mycharm
@@ -48,7 +48,7 @@ Check the limitations of legacy interface implementations in [](/explanation/leg
 This charm supports legacy interface `pgsql` from the previous [PostgreSQL charm](https://launchpad.net/postgresql-charm):
 
 ```text
-juju deploy postgresql-k8s --channel 16/edge --trust
+juju deploy postgresql-k8s --channel 16/stable --trust
 juju deploy finos-waltz-k8s --channel edge
 juju relate postgresql-k8s:db finos-waltz-k8s
 ```

--- a/docs/explanation/legacy-charm.md
+++ b/docs/explanation/legacy-charm.md
@@ -67,7 +67,7 @@ The legacy charm configuration options were not moved to the modern charm due to
 
 ## Extensions supported by modern charm
 
-The legacy charm provided plugins/extensions enabling through the relation (interface `pgsql`). It is NOT supported by the modern charm (neither `pgsql` nor `postgresql_client` interfaces). Please enable the necessary extensions using appropriate `plugin-*-enable` [config option](https://charmhub.io/postgresql-k8s/configurations?channel=16/edge) of the modern charm. After enabling the modern charm will provide plugins support for both `pgsql` and `postgresql_client` interfaces.
+The legacy charm provided plugins/extensions enabling through the relation (interface `pgsql`). It is NOT supported by the modern charm (neither `pgsql` nor `postgresql_client` interfaces). Please enable the necessary extensions using appropriate `plugin-*-enable` [config option](https://charmhub.io/postgresql-k8s/configurations?channel=16/stable) of the modern charm. After enabling the modern charm will provide plugins support for both `pgsql` and `postgresql_client` interfaces.
 
 Please find the list of supported PostgreSQL [Extensions](/reference/plugins-extensions) by modern charm. Feel free to [contact us](/reference/contacts) with a list of required extensions.
 

--- a/docs/explanation/security/index.md
+++ b/docs/explanation/security/index.md
@@ -103,7 +103,7 @@ The following information is configured to be logged:
 * Miscellaneous commands like DISCARD, FETCH, CHECKPOINT, VACUUM, SET.
 * Miscellaneous SET commands.
 
-Other events, like connections and disconnections, are logged depending on the value of the charm configuration options related to them. For more information, check the configuration options with the `logging` prefix in the [configuration reference](https://charmhub.io/postgresql-k8s/configurations?channel=16/edge#logging-log-connections).
+Other events, like connections and disconnections, are logged depending on the value of the charm configuration options related to them. For more information, check the configuration options with the `logging` prefix in the [configuration reference](https://charmhub.io/postgresql-k8s/configurations?channel=16/stable#logging-log-connections).
 
 Also, all operations performed by the charm as a result of user actions — such as enabling or disabling plugins, managing TLS, creating or restoring backups, and configuring replication between clusters (asynchronous or logical) — are executed through the underlying workload components (PostgreSQL, Patroni, or pgBackRest). Consequently, these operations are recorded in the respective workload log files under `/var/lib/pg/logs/16/main/` and also forwarded to COS.
 

--- a/docs/how-to/data-migration/migrate-data-from-14-to-16.md
+++ b/docs/how-to/data-migration/migrate-data-from-14-to-16.md
@@ -33,7 +33,7 @@ PGPASSWORD="${OLD_PASSWORD}" pg_dump -j 4 -Fd -h "${OLD_IP}" -U "${OLD_USER}" -d
 Deploy one unit of Charmed PostgreSQL 16. This will simplify the migration and can be scaled later.
 
 ```shell
-juju deploy postgresql-k8s --channel 16/edge --trust
+juju deploy postgresql-k8s --channel 16/stable --trust
 ```
 
 Define the following variables for the new database:

--- a/docs/how-to/data-migration/migrate-data-via-pg-dump.md
+++ b/docs/how-to/data-migration/migrate-data-via-pg-dump.md
@@ -48,7 +48,7 @@ OLD_DB_USER=$(juju show-unit ${CLIENT_APP} | yq '.[] | .relation-info | select(.
 Deploy new PostgreSQL database charm:
 
 ```text
-juju deploy postgresql-k8s ${NEW_DB_APP} --channel 16/edge --trust
+juju deploy postgresql-k8s ${NEW_DB_APP} --channel 16/stable --trust
 ```
 
 Obtain `operator` user password of new PostgreSQL database from PostgreSQL charm:

--- a/docs/how-to/deploy/air-gapped.md
+++ b/docs/how-to/deploy/air-gapped.md
@@ -106,7 +106,7 @@ For the manual OCI import, please follow [the official Charmhub guide](https://d
 
  Deploy and operate Juju charms normally:
 ```text
-juju deploy postgresql-k8s --channel 16/edge --trust
+juju deploy postgresql-k8s --channel 16/stable --trust
 ```
 ```{note}
 All the charms revisions and OCI resources tags/revisions deployed in the air-gapped environment must match the official Charmhub revisions/tags. 

--- a/docs/how-to/deploy/aks.md
+++ b/docs/how-to/deploy/aks.md
@@ -131,11 +131,11 @@ juju model-config logging-config='<root>=INFO;unit=DEBUG'
 The following command deploys PostgreSQL K8s:
 
 ```text
-juju deploy postgresql-k8s --channel 16/edge --trust -n 3
+juju deploy postgresql-k8s --channel 16/stable --trust -n 3
 ```
 Sample output:
 ```text
-Deployed "postgresql-k8s" from charm-hub charm "postgresql-k8s", revision <number> in channel 16/edge on ubuntu@24.04/edge
+Deployed "postgresql-k8s" from charm-hub charm "postgresql-k8s", revision <number> in channel 16/stable on ubuntu@24.04/edge
 ```
 
 Check the status:
@@ -148,7 +148,7 @@ Model    Controller  Cloud/Region  Version  SLA          Timestamp
 welcome  aks         aks/eastus    3.4.2    unsupported  17:53:35+02:00
 
 App             Version  Status  Scale  Charm           Channel       Rev  Address       Exposed  Message
-postgresql-k8s  14.11    active      3  postgresql-k8s  16/edge       615  10.0.237.223  no       Primary
+postgresql-k8s  14.11    active      3  postgresql-k8s  16/stable       615  10.0.237.223  no       Primary
 
 Unit               Workload  Agent  Address      Ports  Message
 postgresql-k8s/0*  active    idle   10.244.0.19         Primary

--- a/docs/how-to/deploy/canonical-k8s.md
+++ b/docs/how-to/deploy/canonical-k8s.md
@@ -50,7 +50,7 @@ juju bootstrap ck8s
 
 ```text
 juju add-model postgresql
-juju deploy postgresql-k8s --channel 16/edge --trust
+juju deploy postgresql-k8s --channel 16/stable --trust
 ```
 
 follow the deployment progress using:
@@ -64,7 +64,7 @@ Model       Controller  Cloud/Region  Version  SLA          Timestamp
 postgresql  ck8s        ck8s          3.6-rc1  unsupported  17:25:11+01:00
 
 App             Version   Status  Scale  Charm           Channel     Rev  Address         Exposed  Message
-postgresql-k8s  14.12     active      1  postgresql-k8s  16/edge     615  10.152.183.30   no       
+postgresql-k8s  14.12     active      1  postgresql-k8s  16/stable     615  10.152.183.30   no       
 
 Unit               Workload  Agent  Address    Ports  Message
 postgresql-k8s/0*  active    idle   10.1.0.16         Primary

--- a/docs/how-to/deploy/gke.md
+++ b/docs/how-to/deploy/gke.md
@@ -92,7 +92,7 @@ kubectl get pods -n welcome-model
 The following commands deploy PostgreSQL K8s and PgBouncer K8s:
 
 ```text
-juju deploy postgresql-k8s --channel 16/edge --trust
+juju deploy postgresql-k8s --channel 16/stable --trust
 juju deploy pgbouncer-k8s --trust
 ```
 

--- a/docs/how-to/deploy/index.md
+++ b/docs/how-to/deploy/index.md
@@ -20,7 +20,7 @@ juju add-model <model name>
 Then, use the [`juju deploy`](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/juju-cli/list-of-juju-cli-commands/deploy/) command:
 
 ```shell
-juju deploy postgresql-k8s --channel 16/edge -n <number_of_replicas> --trust
+juju deploy postgresql-k8s --channel 16/stable -n <number_of_replicas> --trust
 ```
 
 If you are not sure where to start or would like a more guided walkthrough for setting up your environment, see the {ref}`tutorial`.

--- a/docs/how-to/deploy/multi-az.md
+++ b/docs/how-to/deploy/multi-az.md
@@ -78,7 +78,7 @@ The command below demonstrates how to deploy Charmed PostgreSQL K8s with Juju co
 
 ```text
 export MYAPP="mydatabase" ; \
-juju deploy postgresql-k8s --channel 16/edge  ${MYAPP} --trust -n 3 \
+juju deploy postgresql-k8s --channel 16/stable  ${MYAPP} --trust -n 3 \
  --constraints="tags=anti-pod.app.kubernetes.io/name=${MYAPP},anti-pod.topology-key=topology.kubernetes.io/zone"
 ```
 
@@ -144,7 +144,7 @@ Model    Controller  Cloud/Region  Version  SLA          Timestamp
 mymodel  gke         gke/us-east4  3.5.3    unsupported  22:02:32+02:00
 
 App         Version  Status  Scale  Charm           Channel    Rev  Address         Exposed  Message
-mydatabase  14.13    active      3  postgresql-k8s  16/edge    615  34.118.235.169  no       
+mydatabase  14.13    active      3  postgresql-k8s  16/stable    615  34.118.235.169  no       
 
 Unit           Workload  Agent  Address    Ports  Message
 mydatabase/0   active    idle   10.80.5.9         
@@ -233,7 +233,7 @@ Model    Controller  Cloud/Region  Version  SLA          Timestamp
 mymodel  gke         gke/us-east4  3.5.3    unsupported  22:31:00+02:00
 
 App         Version  Status   Scale  Charm           Channel    Rev  Address         Exposed  Message
-mydatabase  14.13    waiting    2/3  postgresql-k8s  16/edge    615  34.118.235.169  no       installing agent
+mydatabase  14.13    waiting    2/3  postgresql-k8s  16/stable    615  34.118.235.169  no       installing agent
 
 Unit           Workload  Agent  Address    Ports  Message
 mydatabase/0   unknown   lost                     agent lost, see 'juju show-status-log mydatabase/0'
@@ -254,7 +254,7 @@ Model    Controller  Cloud/Region  Version  SLA          Timestamp
 mymodel  gke         gke/us-east4  3.5.3    unsupported  22:38:23+02:00
 
 App         Version  Status  Scale  Charm           Channel    Rev  Address         Exposed  Message
-mydatabase  14.13    active      3  postgresql-k8s  16/edge    615  34.118.235.169  no       
+mydatabase  14.13    active      3  postgresql-k8s  16/stable    615  34.118.235.169  no       
 
 Unit           Workload  Agent  Address     Ports  Message
 mydatabase/0   active    idle   10.80.5.10         

--- a/docs/how-to/deploy/terraform.md
+++ b/docs/how-to/deploy/terraform.md
@@ -88,7 +88,7 @@ Model     Controller  Cloud/Region        Version  SLA          Timestamp
 my-model  k8s         microk8s/localhost  3.5.3    unsupported  12:09:38Z
 
 App             Version  Status  Scale  Charm           Channel    Rev  Address         Exposed  Message     
-postgresql-k8s  14.11    active      1  postgresql-k8s  16/edge    615  10.152.183.137  no                                     
+postgresql-k8s  14.11    active      1  postgresql-k8s  16/stable    615  10.152.183.137  no                                     
 
 Unit               Workload  Agent  Address     Ports  Message       
 postgresql-k8s/0*  active    idle   10.1.77.74         Primary                                           

--- a/docs/how-to/enable-ldap.md
+++ b/docs/how-to/enable-ldap.md
@@ -24,7 +24,7 @@ Deploy the [GLAuth charm](https://charmhub.io/glauth-k8s):
 ```text
 juju add-model glauth
 juju deploy self-signed-certificates
-juju deploy postgresql-k8s --channel 16/edge --trust
+juju deploy postgresql-k8s --channel 16/stable --trust
 juju deploy glauth-k8s --channel edge --trust
 ```
 

--- a/docs/how-to/integrate-with-another-application.md
+++ b/docs/how-to/integrate-with-another-application.md
@@ -96,7 +96,7 @@ The simplest way to test it is to use `requested-entities-secret` field via the 
 ````{dropdown} Example
 
 ```shell
-$ juju deploy postgresql-k8s --channel 16/edge --trust
+$ juju deploy postgresql-k8s --channel 16/stable --trust
 
 $ juju add-secret myusername mylogin=mypassword
 secret:d5l3do605d8c4b1gn9a0

--- a/docs/how-to/logical-replication/set-up-clusters.md
+++ b/docs/how-to/logical-replication/set-up-clusters.md
@@ -7,8 +7,8 @@ This feature is only available for revision 630 or higher, which is not yet in t
 
 Start by deploying two PostgreSQL clusters:
 ```sh
-juju deploy postgresql-k8s --channel 16/edge --trust postgresql1
-juju deploy postgresql-k8s --channel 16/edge --trust postgresql2
+juju deploy postgresql-k8s --channel 16/stable --trust postgresql1
+juju deploy postgresql-k8s --channel 16/stable --trust postgresql2
 ```
 
 For testing purposes, you can deploy two applications of the [data integrator charm](https://charmhub.io/data-integrator) and then integrate them to the two PostgreSQL clusters you want to replicate data between.

--- a/docs/how-to/monitoring-cos/enable-monitoring.md
+++ b/docs/how-to/monitoring-cos/enable-monitoring.md
@@ -92,7 +92,7 @@ prometheus  active  microk8s  admin/cos.prometheus
 
 App                Version  Status  Scale  Charm              Channel  Rev  Address         Exposed  Message
 grafana-agent-k8s  0.32.1   active      1  grafana-agent-k8s  stable    42  10.152.183.61   no       
-postgresql-k8s     14.9     active      3  postgresql-k8s     16/edge  615  10.152.183.126  no       
+postgresql-k8s     14.9     active      3  postgresql-k8s     16/stable  615  10.152.183.126  no       
 
 Unit                  Workload  Agent   Address       Ports  Message
 grafana-agent-k8s/0*  active    idle    10.1.142.191         

--- a/docs/how-to/scale-replicas.md
+++ b/docs/how-to/scale-replicas.md
@@ -10,7 +10,7 @@ This guide will show you how to establish and change the amount of juju units us
 To deploy PostgreSQL with multiple replicas, specify the number of desired units with the `-n` option:
 
 ```text
-juju deploy postgresql-k8s --channel 16/edge -n <number_of_replicas> --trust
+juju deploy postgresql-k8s --channel 16/stable -n <number_of_replicas> --trust
 ```
 
 ### Primary vs. leader unit

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,14 +1,8 @@
 ---
-relatedlinks: "[Charmhub](https://charmhub.io/postgresql?channel=16/edge)"
+relatedlinks: "[Charmhub](https://charmhub.io/postgresql?channel=16/stable)"
 ---
 
 # Charmed PostgreSQL K8s documentation
-
-```{caution}
-**Charmed PostgreSQL K8s 16 is under development.** Please wait for the upcoming stable release before deploying it in production, or see the documentation for [version 14](https://canonical-charmed-postgresql-k8s.readthedocs-hosted.com/14/).
-
-Meanwhile, you’re welcome to explore the [`16/edge` track](https://charmhub.io/postgresql-k8s?channel=16/edge) and share your feedback as we continue to improve.
-```
 
 Charmed PostgreSQL K8s is an open-source software operator designed to deploy and operate object-relational databases on Kubernetes. It packages the powerful database management system [PostgreSQL](https://www.postgresql.org/) into a charmed operator for deployment with [Juju](https://juju.is/docs/juju).
 
@@ -64,7 +58,7 @@ Charmed PostgreSQL is an official distribution of PostgreSQL. It’s an open-sou
 * [Discourse forum](https://discourse.charmhub.io/tag/postgresql)
 * [Public Matrix channel](https://matrix.to/#/#charmhub-data-platform:ubuntu.com)
 * [Report an issue](https://github.com/canonical/postgresql-k8s-operator/issues/new/choose)
-* [Contribute](https://github.com/canonical/postgresql-k8s-operator/blob/16/edge/CONTRIBUTING.md)
+* [Contribute](https://github.com/canonical/postgresql-k8s-operator/blob/16/stable/CONTRIBUTING.md)
 
 ### Governance and policies
 

--- a/docs/reference/performance-and-resources.md
+++ b/docs/reference/performance-and-resources.md
@@ -23,7 +23,7 @@ Pre-deployed application profile change is planned but currently is NOT supporte
 You can set the profile during deployment using the `--config` flag. For example:
 
 ```text
-juju deploy postgresql-k8s --channel 16/edge --trust --config profile=testing
+juju deploy postgresql-k8s --channel 16/stable --trust --config profile=testing
 ```
 
 You can change the profile using the `juju config` action. For example:
@@ -39,12 +39,12 @@ For a list of all of this charm's config options, see the [Configuration tab](ht
 The Juju [`--constraints`](https://juju.is/docs/juju/constraint) flag sets RAM and CPU limits for Kubernetes pods:
 
 ```text
-juju deploy postgresql-k8s --channel 16/edge --trust --constraints cores=8 mem=16G
+juju deploy postgresql-k8s --channel 16/stable --trust --constraints cores=8 mem=16G
 ```
 
 Juju constraints can be set together with the charm's profile:
 
 ```text
-juju deploy postgresql-k8s --channel 16/edge --trust --constraints cores=8 mem=16G --config profile=testing
+juju deploy postgresql-k8s --channel 16/stable --trust --constraints cores=8 mem=16G --config profile=testing
 ```
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -73,7 +73,7 @@ Model "admin/tutorial" is empty.
 To deploy Charmed PostgreSQL K8s, run
 
 ```text
-juju deploy postgresql-k8s --channel=16/edge --trust
+juju deploy postgresql-k8s --channel=16/stable --trust
 ```
 
 Juju will now fetch Charmed PostgreSQL K8s from [Charmhub][Charmhub PostgreSQL K8s] and deploy it to the local MicroK8s. This process can take several minutes depending on how provisioned (RAM, CPU, etc) your machine is. 
@@ -93,7 +93,7 @@ Model     Controller  Cloud/Region        Version  SLA          Timestamp
 tutorial  overlord    microk8s/localhost  2.9.42   unsupported  12:00:43+01:00
 
 App             Version  Status  Scale  Charm           Channel    Rev  Address         Exposed  Message
-postgresql-k8s           active      1  postgresql-k8s  16/edge    615   10.152.183.167  no
+postgresql-k8s           active      1  postgresql-k8s  16/stable    615   10.152.183.167  no
 
 Unit               Workload  Agent  Address       Ports  Message
 postgresql-k8s/0*  active    idle   10.1.188.206
@@ -318,7 +318,7 @@ Model     Controller  Cloud/Region        Version  SLA          Timestamp
 tutorial  overlord    microk8s/localhost  2.9.42   unsupported  12:09:49+01:00
 
 App             Version  Status  Scale  Charm           Channel    Rev  Address         Exposed  Message
-postgresql-k8s           active      3  postgresql-k8s  16/edge    615  10.152.183.167  no
+postgresql-k8s           active      3  postgresql-k8s  16/stable    615  10.152.183.167  no
 
 Unit               Workload  Agent  Address       Ports  Message
 postgresql-k8s/0*  active    idle   10.1.188.206         Primary
@@ -345,7 +345,7 @@ Model     Controller  Cloud/Region        Version  SLA          Timestamp
 tutorial  overlord    microk8s/localhost  2.9.42   unsupported  12:10:08+01:00
 
 App             Version  Status  Scale  Charm           Channel    Rev  Address         Exposed  Message
-postgresql-k8s           active      2  postgresql-k8s  16/edge    615   10.152.183.167  no
+postgresql-k8s           active      2  postgresql-k8s  16/stable    615   10.152.183.167  no
 
 Unit               Workload  Agent  Address       Ports  Message
 postgresql-k8s/0*  active    idle   10.1.188.206         Primary
@@ -385,7 +385,7 @@ tutorial  overlord    microk8s/localhost  2.9.42   unsupported  12:11:53+01:00
 
 App              Version  Status   Scale  Charm            Channel    Rev  Address         Exposed  Message
 data-integrator           waiting      1  data-integrator  edge       6    10.152.183.66   no       installing agent
-postgresql-k8s            active       2  postgresql-k8s   16/edge    615   10.152.183.167  no
+postgresql-k8s            active       2  postgresql-k8s   16/stable    615   10.152.183.167  no
 
 Unit                Workload    Agent  Address       Ports  Message
 data-integrator/0*  blocked     idle   10.1.188.211         Please relate the data-integrator with the desired product
@@ -409,7 +409,7 @@ tutorial  overlord    microk8s/localhost  2.9.42   unsupported  12:12:12+01:00
 
 App              Version  Status   Scale  Charm            Channel    Rev  Address         Exposed  Message
 data-integrator           waiting      1  data-integrator  edge       6    10.152.183.66   no       installing agent
-postgresql-k8s            active       2  postgresql-k8s   16/edge    615  10.152.183.167  no
+postgresql-k8s            active       2  postgresql-k8s   16/stable    615  10.152.183.167  no
 
 Unit                Workload    Agent  Address       Ports  Message
 data-integrator/0*  active      idle   10.1.188.211
@@ -544,7 +544,7 @@ Model     Controller  Cloud/Region        Version  SLA          Timestamp
 tutorial  overlord    microk8s/localhost  3.1.7    unsupported  12:18:05+01:00
 
 App                        Version  Status   Scale  Charm                      Channel    Rev  Address         Exposed  Message
-postgresql-k8s                      active       2  postgresql-k8s             16/edge    615  10.152.183.167  no
+postgresql-k8s                      active       2  postgresql-k8s             16/stable    615  10.152.183.167  no
 self-signed-certificates            active       1  self-signed-certificates   stable     72   10.152.183.138  no
 
 Unit                          Workload    Agent  Address       Ports  Message
@@ -627,4 +627,4 @@ multipass delete --purge my-vm
 
 <!--Links-->
 
-[Charmhub PostgreSQL K8s]: https://charmhub.io/postgresql-k8s?channel=16/edge
+[Charmhub PostgreSQL K8s]: https://charmhub.io/postgresql-k8s?channel=16/stable

--- a/tests/integration/high_availability/test_upgrade_skip_pre_upgrade_check.py
+++ b/tests/integration/high_availability/test_upgrade_skip_pre_upgrade_check.py
@@ -80,7 +80,7 @@ async def test_rollback_without_pre_refresh_check(
     """Test refresh back to stable channel."""
     # Early Jubilant 1.X.Y versions do not support the `switch` option
     logging.info("Refresh the charm to stable channel")
-    juju.cli("refresh", "--channel=16/edge", f"--switch={DB_APP_NAME}", DB_APP_NAME)
+    juju.cli("refresh", "--channel=16/stable", f"--switch={DB_APP_NAME}", DB_APP_NAME)
 
     logging.info("Wait for refresh to block as paused or incompatible")
     units = get_app_units(juju, DB_APP_NAME)


### PR DESCRIPTION
* Removed warning in home page about edge channel
* Updated Charmhub links and deployment instructions from `16/edge` to `16/stable` 

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
