### PR TITLE
fix: defer hooks when the database or workload is transiently unavailable (DPE-9735)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ requirements-last-build.txt
 
 # PyCharm project folder.
 .idea/
+
+# uv lockfile stubs created by tooling during test/lint runs
+uv.lock

--- a/src/charm.py
+++ b/src/charm.py
@@ -93,6 +93,9 @@ from ops.pebble import (
     ServiceInfo,
     ServiceStatus,
 )
+from ops.pebble import (
+    ConnectionError as PebbleConnectionError,
+)
 from ops_tracing import Tracing
 from requests import ConnectionError as RequestsConnectionError
 from tenacity import RetryError, Retrying, stop_after_attempt, stop_after_delay, wait_fixed
@@ -687,6 +690,14 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             logger.debug("Defer on_config_changed: Cannot connect to database")
             event.defer()
             return
+        except (ChangeError, PebbleConnectionError) as e:
+            # The workload container or its services are (transiently) unavailable,
+            # e.g. while the pod is restarting after a controller migration. Log at
+            # warning level so a permanently broken service stays observable while
+            # the event keeps being deferred and retried.
+            logger.warning("Deferring on_config_changed: workload not ready yet: %r", e)
+            event.defer()
+            return
         except ValueError as e:
             self.unit.status = BlockedStatus("Configuration Error. Please check the logs")
             logger.error("Invalid configuration: %s", str(e))
@@ -702,7 +713,12 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             return
 
         # Enable and/or disable the extensions.
-        self.enable_disable_extensions()
+        try:
+            self.enable_disable_extensions()
+        except PostgreSQLEnableDisableExtensionError:
+            logger.warning("Deferring on_config_changed: cannot connect to the database")
+            event.defer()
+            return
 
         self._unblock_extensions()
 
@@ -768,6 +784,18 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             self.unit.status = BlockedStatus(EXTENSION_OBJECT_MESSAGE)
             return
         except PostgreSQLEnableDisableExtensionError as e:
+            if isinstance(e.__cause__, psycopg2.OperationalError | psycopg2.InterfaceError):
+                # The database is (transiently) unreachable, e.g. while the workload is
+                # restarting after a controller migration. Raise the error to let the
+                # caller defer the event and retry, instead of failing the hook or
+                # silently skipping the extension change. Restore the original status
+                # first so the update-status retry gate keeps matching it.
+                logger.warning(
+                    "cannot connect to the database to update extensions: %s", str(e.__cause__)
+                )
+                if not isinstance(original_status, UnknownStatus | ErrorStatus):
+                    self.unit.status = original_status
+                raise
             logger.exception("failed to change plugins: %s", str(e))
         if original_status.message == EXTENSION_OBJECT_MESSAGE:
             self._set_active_status()
@@ -1003,9 +1031,30 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             )
             event.defer()
             return
+        except (ChangeError, PebbleConnectionError, psycopg2.OperationalError) as e:
+            # The database or the workload services are (transiently) unavailable,
+            # e.g. while the pod is restarting after a controller migration.
+            logger.debug("Deferring on_postgresql_pebble_ready: workload not ready yet: %r", e)
+            event.defer()
+            return
 
+        self._update_workload(event)
+
+    def _update_workload(self, event: WorkloadEvent) -> None:
+        """Update the workload services and configuration after the container is ready.
+
+        Defers the event when the database or the workload services are (transiently)
+        unavailable, e.g. while the pod is restarting after a controller migration.
+        """
         # Start the database service.
-        self._update_pebble_layers()
+        try:
+            self._update_pebble_layers()
+        except (ChangeError, PebbleConnectionError) as e:
+            logger.debug(
+                "Deferring on_postgresql_pebble_ready: cannot update pebble layers: %r", e
+            )
+            event.defer()
+            return
 
         # Ensure the member is up and running before marking the cluster as initialised.
         if not self._patroni.member_started:
@@ -1018,11 +1067,21 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             return
 
         # Update the archive command and replication configurations.
-        self.update_config()
+        try:
+            self.update_config()
+        except (ChangeError, PebbleConnectionError, psycopg2.OperationalError) as e:
+            logger.debug("Deferring on_postgresql_pebble_ready: workload not ready yet: %r", e)
+            event.defer()
+            return
 
         # Enable/disable PostgreSQL extensions if they were set before the cluster
         # was fully initialised.
-        self.enable_disable_extensions()
+        try:
+            self.enable_disable_extensions()
+        except PostgreSQLEnableDisableExtensionError:
+            logger.debug("Deferring on_postgresql_pebble_ready: Cannot connect to database")
+            event.defer()
+            return
 
         # Enable pgbackrest service
         self.backup.start_stop_pgbackrest_service()
