### PR TITLE
fix: make _create_pgdata idempotent on re-emitted pebble-ready

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -933,21 +933,13 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
     def _create_pgdata(self, container: Container):
         """Create the PostgreSQL data directory."""
         if not container.exists(self.pgdata_path):
-            try:
-                container.make_dir(
-                    self.pgdata_path,
-                    permissions=0o750,
-                    user=WORKLOAD_OS_USER,
-                    group=WORKLOAD_OS_GROUP,
-                )
-            except PathError as e:
-                # This handler can run more than once, e.g. a deferred pebble-ready event is
-                # re-emitted on later hooks. container.exists() may also report the pgdata
-                # directory as missing even when it is present (restrictively-mounted cloud
-                # volumes), so a redundant make_dir() must stay idempotent: ignore "file exists".
-                if "file exists" not in str(e):
-                    raise
-                logger.info("pgdata directory already exists, skipping creation")
+            container.make_dir(
+                self.pgdata_path,
+                permissions=0o750,
+                user=WORKLOAD_OS_USER,
+                group=WORKLOAD_OS_GROUP,
+                make_parents=True,
+            )
         # Also, fix the permissions from the parent directory.
         container.exec([
             "chown",

--- a/src/charm.py
+++ b/src/charm.py
@@ -933,9 +933,21 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
     def _create_pgdata(self, container: Container):
         """Create the PostgreSQL data directory."""
         if not container.exists(self.pgdata_path):
-            container.make_dir(
-                self.pgdata_path, permissions=0o750, user=WORKLOAD_OS_USER, group=WORKLOAD_OS_GROUP
-            )
+            try:
+                container.make_dir(
+                    self.pgdata_path,
+                    permissions=0o750,
+                    user=WORKLOAD_OS_USER,
+                    group=WORKLOAD_OS_GROUP,
+                )
+            except PathError as e:
+                # This handler can run more than once, e.g. a deferred pebble-ready event is
+                # re-emitted on later hooks. container.exists() may also report the pgdata
+                # directory as missing even when it is present (restrictively-mounted cloud
+                # volumes), so a redundant make_dir() must stay idempotent: ignore "file exists".
+                if "file exists" not in str(e):
+                    raise
+                logger.info("pgdata directory already exists, skipping creation")
         # Also, fix the permissions from the parent directory.
         container.exec([
             "chown",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -19,7 +19,7 @@ from ops.model import (
     RelationDataTypeError,
     WaitingStatus,
 )
-from ops.pebble import ChangeError, ServiceStatus
+from ops.pebble import ChangeError, PathError, ServiceStatus
 from ops.testing import Harness
 from requests import ConnectionError as RequestsConnectionError
 from tenacity import RetryError, wait_fixed
@@ -1818,6 +1818,38 @@ def test_create_pgdata(harness):
         "postgres:postgres",
         "/var/lib/postgresql/data",
     ])
+
+
+def test_create_pgdata_is_idempotent_when_dir_already_exists(harness):
+    # _on_postgresql_pebble_ready can run more than once (a deferred event is re-emitted on
+    # later hooks). container.exists() may report the pgdata directory as missing even when it
+    # is present (e.g. restrictively-mounted cloud volumes), so make_dir() raises "file exists".
+    # _create_pgdata must tolerate that and not crash the charm.
+    container = MagicMock()
+    container.exists.return_value = False
+    container.make_dir.side_effect = PathError(
+        "generic-file-error", "mkdir /var/lib/postgresql/data/pgdata: file exists"
+    )
+
+    harness.charm._create_pgdata(container)
+
+    # The parent-directory ownership fix must still run.
+    container.exec.assert_called_once_with([
+        "chown",
+        "postgres:postgres",
+        "/var/lib/postgresql/data",
+    ])
+
+
+def test_create_pgdata_reraises_unexpected_path_error(harness):
+    container = MagicMock()
+    container.exists.return_value = False
+    container.make_dir.side_effect = PathError(
+        "permission-denied", "mkdir /var/lib/postgresql/data/pgdata: permission denied"
+    )
+
+    with pytest.raises(PathError):
+        harness.charm._create_pgdata(container)
 
 
 def test_get_plugins(harness):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -4,7 +4,7 @@ import itertools
 import json
 import logging
 from unittest import TestCase
-from unittest.mock import MagicMock, Mock, PropertyMock, patch, sentinel
+from unittest.mock import MagicMock, Mock, PropertyMock, call, patch, sentinel
 
 import psycopg2
 import pytest
@@ -19,7 +19,7 @@ from ops.model import (
     RelationDataTypeError,
     WaitingStatus,
 )
-from ops.pebble import ChangeError, PathError, ServiceStatus
+from ops.pebble import ChangeError, ServiceStatus
 from ops.testing import Harness
 from requests import ConnectionError as RequestsConnectionError
 from tenacity import RetryError, wait_fixed
@@ -1799,8 +1799,14 @@ def test_create_pgdata(harness):
     container = MagicMock()
     container.exists.return_value = False
     harness.charm._create_pgdata(container)
+    # make_parents=True gives idempotent "mkdir -p" semantics so that a redundant call (e.g. a
+    # re-emitted deferred pebble-ready event) does not crash with "file exists".
     container.make_dir.assert_called_once_with(
-        "/var/lib/postgresql/data/pgdata", permissions=488, user="postgres", group="postgres"
+        "/var/lib/postgresql/data/pgdata",
+        permissions=488,
+        user="postgres",
+        group="postgres",
+        make_parents=True,
     )
     container.exec.assert_called_once_with([
         "chown",
@@ -1820,36 +1826,28 @@ def test_create_pgdata(harness):
     ])
 
 
-def test_create_pgdata_is_idempotent_when_dir_already_exists(harness):
+def test_create_pgdata_is_idempotent_when_dir_reported_missing(harness):
     # _on_postgresql_pebble_ready can run more than once (a deferred event is re-emitted on
-    # later hooks). container.exists() may report the pgdata directory as missing even when it
-    # is present (e.g. restrictively-mounted cloud volumes), so make_dir() raises "file exists".
-    # _create_pgdata must tolerate that and not crash the charm.
+    # later hooks), and container.exists() may report the pgdata directory as missing even when
+    # it is present (e.g. restrictively-mounted cloud volumes). In that case make_dir() must be
+    # called with make_parents=True so the underlying "mkdir -p" stays idempotent instead of
+    # crashing the charm with "file exists".
     container = MagicMock()
     container.exists.return_value = False
-    container.make_dir.side_effect = PathError(
-        "generic-file-error", "mkdir /var/lib/postgresql/data/pgdata: file exists"
-    )
 
+    # Simulate the event being handled twice in a row.
+    harness.charm._create_pgdata(container)
     harness.charm._create_pgdata(container)
 
-    # The parent-directory ownership fix must still run.
-    container.exec.assert_called_once_with([
-        "chown",
-        "postgres:postgres",
-        "/var/lib/postgresql/data",
-    ])
-
-
-def test_create_pgdata_reraises_unexpected_path_error(harness):
-    container = MagicMock()
-    container.exists.return_value = False
-    container.make_dir.side_effect = PathError(
-        "permission-denied", "mkdir /var/lib/postgresql/data/pgdata: permission denied"
-    )
-
-    with pytest.raises(PathError):
-        harness.charm._create_pgdata(container)
+    assert container.make_dir.call_count == 2
+    for actual_call in container.make_dir.call_args_list:
+        assert actual_call == call(
+            "/var/lib/postgresql/data/pgdata",
+            permissions=488,
+            user="postgres",
+            group="postgres",
+            make_parents=True,
+        )
 
 
 def test_get_plugins(harness):


### PR DESCRIPTION
## Issue

Nightly CI/CD test failed:
https://github.com/canonical/postgresql-k8s-operator/actions/runs/27175388869/job/80223717923#logs

```
unit-postgresql-k8s-0: 00:29:23 ERROR unit.postgresql-k8s/0.juju-log database-peers:0: Uncaught exception while in charm code:
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-postgresql-k8s-0/charm/src/charm.py", line 2810, in <module>
    main(PostgresqlOperatorCharm, use_juju_for_storage=True)
...
  File "/var/lib/juju/agents/unit-postgresql-k8s-0/charm/venv/lib/python3.10/site-packages/ops/pebble.py", line 2673, in _raise_on_path_error
    raise PathError(error['kind'], error['message'])
ops.pebble.PathError: generic-file-error - mkdir /var/lib/postgresql/data/pgdata: file exists
```

## Solution

A deferred _on_postgresql_pebble_ready event is re-emitted by
the ops framework on every subsequent hook.
On re-emit, _create_pgdata runs again; container.exists() can report the
pgdata directory as missing even when present (restrictively-mounted cloud volumes),
so make_dir() raises "PathError: ... file exists" and crashes the hook.

Make _create_pgdata idempotent by tolerateting the redundant make_dir() by
adding make_parents=True (like happens for 16/edge).

Added unit tests to prevent regression.

Assisted-by: Claude:claude-4.8-opus

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
