### PR TITLE
[test-only, draft] Use 14 rock with Go-1.25.14 exporters

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -34,7 +34,7 @@ resources:
   postgresql-image:
     type: oci-image
     description: OCI image for PostgreSQL
-    upstream-source: ghcr.io/canonical/charmed-postgresql@sha256:11db80a0b5a2fb24cee833b22bf337cbb6d6f4d3eab2328648320c020644d21e # renovate: oci-image tag: 14.24-22.04_edge
+    upstream-source: ghcr.io/marceloneppel/charmed-postgresql:14.24-22.04_go125  # test-only: rock packing charmed-postgresql/14/edge/pg-exporters-go125 (go1.25.14 exporters); push from charmed-postgresql-rock CI artifact before integration runs
 
 peers:
   database-peers:


### PR DESCRIPTION
> **Draft — TEST ONLY.** Not for merge; exists so CI packs the 14-track k8s charm against a 14-track rock built from the Go-1.25 exporter snap, for later secscan validation.

## Change

`metadata.yaml` `postgresql-image` `upstream-source` now points at `ghcr.io/marceloneppel/charmed-postgresql:14.24-22.04_go125` — a test rock to be pushed from the canonical/charmed-postgresql-rock CI artifact (14-22.04 rock packing snap channel `charmed-postgresql/14/edge/pg-exporters-go125`):

```
skopeo copy oci-archive:charmed-postgresql_14.24-22.04_amd64.rock \
  docker://ghcr.io/marceloneppel/charmed-postgresql:14.24-22.04_go125
```

**Before the integration-test jobs can pull it, that image must be pushed from the companion rock PR's CI artifact** (charmed-postgresql-rock 14-track test PR). Until then, integration jobs are expected to fail on image pull; unit/lint/build jobs validate the charm build itself.

The rock contains the 14-track snap whose exporters are rebuilt with `golang-1.25.14` (all `govulncheck` clean).