### PR TITLE
[DPE-10368] Bump replication lag defaults from 16kB to 100MB

### DIFF
--- a/src/patroni.py
+++ b/src/patroni.py
@@ -379,7 +379,9 @@ class Patroni:
                     )
                     for member_endpoint in self._endpoints:
                         endpoint = (
-                            "leader" if member_endpoint == primary_endpoint else "replica?lag=100MB"
+                            "leader"
+                            if member_endpoint == primary_endpoint
+                            else "replica?lag=100MB"
                         )
                         url = self._patroni_url.replace(self._endpoint, member_endpoint)
                         member_status = requests.get(

--- a/src/patroni.py
+++ b/src/patroni.py
@@ -379,7 +379,7 @@ class Patroni:
                     )
                     for member_endpoint in self._endpoints:
                         endpoint = (
-                            "leader" if member_endpoint == primary_endpoint else "replica?lag=16kB"
+                            "leader" if member_endpoint == primary_endpoint else "replica?lag=100MB"
                         )
                         url = self._patroni_url.replace(self._endpoint, member_endpoint)
                         member_status = requests.get(


### PR DESCRIPTION
## Issue

The new units have troubles to join the cluster if active writes performed to Primary.

## Solution

Bump replication lag defaults from 16kB to 100MB for replication health (to mimic PG16 behavior).

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
