### PR TITLE
[DPE-10012] Bump PG to 16.14 (OCI bumped by renovate)

### DIFF
--- a/docs/how-to/integrate-with-another-application.md
+++ b/docs/how-to/integrate-with-another-application.md
@@ -115,7 +115,7 @@ postgresql-k8s:
   username: mylogin
   password: mypassword
   uris: postgresql://mylogin:mypassword@10.218.34.199:5432/mydbname
-  version: "16.13"
+  version: "16.14"
   ...
 
 $ psql postgresql://mylogin:mypassword@10.218.34.199:5432/mydbname -c "SELECT SESSION_USER, CURRENT_USER"

--- a/refresh_versions.toml
+++ b/refresh_versions.toml
@@ -1,4 +1,4 @@
 # https://canonical-charm-refresh.readthedocs-hosted.com/latest/refresh-versions-toml/
 
 charm_major = 1
-workload = "16.13"
+workload = "16.14"

--- a/tests/integration/high_availability/test_upgrade.py
+++ b/tests/integration/high_availability/test_upgrade.py
@@ -164,7 +164,7 @@ def inject_dependency_fault(juju: Juju, app_name: str, charm_file: str | Path) -
         versions = tomli.load(file)
 
     versions["charm"] = "16/0.0.0"
-    versions["workload"] = "16.13"
+    versions["workload"] = "16.14"
 
     # Overwrite refresh_versions.toml with incompatible version.
     with zipfile.ZipFile(charm_file, mode="a") as charm_zip:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -27,7 +27,7 @@ def mock_refresh():
     # Mock the _RefreshVersions class to avoid KeyError when charm key is missing
     versions_mock = Mock()
     versions_mock.charm = "v1/16.0.0"
-    versions_mock.workload = "16.13"
+    versions_mock.workload = "16.14"
 
     with (
         patch("charm_refresh.Kubernetes", Mock(return_value=refresh_mock)),


### PR DESCRIPTION
## Issue

Renovate bumped OCI to 16.14, but charm is still using 16.13 for the reference.

## Solution

Bump charm from 16.13 to 16.14.

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
