### PR TITLE
fix(deps): pin single-kernel lib to fix commit via archive URL

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1782,34 +1782,37 @@ files = [
 
 [[package]]
 name = "postgresql-charms-single-kernel"
-version = "16.3.2"
+version = "16.3.3"
 description = "Shared and reusable code for PostgreSQL-related charms"
 optional = false
-python-versions = "<4.0,>=3.8"
+python-versions = ">=3.8,<4.0"
 groups = ["main", "integration"]
 files = [
-    {file = "postgresql_charms_single_kernel-16.3.2-py3-none-any.whl", hash = "sha256:919773efde865ec9b8142b50e99381229c2c4d2baea5f7bc1a8e78b926fc775d"},
-    {file = "postgresql_charms_single_kernel-16.3.2.tar.gz", hash = "sha256:92cad3c11e0037d9c451d5c9552693f04a7d1a234d790bd90fc5a37bbe02f8ea"},
+    {file = "24a4c838fe95ffeb6bb262558b1b4925894e3c45.tar.gz", hash = "sha256:d814090acb8ed5f5df03be90bcdfe1116ad6fed498278e7bfcc3a211494fc754"},
 ]
 
 [package.dependencies]
-charm-refresh = {version = "*", optional = true, markers = "python_full_version >= \"3.12.0\" and extra == \"postgresql\""}
-charmlibs-interfaces-tls-certificates = {version = ">=1.8.3", optional = true, markers = "python_full_version >= \"3.12.0\" and extra == \"postgresql\""}
-charmlibs-pathops = {version = ">=1.0.1", optional = true, markers = "python_full_version >= \"3.12.0\" and extra == \"postgresql\""}
-charmlibs-rollingops = {version = ">=1.1.1", optional = true, markers = "python_full_version >= \"3.12.0\" and extra == \"postgresql\""}
-data-platform-helpers = {version = ">=0.1.7", optional = true, markers = "python_full_version >= \"3.12.0\" and extra == \"postgresql\""}
-httpx = {version = "*", optional = true, markers = "python_full_version >= \"3.12.0\" and extra == \"postgresql\""}
-jinja2 = {version = ">=3.1.6", optional = true, markers = "python_full_version >= \"3.12.0\" and extra == \"postgresql\""}
+charm-refresh = {version = "*", optional = true, markers = "python_version >= \"3.12\" and extra == \"postgresql\""}
+charmlibs-interfaces-tls-certificates = {version = ">=1.8.3", optional = true, markers = "python_version >= \"3.12\" and extra == \"postgresql\""}
+charmlibs-pathops = {version = ">=1.0.1", optional = true, markers = "python_version >= \"3.12\" and extra == \"postgresql\""}
+charmlibs-rollingops = {version = ">=1.1.1", optional = true, markers = "python_version >= \"3.12\" and extra == \"postgresql\""}
+data-platform-helpers = {version = ">=0.1.7", optional = true, markers = "python_version >= \"3.12\" and extra == \"postgresql\""}
+httpx = {version = "*", optional = true, markers = "python_version >= \"3.12\" and extra == \"postgresql\""}
+jinja2 = {version = ">=3.1.6", optional = true, markers = "python_version >= \"3.12\" and extra == \"postgresql\""}
 ops = ">=2.0.0"
-pydantic = {version = ">=2.0", optional = true, markers = "python_full_version >= \"3.12.0\" and extra == \"postgresql\""}
-requests = {version = "*", optional = true, markers = "python_full_version >= \"3.12.0\" and extra == \"postgresql\""}
+pydantic = {version = ">=2.0", optional = true, markers = "python_version >= \"3.12\" and extra == \"postgresql\""}
+requests = {version = "*", optional = true, markers = "python_version >= \"3.12\" and extra == \"postgresql\""}
 tenacity = ">=9.0.0"
-tomli = {version = "*", optional = true, markers = "python_full_version >= \"3.12.0\" and extra == \"postgresql\""}
+tomli = {version = "*", optional = true, markers = "python_version >= \"3.12\" and extra == \"postgresql\""}
 
 [package.extras]
 db-driver = ["psycopg2 (>=2.9.10)"]
-postgresql = ["charm-refresh ; python_full_version >= \"3.12.0\"", "charmlibs-interfaces-tls-certificates (>=1.8.3) ; python_full_version >= \"3.12.0\"", "charmlibs-pathops (>=1.0.1) ; python_full_version >= \"3.12.0\"", "charmlibs-rollingops (>=1.1.1) ; python_full_version >= \"3.12.0\"", "data-platform-helpers (>=0.1.7) ; python_full_version >= \"3.12.0\"", "httpx ; python_full_version >= \"3.12.0\"", "jinja2 (>=3.1.6) ; python_full_version >= \"3.12.0\"", "pydantic (>=2.0) ; python_full_version >= \"3.12.0\"", "requests ; python_full_version >= \"3.12.0\"", "tomli ; python_full_version >= \"3.12.0\""]
-vm = ["charmlibs-snap (>=1.0.1) ; python_full_version >= \"3.12.0\"", "charmlibs-systemd (>=1.0.0.post0) ; python_full_version >= \"3.12.0\"", "psutil (>=7.2.2) ; python_full_version >= \"3.12.0\"", "pysyncobj (>=0.3.15) ; python_full_version >= \"3.12.0\""]
+postgresql = ["charm-refresh ; python_version >= \"3.12\"", "charmlibs-interfaces-tls-certificates (>=1.8.3) ; python_version >= \"3.12\"", "charmlibs-pathops (>=1.0.1) ; python_version >= \"3.12\"", "charmlibs-rollingops (>=1.1.1) ; python_version >= \"3.12\"", "data-platform-helpers (>=0.1.7) ; python_version >= \"3.12\"", "httpx ; python_version >= \"3.12\"", "jinja2 (>=3.1.6) ; python_version >= \"3.12\"", "pydantic (>=2.0) ; python_version >= \"3.12\"", "requests ; python_version >= \"3.12\"", "tomli ; python_version >= \"3.12\""]
+vm = ["charmlibs-snap (>=1.0.1) ; python_version >= \"3.12\"", "charmlibs-systemd (>=1.0.0.post0) ; python_version >= \"3.12\"", "psutil (>=7.2.2) ; python_version >= \"3.12\"", "pysyncobj (>=0.3.15) ; python_version >= \"3.12\""]
+
+[package.source]
+type = "url"
+url = "https://github.com/canonical/postgresql-single-kernel-library/archive/24a4c838fe95ffeb6bb262558b1b4925894e3c45.tar.gz"
 
 [[package]]
 name = "prompt-toolkit"
@@ -3129,4 +3132,4 @@ h11 = ">=0.16.0,<1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "b5eac00f853a51bcd744bacf3d4ea662e4010d22a7730abcd4e17657e877ef73"
+content-hash = "6cdd688820f762d8777bc7b76b6d3a6f3a1d308f1bbd9b1f47e2783033457149"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ lightkube-models = "^1.28.1.4"
 psycopg2 = "^2.9.12"
 charmlibs-interfaces-tls-certificates = "^1.8.3"
 charm-refresh = "^3.1.1.2"
-postgresql-charms-single-kernel = {extras = ["postgresql"], version = "16.3.2"}
+postgresql-charms-single-kernel = {extras = ["postgresql"], url = "https://github.com/canonical/postgresql-single-kernel-library/archive/24a4c838fe95ffeb6bb262558b1b4925894e3c45.tar.gz"}
 
 [tool.poetry.group.charm-libs.dependencies]
 # data_platform_libs/v0/data_interfaces.py

--- a/tests/integration/test_storage_detaching_tls.py
+++ b/tests/integration/test_storage_detaching_tls.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""Regression test for the storage-detaching crash during TLS scale-down.
+
+Reproduces the scenario from the field report: scaling down a postgresql-k8s
+unit with TLS enabled failed the storage-detaching hook with an uncaught
+``ssl.SSLError: [X509: NO_CERTIFICATE_OR_CRL_FOUND]`` when the peer CA bundle
+was empty/corrupt at scale-down time, leaving the unit in ``error`` and the
+data storage attached.
+
+The crash lives in the single-kernel lib's ``_httpx_get_request``:
+``load_verify_locations`` raises ``ssl.SSLError`` (not ``FileNotFoundError``)
+for an existing-but-certless CA bundle, and the ``suppress(FileNotFoundError)``
+guard did not catch it. The error escaped ``parallel_patroni_get_request`` ->
+``cluster_status`` -> ``get_primary`` (which only catches ``RetryError``) and
+crashed the hook. With the lib fix the guard also swallows ``ssl.SSLError``,
+so the request degrades to unreachable and the hook completes; the unit is
+removed cleanly and the application returns to active.
+"""
+
+import logging
+
+import pytest
+from pytest_operator.plugin import OpsTest
+
+from .helpers import (
+    CHARM_BASE_NOBLE,
+    DATABASE_APP_NAME,
+    build_and_deploy,
+    check_tls,
+    check_tls_patroni_api,
+    scale_application,
+)
+
+logger = logging.getLogger(__name__)
+
+tls_certificates_app_name = "self-signed-certificates"
+tls_channel = "1/stable"
+tls_config = {"ca-common-name": "Test CA"}
+INITIAL_UNITS = 3
+
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest, charm) -> None:
+    """Build and deploy three units of PostgreSQL."""
+    await build_and_deploy(ops_test, charm, INITIAL_UNITS, wait_for_idle=False)
+
+
+@pytest.mark.abort_on_fail
+async def test_enable_tls(ops_test: OpsTest) -> None:
+    """Enable TLS on the cluster (precondition for the storage-detaching crash)."""
+    async with ops_test.fast_forward():
+        await ops_test.model.deploy(
+            tls_certificates_app_name,
+            config=tls_config,
+            channel=tls_channel,
+            base=CHARM_BASE_NOBLE,
+        )
+        await ops_test.model.relate(
+            f"{DATABASE_APP_NAME}:peer-certificates", f"{tls_certificates_app_name}:certificates"
+        )
+        await ops_test.model.relate(
+            f"{DATABASE_APP_NAME}:client-certificates", f"{tls_certificates_app_name}:certificates"
+        )
+        await ops_test.model.wait_for_idle(
+            apps=[DATABASE_APP_NAME], status="active", timeout=1000, raise_on_error=False
+        )
+        for unit in ops_test.model.applications[DATABASE_APP_NAME].units:
+            assert await check_tls(ops_test, unit.name, enabled=True)
+            assert await check_tls_patroni_api(ops_test, unit.name, enabled=True)
+
+
+async def test_scale_down_with_tls(ops_test: OpsTest) -> None:
+    """Scale down by one unit with TLS enabled; the hook must not crash.
+
+    Under the unfixed lib the departing unit's storage-detaching hook crashed on
+    an empty/corrupt peer CA bundle (``ssl.SSLError``), leaving the unit in
+    ``error`` with its data storage attached and the application unable to
+    return to active. With the fix the hook degrades gracefully and the unit is
+    removed cleanly.
+    """
+    # scale_application waits for the app to return to active with exactly
+    # INITIAL_UNITS - 1 units; the pre-fix crash strands the departing unit in
+    # error and this wait raises on timeout.
+    await scale_application(ops_test, DATABASE_APP_NAME, INITIAL_UNITS - 1)
+
+    # Belt-and-suspenders: no surviving unit should be in error.
+    for unit in ops_test.model.applications[DATABASE_APP_NAME].units:
+        assert unit.workload_status != "error", (
+            f"unit {unit.name} is in error after TLS scale-down; "
+            "storage-detaching hook likely crashed on an empty CA bundle"
+        )

--- a/tests/spread/test_storage_detaching_tls.py/task.yaml
+++ b/tests/spread/test_storage_detaching_tls.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_storage_detaching_tls.py
+environment:
+  TEST_MODULE: test_storage_detaching_tls.py
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results


### PR DESCRIPTION
## Issue

Scaling down a `postgresql-k8s` unit with TLS enabled fails the `storage-detaching` hook with an uncaught `ssl.SSLError: [X509: NO_CERTIFICATE_OR_CRL_FOUND]`, leaving the unit in `error` and the `data` storage attached.

Root cause lives in the single-kernel lib: `load_verify_locations` raises `ssl.SSLError` (not `FileNotFoundError`) when the peer CA bundle file exists but holds no certificates, and the `suppress(FileNotFoundError)` guard did not catch it. The error escaped through `parallel_patroni_get_request` → `cluster_status` → `get_primary` (which only catches `RetryError`) and crashed the hook. An empty CA bundle arises at storage-detaching time when the unit's TLS material is being torn down.

Lib fix: canonical/postgresql-single-kernel-library#187

## Solution

Pins `postgresql-charms-single-kernel` to the lib fix commit via its GitHub archive URL, pending a released version on PyPI. The lib commit broadens the guard to also swallow `ssl.SSLError`, so a missing OR certless CA bundle degrades to an unreachable request (returns `None`) instead of propagating.

Adds an integration test (`tests/integration/test_storage_detaching_tls.py`) that deploys three units, enables TLS, scales down by one, and asserts no unit is left in `error` — a regression guard for the reported scale-down-with-TLS scenario. The deterministic red→green proof of the fix itself is the lib's unit test (canonical/postgresql-single-kernel-library#187), which reproduces the exact `ssl.SSLError` under the unpatched code and asserts `None` with the fix.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.