### PR TITLE
[DPE-9734] Guard against remote app being None on deferred TLS certificate events

### DIFF
--- a/src/relations/tls_transfer.py
+++ b/src/relations/tls_transfer.py
@@ -42,6 +42,12 @@ class TLSTransfer(Object):
         if relation is None:
             logger.error("Relationship not established anymore.")
             return
+        if relation.app is None:
+            logger.debug(
+                "Cannot push TLS certificates: remote application of relation %s is gone.",
+                relation.id,
+            )
+            return
 
         secret_name = f"ca-{relation.app.name}"
         self.charm.set_secret(SCOPE, secret_name, event.ca)
@@ -61,6 +67,12 @@ class TLSTransfer(Object):
         relation = self.charm.model.get_relation(TLS_TRANSFER_RELATION, event.relation_id)
         if relation is None:
             logger.error("Relationship not established anymore.")
+            return
+        if relation.app is None:
+            logger.debug(
+                "Cannot clean CA certificates: remote application of relation %s is gone.",
+                relation.id,
+            )
             return
 
         secret_name = f"ca-{relation.app.name}"

--- a/tests/unit/test_tls_transfer.py
+++ b/tests/unit/test_tls_transfer.py
@@ -87,3 +87,76 @@ def test_on_ca_certificate_removed(harness):
         emit_ca_certificate_removed_event(harness, rel_id)
         _clean_ca_file_from_workload.assert_called_once()
         _defer.assert_called_once()
+
+
+def test_on_ca_certificate_removed_relation_app_none(harness):
+    with patch(
+        "charm.PostgresqlOperatorCharm.clean_ca_file_from_workload"
+    ) as _clean_ca_file_from_workload:
+        rel_id = relate_to_ca_certificates_operator(harness)
+
+        # The workload cleanup fails (e.g. Patroni rejects the request with 401),
+        # so the event is deferred.
+        _clean_ca_file_from_workload.return_value = False
+        deferred_notices = len(list(harness.framework._storage.notices()))
+        emit_ca_certificate_removed_event(harness, rel_id)
+        assert len(list(harness.framework._storage.notices())) == deferred_notices + 1
+
+        # The relation is already gone when the deferred event is re-emitted,
+        # e.g. during the stop hook
+        # (https://github.com/canonical/postgresql-k8s-operator/issues/1405).
+        # In real Juju the remote application is not reported for a torn-down
+        # relation, unlike the test backend which keeps its metadata.
+        # Success is restored before remove_relation so the removal-triggered
+        # event (the lib re-emits certificate_removed on relation-broken) does
+        # not defer a second notice.
+        _clean_ca_file_from_workload.return_value = True
+        harness.remove_relation(rel_id)
+        _clean_ca_file_from_workload.reset_mock()
+
+        with patch.object(
+            harness.charm.model._backend, "relation_remote_app_name", return_value=None
+        ):
+            harness.framework.reemit()
+
+        # The cleanup is skipped since the remote application is not available
+        # anymore, and the deferred event is consumed instead of crashing with
+        # AttributeError: 'NoneType' object has no attribute 'name'.
+        _clean_ca_file_from_workload.assert_not_called()
+        assert len(list(harness.framework._storage.notices())) == deferred_notices
+
+
+def test_on_ca_certificate_added_relation_app_none(harness):
+    with patch(
+        "charm.PostgresqlOperatorCharm.push_ca_file_into_workload"
+    ) as _push_ca_file_into_workload:
+        rel_id = relate_to_ca_certificates_operator(harness)
+
+        # The workload push fails, so the event is deferred.
+        _push_ca_file_into_workload.return_value = False
+        deferred_notices = len(list(harness.framework._storage.notices()))
+        emit_ca_certificate_added_event(harness, rel_id)
+        assert len(list(harness.framework._storage.notices())) == deferred_notices + 1
+
+        # The relation is already gone when the deferred event is re-emitted,
+        # e.g. during the stop hook
+        # (https://github.com/canonical/postgresql-k8s-operator/issues/1405).
+        # In real Juju the remote application is not reported for a torn-down
+        # relation, unlike the test backend which keeps its metadata.
+        # Success is restored before remove_relation so the removal-triggered
+        # event (the lib re-emits certificate_removed on relation-broken) does
+        # not defer a second notice.
+        _push_ca_file_into_workload.return_value = True
+        harness.remove_relation(rel_id)
+        _push_ca_file_into_workload.reset_mock()
+
+        with patch.object(
+            harness.charm.model._backend, "relation_remote_app_name", return_value=None
+        ):
+            harness.framework.reemit()
+
+        # The push is skipped since the remote application is not available
+        # anymore, and the deferred event is consumed instead of crashing with
+        # AttributeError: 'NoneType' object has no attribute 'name'.
+        _push_ca_file_into_workload.assert_not_called()
+        assert len(list(harness.framework._storage.notices())) == deferred_notices


