### PR TITLE
[test-only, draft] Use rock with Go-1.25.14 exporters

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -41,7 +41,7 @@ resources:
   postgresql-image:
     type: oci-image
     description: OCI image for PostgreSQL
-    upstream-source: ghcr.io/canonical/charmed-postgresql@sha256:856a221b97bdfafed974b483a911794ec254d4e4cd5b5eb323b676aebc72785a  # renovate: oci-image tag: 16.15-24.04_edge
+    upstream-source: ghcr.io/marceloneppel/charmed-postgresql:16.15-24.04_go125  # test-only: rock packing charmed-postgresql/16/edge/pg-exporters-go125 (go1.25.14 exporters); push from charmed-postgresql-rock CI artifact before integration runs
 
 peers:
   database-peers:


### PR DESCRIPTION
> **Draft — TEST ONLY.** Not for merge; exists so CI packs the k8s charm against a rock built from the Go-1.25 exporter snap, for later secscan validation.

## Change

`metadata.yaml` `postgresql-image` `upstream-source` now points at `ghcr.io/marceloneppel/charmed-postgresql:16.15-24.04_go125` — a test rock to be pushed from the canonical/charmed-postgresql-rock CI artifact (rock packing snap channel `charmed-postgresql/16/edge/pg-exporters-go125`):

```
skopeo copy oci-archive:charmed-postgresql_16.15-24.04_amd64.rock \
  docker://ghcr.io/marceloneppel/charmed-postgresql:16.15-24.04_go125
```

**Before the integration-test jobs can pull it, that image must be pushed from the companion rock PR's CI artifact** (canonical/charmed-postgresql-rock test PR). Until then, integration jobs are expected to fail on image pull; unit/lint/build jobs validate the charm build itself.

The rock contains `prometheus-postgres-exporter 0.15.0-1ubuntu0.7ppa1`, `golang-github-prometheus-community-pgbouncer-exporter 0.7.0-1ubuntu0.24.04.6ppa1`, `prometheus-pgbackrest-exporter 0.17.0+ds1-0ubuntu0.24.04.4ppa1` — all `go1.25.14`, `govulncheck` on all six binaries: **0 vulnerabilities**.