### PR TITLE
fix(relations): skip database request without a database name

### DIFF
--- a/src/relations/postgresql_provider.py
+++ b/src/relations/postgresql_provider.py
@@ -207,7 +207,10 @@ class PostgreSQLProvider(Object):
         self, user: str, event: DatabaseRequestedEvent
     ) -> tuple[str, list[str]] | None:
         # Retrieve the database name and extra user roles using the charm library.
-        database = event.database or ""
+        database = event.database
+        if not database:
+            logger.warning("Database name is not set in the relation data, skipping.")
+            return
         if database and database[-1] == "*":
             if len(database) < 4:
                 self.charm.unit.status = BlockedStatus(PREFIX_TOO_SHORT_MSG)

--- a/tests/unit/test_postgresql_provider.py
+++ b/tests/unit/test_postgresql_provider.py
@@ -246,3 +246,6 @@ def test_on_database_requested_without_database_name(harness, caplog):
         assert "Database name is not set in the relation data, skipping." in caplog.text
         postgresql_mock.create_database.assert_not_called()
         postgresql_mock.create_user.assert_not_called()
+        # Returning without deferring is what lets ops drop the stale notice; a
+        # handler that defers again would replay it forever.
+        event.defer.assert_not_called()

--- a/tests/unit/test_postgresql_provider.py
+++ b/tests/unit/test_postgresql_provider.py
@@ -219,7 +219,8 @@ def test_on_relation_broken(harness):
         postgresql_mock.delete_user.assert_not_called()
 
 
-def test_on_database_requested_without_database_name(harness, caplog):
+@pytest.mark.parametrize("missing_database", [None, ""])
+def test_on_database_requested_without_database_name(harness, caplog, missing_database):
     """A replayed request whose databag no longer carries a database name is skipped."""
     with (
         patch("charm.PostgresqlOperatorCharm.update_config"),
@@ -237,7 +238,7 @@ def test_on_database_requested_without_database_name(harness, caplog):
         event.requested_entity_secret_content = None
         # The relation is gone on this replay, so the library reads the name back
         # as absent rather than as an empty string.
-        event.database = None
+        event.database = missing_database
         event.extra_user_roles = None
 
         with caplog.at_level(logging.WARNING):

--- a/tests/unit/test_postgresql_provider.py
+++ b/tests/unit/test_postgresql_provider.py
@@ -1,6 +1,7 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import logging
 from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
@@ -216,3 +217,32 @@ def test_on_relation_broken(harness):
             )
         harness.charm.postgresql_client_relation._on_relation_broken(event)
         postgresql_mock.delete_user.assert_not_called()
+
+
+def test_on_database_requested_without_database_name(harness, caplog):
+    """A replayed request whose databag no longer carries a database name is skipped."""
+    with (
+        patch("charm.PostgresqlOperatorCharm.update_config"),
+        patch.object(PostgresqlOperatorCharm, "postgresql", Mock()) as postgresql_mock,
+        patch(
+            "charm.PatroniManager.primary_endpoint_ready",
+            new_callable=PropertyMock,
+            return_value=True,
+        ),
+        patch("charm.PostgreSQLProvider._are_units_in_sync", return_value=True),
+    ):
+        rel_id = harness.model.get_relation(RELATION_NAME).id
+        event = Mock()
+        event.relation.id = rel_id
+        event.requested_entity_secret_content = None
+        # The relation is gone on this replay, so the library reads the name back
+        # as absent rather than as an empty string.
+        event.database = None
+        event.extra_user_roles = None
+
+        with caplog.at_level(logging.WARNING):
+            harness.charm.postgresql_client_relation._on_database_requested(event)
+
+        assert "Database name is not set in the relation data, skipping." in caplog.text
+        postgresql_mock.create_database.assert_not_called()
+        postgresql_mock.create_user.assert_not_called()


### PR DESCRIPTION
## Issue

On a leader unit, a `database_requested` event that was deferred while the primary endpoint was not ready gets replayed by ops on every subsequent dispatch. If the relation has gone away in the meantime, ops supplies a dead relation whose remote application cannot be resolved, so the requested database name reads back as absent. `_collect_databases` coerced that missing value to an empty string, and `_on_database_requested` then indexed it, raising an uncaught `IndexError: string index out of range`.

ops replays deferred notices before the hook's own event, and only drops a notice once its handler returns. The exception therefore aborts every later hook on that unit permanently, actions included. The leader can no longer provision client relations or refresh endpoints, so any client relation that had not yet been served stays unserved. The unit itself sits in `error` on a failed hook.

The same defect was reported downstream against the VM charm as ISREQ-3825. `_collect_databases` is duplicated per charm rather than shared, so both charms received it independently from their respective prefix-matching changes and both need the fix. The VM counterpart is canonical/postgresql-operator#1897.

## Solution

Return early from `_collect_databases` when the relation no longer carries a database name, instead of coercing the missing value to an empty string. The handler already treats a `None` return as "nothing to do", so the stale notice drains on its next replay. Note this only applies once the fixed revision is running: a unit already wedged on an older revision needs to be refreshed and have its failed hook cleared before the guard can execute.

An empty name is not reachable from a live requirer: Juju drops a databag key whose value is an empty string, and the library only emits `database_requested` when that key is added. The guard therefore only affects the replayed-stale-notice path. The remaining `database[-1]` sites in this module are already protected by truthiness checks and are left unchanged.

Adds a regression test that drives the handler with an absent database name, which reproduces the `IndexError` without the guard.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