@@ -1545,7 +1604,11 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
         ) or self._has_non_restore_waiting_status:
             # If charm was failing to disable plugin, try again and continue (user may have removed the objects)
             if self.unit.status.message == EXTENSION_OBJECT_MESSAGE:
-                self.enable_disable_extensions()
+                try:
+                    self.enable_disable_extensions()
+                except PostgreSQLEnableDisableExtensionError:
+                    logger.warning("cannot connect to the database to update extensions")
+                    return False
                 return True
 
             logger.debug("on_update_status early exit: Unit is in Blocked/Waiting status")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -8,7 +8,10 @@ from unittest.mock import MagicMock, Mock, PropertyMock, call, patch, sentinel
 
 import psycopg2
 import pytest
-from charms.postgresql_k8s.v0.postgresql import PostgreSQLUpdateUserPasswordError
+from charms.postgresql_k8s.v0.postgresql import (
+    PostgreSQLEnableDisableExtensionError,
+    PostgreSQLUpdateUserPasswordError,
+)
 from lightkube import ApiError
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.core_v1 import Endpoints, Pod, Service
@@ -23,6 +26,7 @@ from ops.model import (
     WaitingStatus,
 )
 from ops.pebble import ChangeError, ServiceStatus
+from ops.pebble import ConnectionError as PebbleConnectionError
 from ops.testing import Harness
 from requests import ConnectionError as RequestsConnectionError
 from tenacity import RetryError, wait_fixed
@@ -345,6 +349,208 @@ def test_on_config_changed(harness):
         harness.charm._on_config_changed(mock_event)
         assert isinstance(harness.charm.unit.status, ActiveStatus)
         _enable_disable_extensions.assert_called_once_with()