### PR DESCRIPTION
## Issue
`postgresql-k8s` (rev845, 14/edge) fails its `stop` hook during scale-in with `AttributeError: 'NoneType' object has no attribute 'name'` at `src/relations/tls_transfer.py:66` (`secret_name = f"ca-{relation.app.name}"`), as reported in #1405.

Mechanism:
1. During scale-in, `receive-ca-cert-relation-broken` fires. The `certificate_transfer` lib emits `certificate_removed`; the charm's `_on_certificate_removed` calls `clean_ca_file_from_workload` → `update_config()` → Patroni PATCH fails (401: the cert being removed authenticates the request) → returns `False` → `event.defer()`.
2. Juju then runs the `stop` hook and ops' `reemit()` re-emits the deferred event. The handler resolves the relation via `model.get_relation(receive-ca-cert, rid)`; in ops ≥3.7, `_get_unique` reconstructs the torn-down relation as a dead `Relation(active=False)`. In a `stop` hook there is no `JUJU_REMOTE_APP` fallback, so `relation.app` is `None` (juju bug 1960934) and the handler crashes. Juju retries the stop hook 7× and the scale-in wedges.

## Solution
Guard both `_on_certificate_available` and `_on_certificate_removed` with `if relation.app is None: return` (skip without re-deferring):

- A torn-down relation never re-activates (relation ids are never reused), so deferring again would re-crash the stop hook forever.
- Live-relation behavior is unchanged: in a live `relation-broken` hook, `JUJU_REMOTE_APP` still resolves the remote app, so cleanup proceeds as before. `get_ca_secret_names()` iterates live relations only, so it is unaffected.
- Skipping the secret deletion leaves an inert unit-databag key (`ca-<app>`); a later `certificate_available` for the same app overwrites it, and it dies with the unit's peer relation on scale-in.
- `relation.active` was deliberately NOT used as the guard condition: ops sets `active=False` during live relation-broken hooks even when the app still resolves, which would skip legitimate cleanup.

Verified:
- Not fixed in any later same-track revision: `src/relations/tls_transfer.py` is byte-identical from rev845 to the latest 14/edge lineage (rev954 / current `main`).
- 16/edge is not affected by this repo's copy (the file was deleted in #1226), but the successor code in the pinned `postgresql-charms-single-kernel` package (imported via `single_kernel_postgresql.events.tls_transfer`) has the same unguarded pattern; the guard needs to be ported upstream to canonical/single-kernel-postgresql.
- The root trigger (Patroni PATCH 401 during TLS teardown because the removed cert authenticates the request) is a separate cleanup-order design point noted in the issue and intentionally not addressed here; the 401 → defer path on a live relation is unchanged.
- The rev869 failure in the issue comments (`restart-relation-broken` → `enable_disable_extensions`, AttributeError on `.data`) is a different site and remains out of scope.

Testing:
- Unit (TDD): the two new tests in `tests/unit/test_tls_transfer.py` fail pre-fix with exactly `AttributeError: 'NoneType' object has no attribute 'name'` and pass post-fix (real `event.defer()`, deferred-notice counting, `relation_remote_app_name` patched to `None` to mirror real-Juju teardown). Full suite: 385 passed, 9 skipped; `tox -e lint` clean; guard lines fully covered.
- Real Juju 3.6.28 k8s model (local charm build + glauth-k8s + self-signed-certificates, Patroni REST on TLS, Patroni REST auth rotated so the charm's PATCH returns 401): with the rev845 build, scale-in reproduces the exact CI failure (deferred event → stop-hook `AttributeError` → `hook "stop" failed`); with this branch, same trigger and deferral, the stop hook logs `Cannot clean CA certificates: remote application of relation 12 is gone.` and completes, and scale-in finishes cleanly to 0 units.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.

Fixes https://github.com/canonical/postgresql-k8s-operator/issues/1405.
