### PR TITLE
[DPE-9978] fix(charm): apply minimal ownerReferences SSA patch on app removal

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -1960,21 +1960,10 @@ class PostgresqlOperatorCharm(TypedCharmBase[K8SCharmConfig]):
                 or resource.metadata.ownerReferences == pod0.metadata.ownerReferences
             ):
                 continue
-            # Reparent the resource onto the StatefulSet (pod0's owner) so it
-            # is garbage-collected when the application is removed.
-            #
-            # Apply only ownerReferences (plus identity) via a targeted
-            # server-side-apply patch, NOT the whole listed object. Patroni
-            # mutates its leader-election Service (e.g. config annotations)
-            # continuously, so the snapshot from client.list() above is already
-            # stale by the time we apply. Sending the whole object would
-            # both (a) carry a stale metadata.resourceVersion, which SSA treats
-            # as an optimistic-concurrency precondition and rejects with
-            # 409 "the object has been modified; please apply your changes to
-            # the latest version", and (b) revert any field Patroni changed
-            # since the list. A minimal body carrying just ownerReferences
-            # avoids both: SSA skips the resourceVersion precondition (absent
-            # from the body) and leaves Patroni-owned fields untouched.
+            # Reparent onto the StatefulSet (pod0's owner) for GC on removal.
+            # Apply only ownerReferences: the whole listed object would carry a
+            # stale resourceVersion (Patroni churns this Service) and 409, and
+            # would revert Patroni's in-flight changes.
             try:
                 patch = type(resource)(
                     metadata=ObjectMeta(

--- a/src/charm.py
+++ b/src/charm.py
@@ -1960,12 +1960,31 @@ class PostgresqlOperatorCharm(TypedCharmBase[K8SCharmConfig]):
                 or resource.metadata.ownerReferences == pod0.metadata.ownerReferences
             ):
                 continue
-            # Patch the resource.
+            # Reparent the resource onto the StatefulSet (pod0's owner) so it
+            # is garbage-collected when the application is removed.
+            #
+            # Apply only ownerReferences (plus identity) via a targeted
+            # server-side-apply patch, NOT the whole listed object. Patroni
+            # mutates its leader-election Service (e.g. config annotations)
+            # continuously, so the snapshot from client.list() above is already
+            # stale by the time we apply. Sending the whole object would
+            # both (a) carry a stale metadata.resourceVersion, which SSA treats
+            # as an optimistic-concurrency precondition and rejects with
+            # 409 "the object has been modified; please apply your changes to
+            # the latest version", and (b) revert any field Patroni changed
+            # since the list. A minimal body carrying just ownerReferences
+            # avoids both: SSA skips the resourceVersion precondition (absent
+            # from the body) and leaves Patroni-owned fields untouched.
             try:
-                resource.metadata.ownerReferences = pod0.metadata.ownerReferences
-                resource.metadata.managedFields = None
+                patch = type(resource)(
+                    metadata=ObjectMeta(
+                        name=resource.metadata.name,
+                        namespace=resource.metadata.namespace,
+                        ownerReferences=pod0.metadata.ownerReferences,
+                    )
+                )
                 client.apply(
-                    obj=resource,  # type: ignore
+                    obj=patch,  # type: ignore
                     name=resource.metadata.name,
                     namespace=resource.metadata.namespace,
                     force=True,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, Mock, PropertyMock, call, patch, sentinel
 import psycopg2
 import pytest
 from lightkube import ApiError
+from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.core_v1 import Endpoints, Pod, Service
 from ops import JujuVersion
 from ops.model import (
@@ -945,6 +946,20 @@ def test_on_stop(harness):
                 assert _client.return_value.list.call_count == 4
                 # Verify apply() was called for the 2 resources found (fakeName1 and fakeName2)
                 assert _client.return_value.apply.call_count == 2
+                # The fix applies a minimal server-side-apply patch (a fresh
+                # object carrying only identity + ownerReferences in a real
+                # ObjectMeta), NOT the whole listed resource. Asserting on
+                # the apply body distinguishes the fix from the old whole
+                # object apply, where `obj` was the listed resource whose
+                # metadata was a MagicMock. Here the patched object's
+                # metadata is a real ObjectMeta carrying pod0's real
+                # ownerReferences string; the listed resource's mock
+                # name/namespace are passed through as identity.
+                for call_args in _client.return_value.apply.call_args_list:
+                    patched = call_args.kwargs["obj"]
+                    assert isinstance(patched.metadata, ObjectMeta)
+                    assert patched.metadata.ownerReferences == "fakeOwnerReferences"
+                    assert patched.metadata.resourceVersion is None
                 assert harness.get_relation_data(rel_id, harness.charm.unit) == relation_data
                 _client.reset_mock()
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -946,15 +946,7 @@ def test_on_stop(harness):
                 assert _client.return_value.list.call_count == 4
                 # Verify apply() was called for the 2 resources found (fakeName1 and fakeName2)
                 assert _client.return_value.apply.call_count == 2
-                # The fix applies a minimal server-side-apply patch (a fresh
-                # object carrying only identity + ownerReferences in a real
-                # ObjectMeta), NOT the whole listed resource. Asserting on
-                # the apply body distinguishes the fix from the old whole
-                # object apply, where `obj` was the listed resource whose
-                # metadata was a MagicMock. Here the patched object's
-                # metadata is a real ObjectMeta carrying pod0's real
-                # ownerReferences string; the listed resource's mock
-                # name/namespace are passed through as identity.
+                # Verify apply() got a minimal ObjectMeta patch (not the whole resource).
                 for call_args in _client.return_value.apply.call_args_list:
                     patched = call_args.kwargs["obj"]
                     assert isinstance(patched.metadata, ObjectMeta)


### PR DESCRIPTION
## Issue

On stop, the charm reparented Patroni/Juju Endpoints+Services onto the StatefulSet (pod0's owner) by server-side-applying the WHOLE object listed moments earlier. Patroni mutates its `patroni-postgresql-k8s-config` Service (its DCS config object) continuously, so the snapshot carried a stale `metadata.resourceVersion`. Server-Side Apply (SSA) treats a body `resourceVersion` as an optimistic-concurrency precondition, so the apply 409'd with "the object has been modified; please apply your changes to the latest version", the reparent silently failed (the apply is in a `except ApiError: logger.exception` block), and the resource leaked — k8s garbage-collects objects whose `ownerReferences` points at the StatefulSet when it is deleted on app removal, so a resource that never got reparented is never GC'd.

## Solution

Apply a targeted patch carrying only the object's name/namespace (identity) + `ownerReferences` instead. SSA skips the `resourceVersion` precondition (absent from the body) and leaves Patroni-owned fields untouched (SSA only touches fields present in the patch body), so `ownerReferences` reparenting succeeds and GC proceeds on StatefulSet deletion. `force=True` is retained so the charm can take ownership of `ownerReferences` even if another field manager owns it. Omitting `resourceVersion` makes the precondition that caused this 409 structurally impossible to trigger, not merely less likely.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.