+
+
+def test_on_config_changed_defers_on_transient_extension_error(harness):
+    # DPE-9735: a transient database outage while updating extensions must defer
+    # config-changed instead of failing the hook or silently skipping the change.
+    with (
+        patch(
+            "charm.PostgresqlOperatorCharm.is_cluster_initialised",
+            new_callable=PropertyMock,
+            return_value=True,
+        ),
+        patch("charm.PostgreSQLUpgrade.idle", return_value=True, new_callable=PropertyMock),
+        patch("charm.PostgresqlOperatorCharm._validate_config_options"),
+        patch("charm.PostgresqlOperatorCharm.update_config"),
+        patch("charm.Patroni.get_primary", return_value="postgresql-k8s-0"),
+        patch("charm.PostgreSQL.enable_disable_extensions") as _enable_disable_extensions,
+    ):
+        with harness.hooks_disabled():
+            harness.set_leader()
+
+        # Simulate the charm library wrapping a transient connection error, as seen
+        # after a controller migration: Patroni is reachable, but connecting to the
+        # primary service fails with "Operation not permitted".
+        def _raise_wrapped_error(*_args, **_kwargs):
+            try:
+                raise psycopg2.OperationalError(
+                    'connection to server at "postgresql-k8s-primary" failed:'
+                    " Operation not permitted"
+                )
+            except psycopg2.OperationalError as cause:
+                raise PostgreSQLEnableDisableExtensionError() from cause
+
+        _enable_disable_extensions.side_effect = _raise_wrapped_error
+
+        mock_event = Mock()
+        harness.charm._on_config_changed(mock_event)
+
+        # The event is deferred so the extension change is retried, and the hook
+        # does not fail.
+        mock_event.defer.assert_called_once_with()
+        assert not isinstance(harness.charm.unit.status, ErrorStatus)
+
+        # A permanent extension failure (cause is not a connection error) keeps the
+        # existing swallow-and-log behaviour instead of deferring forever.
+        def _raise_permanent_error(*_args, **_kwargs):
+            try:
+                raise psycopg2.ProgrammingError("could not open extension control file")
+            except psycopg2.ProgrammingError as cause:
+                raise PostgreSQLEnableDisableExtensionError() from cause
+
+        _enable_disable_extensions.side_effect = _raise_permanent_error
+        mock_event = Mock()
+        harness.charm._on_config_changed(mock_event)
+        mock_event.defer.assert_not_called()
+        assert not isinstance(harness.charm.unit.status, ErrorStatus)
+
+        # A client-side connection invalidation is transient as well.
+        def _raise_interface_error(*_args, **_kwargs):
+            try:
+                raise psycopg2.InterfaceError("connection already closed")
+            except psycopg2.InterfaceError as cause:
+                raise PostgreSQLEnableDisableExtensionError() from cause
+
+        _enable_disable_extensions.side_effect = _raise_interface_error
+        mock_event = Mock()
+        harness.charm._on_config_changed(mock_event)
+        mock_event.defer.assert_called_once_with()
+        assert not isinstance(harness.charm.unit.status, ErrorStatus)
+
+
+def test_on_config_changed_defers_on_transient_pebble_error(harness):
+    # DPE-9735: a transient workload/pebble failure while updating config must defer
+    # config-changed instead of failing the hook.
+    with (
+        patch(
+            "charm.PostgresqlOperatorCharm.is_cluster_initialised",
+            new_callable=PropertyMock,
+            return_value=True,
+        ),
+        patch("charm.PostgreSQLUpgrade.idle", return_value=True, new_callable=PropertyMock),
+        patch("charm.PostgresqlOperatorCharm._validate_config_options"),
+        patch("charm.PostgresqlOperatorCharm.update_config") as _update_config,
+        patch("charm.Patroni.get_primary", return_value="postgresql-k8s-0"),
+        patch("charm.PostgreSQL.enable_disable_extensions"),
+    ):
+        with harness.hooks_disabled():
+            harness.set_leader()
+
+        _update_config.side_effect = ChangeError("fake error", Mock())
+        mock_event = Mock()
+        harness.charm._on_config_changed(mock_event)
+        mock_event.defer.assert_called_once_with()
+        assert not isinstance(harness.charm.unit.status, ErrorStatus)
+
+        mock_event.reset_mock()
+        _update_config.side_effect = PebbleConnectionError("cannot connect to pebble")
+        harness.charm._on_config_changed(mock_event)
+        mock_event.defer.assert_called_once_with()
+        assert not isinstance(harness.charm.unit.status, ErrorStatus)
+
+
+def test_on_postgresql_pebble_ready_defers_on_transient_workload_error(harness):
+    # DPE-9735: transient workload/pebble failures while handling postgresql-pebble-ready
+    # (e.g. after a controller migration) must defer the event instead of failing the
+    # hook. The deferred event re-emits within other hooks, so raising here would fail
+    # unrelated hooks such as config-changed.
+    mock_event = Mock()
+    with (
+        patch("charm.PostgresqlOperatorCharm.push_tls_files_to_workload") as _push_tls_files,
+        patch("charm.PostgresqlOperatorCharm._create_pgdata"),
+        patch(
+            "charm.Patroni.rock_postgresql_version", new_callable=PropertyMock
+        ) as _rock_postgresql_version,
+        patch(
+            "charm.PostgresqlOperatorCharm.is_cluster_initialised",
+            new_callable=PropertyMock,
+            return_value=True,
+        ),
+        patch("charm.PostgresqlOperatorCharm._update_pebble_layers") as _update_pebble_layers,
+        patch("charm.PostgresqlOperatorCharm.update_config") as _update_config,
+        patch(
+            "charm.PostgresqlOperatorCharm.enable_disable_extensions"
+        ) as _enable_disable_extensions,
+        patch("charm.PostgresqlOperatorCharm._set_active_status"),
+    ):
+
+        def _raise_wrapped_extension_error(*_args, **_kwargs):
+            try:
+                raise psycopg2.OperationalError("connection refused")
+            except psycopg2.OperationalError as cause:
+                raise PostgreSQLEnableDisableExtensionError() from cause
+
+        _rock_postgresql_version.return_value = "14.7"
+        with harness.hooks_disabled():
+            harness.set_leader()
+        mock_event.workload.can_connect.return_value = True
+
+        # Transient pebble error while pushing TLS files (update_config runs inside it).
+        _push_tls_files.side_effect = ChangeError("fake error", Mock())
+        harness.charm._on_postgresql_pebble_ready(mock_event)
+        mock_event.defer.assert_called_once()
+        mock_event.reset_mock()
+
+        # Transient pebble error while updating the pebble layers.
+        _push_tls_files.side_effect = None
+        _update_pebble_layers.side_effect = ChangeError("fake error", Mock())
+        harness.charm._on_postgresql_pebble_ready(mock_event)
+        mock_event.defer.assert_called_once()
+        mock_event.reset_mock()
+
+        # Transient pebble error while pushing TLS files (ConnectionError arm).
+        _update_pebble_layers.side_effect = None
+        _push_tls_files.side_effect = PebbleConnectionError("cannot connect to pebble")
+        harness.charm._on_postgresql_pebble_ready(mock_event)
+        mock_event.defer.assert_called_once()
+        mock_event.reset_mock()
+
+        # Transient pebble error while updating the pebble layers.
+        _push_tls_files.side_effect = None
+        _update_pebble_layers.side_effect = PebbleConnectionError("cannot connect to pebble")
+        harness.charm._on_postgresql_pebble_ready(mock_event)
+        mock_event.defer.assert_called_once()
+        mock_event.reset_mock()
+
+        # Transient database/pebble error while updating the config.
+        _update_pebble_layers.side_effect = None
+        _update_config.side_effect = psycopg2.OperationalError
+        harness.charm._on_postgresql_pebble_ready(mock_event)
+        mock_event.defer.assert_called_once()
+        mock_event.reset_mock()
+
+        # Transient database error while updating extensions.
+        _update_config.side_effect = None
+        _enable_disable_extensions.side_effect = _raise_wrapped_extension_error
+        harness.charm._on_postgresql_pebble_ready(mock_event)
+        mock_event.defer.assert_called_once()
+
+
+def test_on_update_status_extension_retry_survives_transient_db_error(harness):
+    # DPE-9735: a transient database failure during the update-status extension retry
+    # must restore the blocked status, so the periodic retry keeps running instead of
+    # being silently abandoned.
+    with (
+        patch("charm.PostgreSQLUpgrade.idle", return_value=True, new_callable=PropertyMock),
+        patch("charm.Patroni.get_primary", return_value="postgresql-k8s-0"),
+        patch("charm.PostgreSQL.enable_disable_extensions") as _lib_enable_disable_extensions,
+    ):
+
+        def _raise_wrapped_error(*_args, **_kwargs):
+            try:
+                raise psycopg2.OperationalError("connection refused")
+            except psycopg2.OperationalError as cause:
+                raise PostgreSQLEnableDisableExtensionError() from cause
+
+        _lib_enable_disable_extensions.side_effect = _raise_wrapped_error
+
+        harness.set_can_connect(POSTGRESQL_CONTAINER, True)
+        harness.model.unit.status = BlockedStatus(EXTENSION_OBJECT_MESSAGE)
+        container = harness.model.unit.get_container(POSTGRESQL_CONTAINER)
+        assert not harness.charm._on_update_status_early_exit_checks(container)
+        # The blocked status is restored, so the periodic retry keeps matching the gate.
+        assert harness.model.unit.status == BlockedStatus(EXTENSION_OBJECT_MESSAGE)
 
 
 def test_on_get_password(harness):


