### PR TITLE
fix(charm): confirm missing trust via SelfSubjectAccessReview before blocking (#1404)

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -59,8 +59,10 @@ from charms.postgresql_k8s.v0.postgresql_tls import PostgreSQLTLS
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
 from charms.rolling_ops.v0.rollingops import RollingOpsManager, RunWithLock
 from lightkube import ApiError, Client
+from lightkube.models.authorization_v1 import ResourceAttributes, SelfSubjectAccessReviewSpec
 from lightkube.models.core_v1 import ServicePort, ServiceSpec
 from lightkube.models.meta_v1 import ObjectMeta
+from lightkube.resources.authorization_v1 import SelfSubjectAccessReview
 from lightkube.resources.core_v1 import Endpoints, Node, Pod, Service
 from ops import JujuVersion, main
 from ops.charm import (
@@ -152,6 +154,10 @@ logging.getLogger("asyncio").setLevel(logging.WARNING)
 EXTENSIONS_DEPENDENCY_MESSAGE = "Unsatisfied plugin dependencies. Please check the logs"
 EXTENSION_OBJECT_MESSAGE = "Cannot disable plugins: Existing objects depend on it. See logs"
 INSUFFICIENT_SIZE_WARNING = "<10% free space on pgdata volume."
+
+# k8s resources that are cluster-scoped: their SelfSubjectAccessReview must not
+# carry a namespace, or RoleBindings in the model namespace could grant them.
+CLUSTER_SCOPED_RESOURCES = frozenset({"nodes"})
 
 ORIGINAL_PATRONI_ON_FAILURE_CONDITION = "restart"
 
@@ -933,7 +939,14 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
                 logger.info("Fixed missing leader annotation")
         except ApiError as e:
             if e.status.code == 403:
-                self.on_deployed_without_trust()
+                # A 403 here is not necessarily a proof of missing trust: during
+                # pod recreation the API server can briefly reject requests even
+                # when the application is trusted. Only block the unit when the
+                # API server confirms the permissions are actually missing.
+                if self._is_deployed_without_trust(("get", "endpoints"), ("patch", "endpoints")):
+                    self.on_deployed_without_trust()
+                else:
+                    logger.warning("Transient 403 on endpoints; permissions verified")
                 return False
             # Ignore the error only when the resource doesn't exist.
             if e.status.code != 404:
@@ -1238,7 +1251,16 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
                 logger.info(f"deleted {kind.__name__}/{self.cluster_name}{suffix}")
             except ApiError as e:
                 if e.status.code == 403:
-                    self.on_deployed_without_trust()
+                    # Only block when the API server confirms the permissions
+                    # are actually missing; see _is_deployed_without_trust.
+                    if self._is_deployed_without_trust(
+                        ("delete", "services"), ("delete", "endpoints")
+                    ):
+                        self.on_deployed_without_trust()
+                    else:
+                        logger.warning(
+                            "Transient 403 deleting cluster resources; permissions verified"
+                        )
                     return
                 # Ignore the error only when the resource doesn't exist.
                 if e.status.code != 404:
@@ -2341,7 +2363,12 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
             available_cpu_cores, available_memory = self.get_available_resources()
         except ApiError as e:
             if e.status.code == 403:
-                self.on_deployed_without_trust()
+                # Only block when the API server confirms the permissions are
+                # actually missing; see _is_deployed_without_trust.
+                if self._is_deployed_without_trust(("get", "pods"), ("get", "nodes")):
+                    self.on_deployed_without_trust()
+                else:
+                    logger.warning("Transient 403 reading pod resources; permissions verified")
                 return False
             raise e
 
@@ -2581,6 +2608,49 @@ class PostgresqlOperatorCharm(TypedCharmBase[CharmConfig]):
                 allocable_memory = constrained_memory
 
         return cpu_cores, allocable_memory
+
+    def _is_deployed_without_trust(self, *permissions: tuple[str, str]) -> bool:
+        """Verify with the API server whether the charm's permissions are actually missing.
+
+        A bare 403 on a charm k8s call is not a proof that the application was
+        deployed without `--trust`: during pod recreation the API server can
+        briefly reject requests even when the application is trusted. Ask the
+        API server itself through a SelfSubjectAccessReview (the same check the
+        juju trust flag relies on) and only report "deployed without trust"
+        when it definitively denies the permission.
+
+        Args:
+            permissions: (verb, resource) tuples to review, e.g. ("get", "pods").
+
+        Returns:
+            True only when the API server definitively denies one of the
+            permissions; an inconclusive review (API error or missing status)
+            returns False so the next event retries instead of blocking.
+        """
+        client = Client()
+        for verb, resource in permissions:
+            try:
+                review = client.create(
+                    SelfSubjectAccessReview(
+                        spec=SelfSubjectAccessReviewSpec(
+                            resourceAttributes=ResourceAttributes(
+                                namespace=None
+                                if resource in CLUSTER_SCOPED_RESOURCES
+                                else self._namespace,
+                                verb=verb,
+                                resource=resource,
+                            )
+                        )
+                    )
+                )
+            except ApiError:
+                # No evidence about the permissions: let the next event retry.
+                logger.warning(f"SelfSubjectAccessReview for '{verb} {resource}' failed")
+                return False
+            status = review.status
+            if status is not None and not status.allowed:
+                return True
+        return False
 
     def on_deployed_without_trust(self) -> None:
         """Blocks the application and returns a specific error message for deployments made without --trust."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -161,10 +161,150 @@ def test_on_leader_elected(harness):
         harness.set_leader()
         assert isinstance(harness.charm.unit.status, ActiveStatus)
 
-        # No trust when annotating
+        # No trust when annotating: the API server denies the permissions.
         _client.return_value.get.side_effect = ApiError(response=response)
+        _client.return_value.create.return_value.status.allowed = False
         harness.set_leader(False)
         harness.set_leader()
+
+        assert isinstance(harness.charm.unit.status, BlockedStatus)
+        assert (
+            harness.charm.unit.status.message
+            == "Insufficient permissions, try: `juju trust postgresql-k8s --scope=cluster`"
+        )
+
+
+def test_leader_elected_transient_403_does_not_block(harness):
+    with (
+        patch("charm.PostgresqlOperatorCharm._add_members"),
+        patch("charm.Client") as _client,
+        patch("charm.new_password", return_value="sekr1t"),
+        patch("charm.PostgresqlOperatorCharm.get_secret", return_value="test") as _get_secret,
+        patch("charm.PostgresqlOperatorCharm.set_secret"),
+        patch("charm.Patroni.reload_patroni_configuration"),
+        patch("charm.PostgresqlOperatorCharm._patch_pod_labels"),
+        patch("charm.PostgresqlOperatorCharm._create_services"),
+        patch("charm.PostgreSQLUpgrade.idle", new_callable=PropertyMock) as _idle,
+    ):
+        _idle.return_value = True
+        response = Mock()
+        response.json.return_value = {"code": 403}
+        _client.return_value.get.side_effect = ApiError(response=response)
+        # The API server confirms the charm holds the needed permissions: a
+        # transient 403 (e.g. during pod recreation) must not block the unit.
+        _client.return_value.create.return_value.status.allowed = True
+
+        harness.set_leader(False)
+        harness.set_leader()
+
+        assert not isinstance(harness.charm.unit.status, BlockedStatus)
+        _client.return_value.create.assert_called()
+
+
+def test_leader_elected_genuine_no_trust_blocks(harness):
+    with (
+        patch("charm.PostgresqlOperatorCharm._add_members"),
+        patch("charm.Client") as _client,
+        patch("charm.new_password", return_value="sekr1t"),
+        patch("charm.PostgresqlOperatorCharm.get_secret", return_value="test") as _get_secret,
+        patch("charm.PostgresqlOperatorCharm.set_secret"),
+        patch("charm.Patroni.reload_patroni_configuration"),
+        patch("charm.PostgresqlOperatorCharm._patch_pod_labels"),
+        patch("charm.PostgresqlOperatorCharm._create_services"),
+        patch("charm.PostgreSQLUpgrade.idle", new_callable=PropertyMock) as _idle,
+    ):
+        _idle.return_value = True
+        response = Mock()
+        response.json.return_value = {"code": 403}
+        _client.return_value.get.side_effect = ApiError(response=response)
+        # The API server denies the permissions: the unit must block with the
+        # "Insufficient permissions" message, as deployed without `--trust`.
+        _client.return_value.create.return_value.status.allowed = False
+
+        harness.set_leader(False)
+        harness.set_leader()
+
+        assert isinstance(harness.charm.unit.status, BlockedStatus)
+        assert (
+            harness.charm.unit.status.message
+            == "Insufficient permissions, try: `juju trust postgresql-k8s --scope=cluster`"
+        )
+
+
+def test_update_config_transient_403_does_not_block(harness):
+    with (
+        patch("charm.PostgresqlOperatorCharm.get_available_resources") as _resources,
+        patch("charm.Client") as _client,
+    ):
+        response = Mock()
+        response.json.return_value = {"code": 403}
+        _resources.side_effect = ApiError(response=response)
+        # The API server confirms the charm holds the needed permissions: a
+        # transient 403 (e.g. during pod recreation) must not block the unit.
+        _client.return_value.create.return_value.status.allowed = True
+
+        assert harness.charm.update_config() is False
+
+        assert not isinstance(harness.charm.unit.status, BlockedStatus)
+        _client.return_value.create.assert_called()
+
+
+def test_leader_elected_ssr_error_does_not_block(harness):
+    with (
+        patch("charm.PostgresqlOperatorCharm._add_members"),
+        patch("charm.Client") as _client,
+        patch("charm.new_password", return_value="sekr1t"),
+        patch("charm.PostgresqlOperatorCharm.get_secret", return_value="test") as _get_secret,
+        patch("charm.PostgresqlOperatorCharm.set_secret"),
+        patch("charm.Patroni.reload_patroni_configuration"),
+        patch("charm.PostgresqlOperatorCharm._patch_pod_labels"),
+        patch("charm.PostgresqlOperatorCharm._create_services"),
+        patch("charm.PostgreSQLUpgrade.idle", new_callable=PropertyMock) as _idle,
+    ):
+        _idle.return_value = True
+        response = Mock()
+        response.json.return_value = {"code": 403}
+        _client.return_value.get.side_effect = ApiError(response=response)
+        # An inconclusive SelfSubjectAccessReview (e.g. transient API error) is
+        # no evidence about the permissions: the unit must not block.
+        _client.return_value.create.side_effect = ApiError(response=response)
+
+        harness.set_leader(False)
+        harness.set_leader()
+
+        assert not isinstance(harness.charm.unit.status, BlockedStatus)
+
+
+def test_cleanup_old_cluster_resources_transient_403_does_not_block(harness):
+    with (
+        patch("charm.Client") as _client,
+    ):
+        response = Mock()
+        response.json.return_value = {"code": 403}
+        _client.return_value.delete.side_effect = ApiError(response=response)
+        # The API server confirms the charm holds the needed permissions: a
+        # transient 403 (e.g. during pod recreation) must not block the unit.
+        _client.return_value.create.return_value.status.allowed = True
+
+        harness.charm._cleanup_old_cluster_resources()
+
+        assert not isinstance(harness.charm.unit.status, BlockedStatus)
+        _client.return_value.create.assert_called()
+
+
+def test_update_config_genuine_no_trust_blocks(harness):
+    with (
+        patch("charm.PostgresqlOperatorCharm.get_available_resources") as _resources,
+        patch("charm.Client") as _client,
+    ):
+        response = Mock()
+        response.json.return_value = {"code": 403}
+        _resources.side_effect = ApiError(response=response)
+        # The API server denies the permissions: the unit must block with the
+        # "Insufficient permissions" message, as deployed without `--trust`.
+        _client.return_value.create.return_value.status.allowed = False
+
+        assert harness.charm.update_config() is False
 
         assert isinstance(harness.charm.unit.status, BlockedStatus)
         assert (


### PR DESCRIPTION
## Issue

Fixes #1404

A `postgresql-k8s` unit deployed with `trust: true` enters `blocked: Insufficient permissions, try: juju trust <app> --scope=cluster` after pod deletion. The blocked state is sticky: afterwards the charm stops handling relation events (`pg_hba.conf` is never updated), breaking dependent charms. The failure is intermittent: the same revision passed the identical test plan in a prior CI run, pointing at a race during pod recreation.

## Solution

A bare 403 from the k8s API server is not proof that the application was deployed without `--trust`: during pod recreation the API server can briefly reject requests even for trusted applications. Until now, the charm converted the first 403 from any of three lightkube call sites (`fix_leader_annotation`, `_cleanup_old_cluster_resources`, `update_config`) into a permanent `BlockedStatus`, wedging the unit.

With this change, before declaring the unit untrusted the charm asks the API server itself through a `SelfSubjectAccessReview` for the verb/resource that failed:

- definitive deny (`status.allowed == false`) → block with the actionable message, unchanged behavior for a deployment genuinely made without `--trust`;
- inconclusive review (API error or missing status) → log a warning and let the next event retry instead of wedging the unit;
- reviews for cluster-scoped resources (`nodes`) carry no namespace, so model-namespace RoleBindings cannot inflate the answer.

Tests (TDD): the two transient-403 regression tests fail on the parent commit and pass here; the suite also pins the definitive-deny path, the inconclusive-review path, and all three call sites. Full suite green (393 passed, 9 skipped; `tox -e lint`, `tox -e format` clean).

Two caveats worth recording (reviewer-noted):

- If the transient 403 is caused by RBAC rule staleness inside the API server authorizer cache, the review is evaluated on the same cache and can deny as well; the fix eliminates the non-RBAC transient-403 class and keeps actionable guidance for the rest.
- The race could not be reproduced locally (65 pod deletions on rev845 with `--trust`, including mid-hook re-deletes and config churn, on an RBAC-enforced cluster); the failure chain matches the CI environment where a prior execution of the same plan passed.

## Checklist

- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.