### PR TITLE
Stop flapping alerts

### DIFF
--- a/src/prometheus_alert_rules/patroni_rules.yaml
+++ b/src/prometheus_alert_rules/patroni_rules.yaml
@@ -44,7 +44,7 @@ groups:
     # 2.4.1
     - alert: PatroniHasNoLeader
       expr: '(max by (juju_model,juju_application,juju_model_uuid,scope) (patroni_master) < 1) and (max by (juju_model,juju_application,juju_model_uuid,scope) (patroni_standby_leader) < 1)'
-      for: 0m
+      for: 5m
       labels:
         severity: critical
       annotations:

--- a/src/prometheus_alert_rules/postgresql_rules.yaml
+++ b/src/prometheus_alert_rules/postgresql_rules.yaml
@@ -9,7 +9,7 @@ groups:
     # 2.2.1
     - alert: PostgresqlDown
       expr: 'pg_up == 0'
-      for: 0m
+      for: 5m
       labels:
         severity: critical
       annotations:
@@ -34,7 +34,7 @@ groups:
     # 2.2.3
     - alert: PostgresqlExporterError
       expr: 'pg_exporter_last_scrape_error > 0'
-      for: 0m
+      for: 5m
       labels:
         severity: critical
       annotations:


### PR DESCRIPTION
## Issue

The Postgresql charm constantly has flapping alerts. I see these three regularly.

## Solution

Only fire if the condition is detected for 5 minutes or more.

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