### PR DESCRIPTION
## Issue

Fixes #1406 (DPE-9735).

After a Juju controller migration restarts the workload, the charm's hooks permanently fail instead of deferring while the PostgreSQL database or the workload services are still coming up, leaving the unit in `error` state (the reported `hook failed: "config-changed"` signature, ~30–50% of migration runs on `14/edge` rev 845).

Field reproduction on `14/edge` rev 845 (single-unit k8s controller, bundle from the issue, migrate-out/migrate-back + `kubectl rollout restart` + `juju config` race) captured the escaping exceptions in `juju debug-log`:

- `ops.pebble.ChangeError` raised by `container.replan()` in `_update_pebble_layers()` and by `update_config()`'s service restarts (`metrics_server`, `ldap-sync`), escaping `_on_postgresql_pebble_ready` unhandled.
- Because ops re-emits deferred events before dispatching each new hook, a deferred `postgresql-pebble-ready` whose handler raises fails whichever hook runs next — this is how `config-changed` fails in the field even though its own body defers.
- The charm library wraps `psycopg2.OperationalError` (and `psycopg2.InterfaceError`) into `PostgreSQLEnableDisableExtensionError`, which the extension handler swallowed and silently skipped the pending extension change.

Not fixed by recent track revisions: 14/edge rev 954 (latest as of this writing) ships the same code (`src/charm.py` at main `0845702e33`/rev954; `lib/charms/postgresql_k8s/v0/postgresql.py` is byte-identical from rev 848 through rev 954).

## Solution

- `_handle_enable_disable_extensions` re-raises `PostgreSQLEnableDisableExtensionError` when its cause is a connection error (`psycopg2.OperationalError` or `psycopg2.InterfaceError`), restoring the pre-attempt unit status first so the update-status retry gate for `EXTENSION_OBJECT_MESSAGE` keeps matching. Permanent failures keep the previous swallow-and-log behaviour (pinned by tests).
- `_on_config_changed` defers on transient database and workload errors from config validation, `update_config()` and the extension handling; defers are logged at warning level so a permanently broken database or service stays observable while the event keeps being retried.
- `_on_postgresql_pebble_ready` gets the same transient guards around pushing TLS files, updating the pebble layers, `update_config()` and the extension handling; its tail is extracted into `_update_workload()` to keep the handler under the complexity limit.
- `_on_update_status_early_exit_checks` skips the run when the database is transiently unreachable; update-status retries on its own schedule.

Known accepted tradeoffs (raised in review):
- A *permanent* `OperationalError`/`ChangeError` (e.g. auth misconfiguration, a service that can never start) now defers instead of surfacing a failed hook — consistent with the pre-existing `psycopg2.OperationalError` defer precedent in `_on_config_changed`; observability is kept via warning logs.
- Other `update_config()` callers (`databases-changed`, peer-relation-changed) still fail their hooks on the same transient errors; out of scope here since the reported hooks and the reemission cascade are covered.

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
