### PR TITLE
[DPE-10450] Fix crash restoring non-settable unit status in PG16

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -59,6 +59,7 @@ from ops import (
     BlockedStatus,
     CharmEvents,
     Container,
+    ErrorStatus,
     HookEvent,
     JujuVersion,
     LeaderElectedEvent,
@@ -929,7 +930,7 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         if original_status.message == EXTENSION_OBJECT_MESSAGE:
             self._set_active_status()
             return
-        if not isinstance(original_status, UnknownStatus):
+        if not isinstance(original_status, UnknownStatus | ErrorStatus):
             self.set_unit_status(original_status)
 
     def _check_extension_dependencies(self, extension: str, enable: bool) -> bool:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -14,8 +14,10 @@ from ops import JujuVersion
 from ops.model import (
     ActiveStatus,
     BlockedStatus,
+    ErrorStatus,
     MaintenanceStatus,
     RelationDataTypeError,
+    UnknownStatus,
     WaitingStatus,
 )
 from ops.pebble import ChangeError, FileType, ServiceStatus
@@ -546,6 +548,20 @@ def test_enable_disable_extensions(harness):
         # Should resolve afterwards
         harness.charm.enable_disable_extensions()
         assert isinstance(harness.charm.unit.status, ActiveStatus)
+
+
+@pytest.mark.parametrize("unsettable_status", [ErrorStatus(), UnknownStatus()])
+def test_enable_disable_extensions_does_not_restore_unsettable_status(harness, unsettable_status):
+    # The status getter can return statuses the setter rejects (e.g. an "error" status left
+    # over from a previously failed hook). Restoring them verbatim raises InvalidStatusError
+    # and deadlocks the unit, so they must be skipped.
+    with (
+        patch("charm.PostgresqlOperatorCharm.set_unit_status") as _set_unit_status,
+        patch("charm.PostgreSQL.enable_disable_extensions"),
+    ):
+        harness.charm._handle_enable_disable_extensions(unsettable_status, {}, None)
+
+        assert call(unsettable_status) not in _set_unit_status.mock_calls
 
 
 def test_on_peer_relation_departed(harness):


### PR DESCRIPTION
PostgreSQL VM identified an issue with incompatible charm status setter.
Backport of canonical/postgresql-operator#1792 (VM charm).

The unit status getter can return statuses the setter rejects (e.g. an "error" status left over from a previously failed hook). Restoring such a status verbatim raises InvalidStatusError and deadlocks the unit.

In enable_disable_extensions the cached original_status was restored guarding only against UnknownStatus; an ErrorStatus would still slip through. Extend the guard to also skip ErrorStatus.

The VM PR's _check_detached_storage path does not apply: the K8s charm has no such function.