### PR TITLE
[MISC] Single kernel renovate config (16/edge)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,7 +8,7 @@
   ],
   baseBranchPatterns: [
     'main',
-    '/^*\\/edge$/',
+    '/^[0-9][0-9]\\/edge$/',
   ],
   packageRules: [
     {
@@ -17,6 +17,12 @@
       ],
       "matchBaseBranches": ["main"],
       allowedVersions: '<2.0.0',
+    },
+    {
+      matchPackageNames: ['postgresql-charms-single-kernel'],
+      schedule: ['* * * * *'],
+      minimumReleaseAge: '0',
+      groupName: "Single kernel"
     },
   ],
   customManagers: [],


### PR DESCRIPTION
Port of https://github.com/canonical/postgresql-k8s-operator/pull/1570 to keep Renovate config consistent.