### PR TITLE
fix(tests): correct the location of the Harness cleanup

### DIFF
--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -223,12 +223,12 @@ def test_get_extensions(harness):
         default: false
         type: boolean"""
     harness = Harness(PostgresqlOperatorCharm, config=config)
-    harness.cleanup()
     harness.begin()
     assert harness.charm.legacy_db_relation._get_extensions(relation) == (
         [extensions[1], extensions[2]],
         {extensions[2]},
     )
+    harness.cleanup()
 
 
 def test_set_up_relation(harness):


### PR DESCRIPTION
## Issue

The `test_get_extensions` test calls `cleanup()` on Harness before using it. We're fixing a bug in Harness that leaves a dangling sqlite3 reference (https://github.com/canonical/operator/pull/2507), and that fix breaks this test because of this.

## Solution

Call `cleanup` when finished with the harness.

## Checklist
- [ ] ~I have added or updated any relevant documentation.~
- [ ] ~I have cleaned any remaining cloud resources from my accounts.~
