### PR TITLE
[DPE-10008] docs(restore): fix restore-to-time format to match PostgreSQL timestamp

### DIFF
--- a/docs/how-to/back-up-and-restore/restore-a-backup.md
+++ b/docs/how-to/back-up-and-restore/restore-a-backup.md
@@ -63,9 +63,10 @@ When the user needs to restore a specific backup that was made, they can use the
 juju run postgresql-k8s/leader restore backup-id=YYYY-MM-DDTHH:MM:SSZ
 ```
 
-However, if the user needs to restore to a specific point in time between different backups (e.g. to restore only specific transactions made between those backups), they can use the `restore-to-time` parameter to pass a timestamp related to the moment they want to restore.
+However, if the user needs to restore to a specific point in time between different backups (e.g. to restore only specific transactions made between those backups), they can use the `restore-to-time` parameter to pass a timestamp related to the moment they want to restore. The format matches PostgreSQL's `SELECT current_timestamp` output (`YYYY-MM-DD HH:MM:SS` with a space separator, optional fractional seconds, and an optional `+HH` / `-HH:MM` timezone offset):
+
  ```text
-juju run postgresql-k8s/leader restore restore-to-time="YYYY-MM-DDTHH:MM:SSZ"
+juju run postgresql-k8s/leader restore restore-to-time="YYYY-MM-DD HH:MM:SS"
 ```
 
 Your restore will then be in progress.


### PR DESCRIPTION
## Issue

The PITR `restore-a-backup` how-to documents the `restore-to-time` value as `YYYY-MM-DDTHH:MM:SSZ`, but the charm validates that argument against the PostgreSQL `SELECT current_timestamp` format via the regex in `src/backups.py` — which requires a space separator (not `T`) and rejects a trailing `Z`. Following the doc's format returns `Bad restore-to-time format` on every PITR attempt.

## Solution

Update the example to use `YYYY-MM-DD HH:MM:SS` and add an explanation of the PostgreSQL timestamp format.

## Checklist
- [x] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.

Port of https://github.com/canonical/postgresql-k8s-operator/pull/1515.