### PR TITLE
fix: robustly select valid backup entry in GCP restore integration test

### DIFF
--- a/tests/integration/test_backups_gcp.py
+++ b/tests/integration/test_backups_gcp.py
@@ -125,15 +125,28 @@ async def test_restore_on_new_cluster(
     ):
         with attempt:
             logger.info("restoring the backup")
-            # Last two entries are 'action: restore', that cannot be used without restore-to-time parameter
-            most_recent_real_backup = backups.split("\n")[-3]
-            backup_id = most_recent_real_backup.split()[0]
+            # The list-backups output contains real backup entries (action = "full backup",
+            # "differential backup", "incremental backup") as well as restore/timeline entries
+            # (action = "restore") that cannot be used without the restore-to-time parameter.
+            # Select only lines where the action column contains "backup" to avoid picking
+            # a timeline entry that would cause: "Cannot restore to the timeline without
+            # restore-to-time parameter".
+            real_backup_lines = [
+                line
+                for line in backups.splitlines()
+                for parts in [line.split("|")]
+                if len(parts) > 1 and "backup" in parts[1].lower()
+            ]
+            assert real_backup_lines, (
+                f"No valid backup entry found in list-backups output:\n{backups}"
+            )
+            backup_id = real_backup_lines[-1].split()[0]
             action = await ops_test.model.units.get(f"{database_app_name}/0").run_action(
                 "restore", **{"backup-id": backup_id}
             )
             await action.wait()
             restore_status = action.results.get("restore-status")
-            assert restore_status, "restore hasn't succeeded"
+            assert restore_status, f"restore hasn't succeeded: {action.results}"
 
     # Wait for the restore to complete.
     async with ops_test.fast_forward():


### PR DESCRIPTION
Cherry-pick of 0758e8f4d9 from main.

The test_restore_on_new_cluster integration test was selecting an invalid backup entry using a hardcoded positional index (backups.split("\n")[-3]). When the list-backups output contained extra blank lines or additional restore/timeline entries, this caused the restore action to fail with "Cannot restore to the timeline without restore-to-time parameter".

The fix parses the pipe-delimited output and keeps only lines where the action column (second field) contains "backup", matching "full backup", "differential backup", and "incremental backup" entries while excluding "restore" (timeline) entries that require restore-to-time.

Also improve the assertion failure message to include action.results for easier debugging.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
